### PR TITLE
Add build and publish scripts for demo on gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 
 # build folder
 lib
+_site

--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "postversion": "git commit package.json CHANGELOG.md -m \"Version $npm_package_version\" && npm run tag && git push && git push --tags && npm publish",
     "prepublish": "in-publish && npm run build || not-in-publish",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
-    "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0"
+    "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0",
+    "site:clean": "rimraf _site",
+    "site:build": "build-storybook -s ./public -o _site && touch _site/.nojekyll",
+    "site:publish": "npm run site:clean && npm run site:build && cd _site && git init && rimraf ./.git/config && cp ../.git/config ./.git/config && git checkout -b gh-pages && git add . && git commit -m 'update site' && git push origin gh-pages --force"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thank you for open sourcing this! I find that a live demo page would be really useful.

This PR adds a script to build the demo page and deploys it to Github pages on this repo.

- `npm run site:build` builds `_site` folder
- `npm run site:clean` removes `_site` folder
- `npm run site:publish` rebuilds and deploys `_site` to `origin/gh-pages`
- Adds `_site` folder to `.gitignore`

Tested and deployed on fork: https://xamfoo.github.io/react-dates

Reference: https://github.com/reactjs/redux/blob/master/package.json#L36

Fixes #1 