### PR TITLE
Add disabled functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ If the `showClearDates` prop is set to true, an `x` shows up in the input box th
   showClearDates: PropTypes.bool,
 ```
 
+If the `disabled` prop is set to true, onFocusChange is not called when onStartDateFocus or onEndDateFocus are invoked and disabled is assigned to the actual `<input>` DOM elements.
+```
+  disabled: PropTypes.bool,
+```
+
 **Some useful callbacks:**
 If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.
 ```

--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -14,6 +14,10 @@
   vertical-align: middle;
 }
 
+.DateInput--disabled {
+  background: $react-dates-color-gray-lighter;
+}
+
 .DateInput__label {
   border: 0;
   clip: rect(0, 0, 0, 0);
@@ -50,4 +54,8 @@
   border-color: $react-dates-color-focus;
   border-radius: 3px;
   color: $react-dates-color-text-focus;
+}
+
+.DateInput__display-text--disabled {
+  font-style: italic;
 }

--- a/css/DateRangePickerInput.scss
+++ b/css/DateRangePickerInput.scss
@@ -6,6 +6,10 @@
   display: inline-block;
 }
 
+.DateRangePickerInput--disabled {
+  background: $react-dates-color-gray-lighter;
+}
+
 .DateRangePickerInput__arrow {
   display: inline-block;
   vertical-align: middle;

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -9,6 +9,7 @@ const propTypes = {
   placeholder: PropTypes.string, // also used as label
   dateValue: PropTypes.string,
   focused: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
@@ -20,6 +21,7 @@ const defaultProps = {
   placeholder: 'Select Date',
   dateValue: '',
   focused: false,
+  disabled: false,
 
   onChange() {},
   onFocus() {},
@@ -83,13 +85,16 @@ export default class DateInput extends React.Component {
       dateValue,
       focused,
       onFocus,
+      disabled,
     } = this.props;
 
     const value = dateValue || dateString;
 
     return (
       <div
-        className="DateInput"
+        className={cx('DateInput', {
+          'DateInput--disabled': disabled,
+        })}
         onClick={onFocus}
       >
         <label className="DateInput__label" htmlFor={id}>
@@ -109,13 +114,14 @@ export default class DateInput extends React.Component {
           placeholder={placeholder}
           autoComplete="off"
           maxLength={10}
-          disabled={this.isTouchDevice}
+          disabled={disabled || this.isTouchDevice}
         />
 
         <div
           className={cx('DateInput__display-text', {
             'DateInput__display-text--has-input': !!value,
             'DateInput__display-text--focused': focused,
+            'DateInput__display-text--disabled': disabled,
           })}
         >
           {value || placeholder}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -43,6 +43,7 @@ const defaultProps = {
   enableOutsideDays: false,
   numberOfMonths: 2,
   showClearDates: false,
+  disabled: false,
 
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
@@ -152,14 +153,14 @@ export default class DateRangePicker extends React.Component {
   }
 
   onEndDateFocus() {
-    const { startDate, onFocusChange, orientation } = this.props;
+    const { startDate, onFocusChange, orientation, disabled } = this.props;
 
-    if (!startDate && orientation === VERTICAL_ORIENTATION) {
+    if (!startDate && orientation === VERTICAL_ORIENTATION && !disabled) {
       // Since the vertical datepicker is full screen, we never want to focus the end date first
       // because there's no indication that that is the case once the datepicker is open and it
       // might confuse the user
       onFocusChange(START_DATE);
-    } else {
+    } else if (!disabled) {
       onFocusChange(END_DATE);
     }
   }
@@ -193,7 +194,9 @@ export default class DateRangePicker extends React.Component {
   }
 
   onStartDateFocus() {
-    this.props.onFocusChange(START_DATE);
+    if (!this.props.disabled) {
+      this.props.onFocusChange(START_DATE);
+    }
   }
 
   getDayPickerContainerClasses() {
@@ -381,6 +384,7 @@ export default class DateRangePicker extends React.Component {
       endDate,
       focusedInput,
       showClearDates,
+      disabled,
       startDateId,
       endDateId,
       phrases,
@@ -413,6 +417,7 @@ export default class DateRangePicker extends React.Component {
             endDate={endDateString}
             showClearDates={showClearDates}
             onClearDates={this.clearDates}
+            disabled={disabled}
             phrases={phrases}
           />
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -28,6 +28,7 @@ const propTypes = {
   isStartDateFocused: PropTypes.bool,
   isEndDateFocused: PropTypes.bool,
   showClearDates: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   // i18n
   phrases: PropTypes.shape({
@@ -50,6 +51,7 @@ const defaultProps = {
   isStartDateFocused: false,
   isEndDateFocused: false,
   showClearDates: false,
+  disabled: false,
 
   // i18n
   phrases: {
@@ -99,6 +101,7 @@ export default class DateRangePickerInput extends React.Component {
       onEndDateTab,
       onClearDates,
       showClearDates,
+      disabled,
       phrases,
     } = this.props;
 
@@ -106,12 +109,17 @@ export default class DateRangePickerInput extends React.Component {
     const endDateValue = endDate || endDateString;
 
     return (
-      <div className="DateRangePickerInput">
+      <div
+        className={cx('DateRangePickerInput', {
+          'DateRangePickerInput--disabled': disabled,
+        })}
+      >
         <DateInput
           id={startDateId}
           placeholder={startDatePlaceholderText}
           dateValue={startDateValue}
           focused={isStartDateFocused}
+          disabled={disabled}
 
           onChange={onStartDateChange}
           onFocus={onStartDateFocus}
@@ -127,6 +135,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={endDatePlaceholderText}
           dateValue={endDateValue}
           focused={isEndDateFocused}
+          disabled={disabled}
 
           onChange={onEndDateChange}
           onFocus={onEndDateFocus}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -24,6 +24,7 @@ const propTypes = SingleDatePickerShape;
 const defaultProps = {
   date: null,
   focused: false,
+  disabled: false,
 
   onDateChange() {},
   onFocusChange() {},
@@ -99,7 +100,9 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onFocus() {
-    this.props.onFocusChange({ focused: true });
+    if (!this.props.disabled) {
+      this.props.onFocusChange({ focused: true });
+    }
   }
 
   onClearFocus() {
@@ -225,6 +228,7 @@ export default class SingleDatePicker extends React.Component {
       id,
       placeholder,
       focused,
+      disabled,
       date,
       withPortal,
       withFullScreenPortal,
@@ -241,6 +245,7 @@ export default class SingleDatePicker extends React.Component {
             id={id}
             placeholder={placeholder}
             focused={focused}
+            disabled={disabled}
             dateValue={dateValue}
             onChange={this.onChange}
             onFocus={this.onFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -8,6 +8,7 @@ const propTypes = {
   dateValue: PropTypes.string,
   border: PropTypes.bool,
   focused: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
@@ -20,6 +21,7 @@ const defaultProps = {
   dateValue: '',
   border: false,
   focused: false,
+  disabled: false,
 
   onChange() {},
   onFocus() {},
@@ -33,6 +35,7 @@ export default function SingleDatePickerInput(props) {
     placeholder,
     dateValue,
     focused,
+    disabled,
     onChange,
     onFocus,
     onKeyDownShiftTab,
@@ -46,6 +49,7 @@ export default function SingleDatePickerInput(props) {
         placeholder={placeholder} // also used as label
         dateValue={dateValue}
         focused={focused}
+        disabled={disabled}
 
         onChange={onChange}
         onFocus={onFocus}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -16,6 +16,7 @@ export default {
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   showClearDates: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   orientation: OrientationShape,
 

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -8,6 +8,7 @@ export default {
   placeholder: PropTypes.string,
   date: momentPropTypes.momentObj,
   focused: PropTypes.bool,
+  disabled: PropTypes.bool,
 
   onDateChange: PropTypes.func,
   onFocusChange: PropTypes.func,

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -12,6 +12,20 @@ describe('DateInput', () => {
       expect(wrapper.is('.DateInput')).to.equal(true);
     });
 
+    describe('props.disabled is falsey', () => {
+      it('does not have .DateInput--disabled class ', () => {
+        const wrapper = shallow(<DateInput id="date" disabled={false} />);
+        expect(wrapper.find('.DateInput--disabled')).to.have.lengthOf(0);
+      });
+    });
+
+    describe('props.disabled is truthy', () => {
+      it('has .DateInput--disabled class', () => {
+        const wrapper = shallow(<DateInput id="date" disabled />);
+        expect(wrapper.find('.DateInput--disabled')).to.have.lengthOf(1);
+      });
+    });
+
     describe('label', () => {
       it('has .DateInput__label class', () => {
         const wrapper = shallow(<DateInput id="date" />);
@@ -67,6 +81,20 @@ describe('DateInput', () => {
         it('has .DateInput__display-text--focused class', () => {
           const wrapper = shallow(<DateInput id="date" focused />);
           expect(wrapper.find('.DateInput__display-text--focused')).to.have.lengthOf(1);
+        });
+      });
+
+      describe('props.disabled is falsey', () => {
+        it('does not have .DateInput__display-text--disabled class ', () => {
+          const wrapper = shallow(<DateInput id="date" disabled={false} />);
+          expect(wrapper.find('.DateInput__display-text--disabled')).to.have.lengthOf(0);
+        });
+      });
+
+      describe('props.disabled is truthy', () => {
+        it('has .DateInput__display-text--disabled class', () => {
+          const wrapper = shallow(<DateInput id="date" disabled />);
+          expect(wrapper.find('.DateInput__display-text--disabled')).to.have.lengthOf(1);
         });
       });
     });

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -18,6 +18,20 @@ describe('DateRangePickerInput', () => {
       expect(wrapper.find(DateInput)).to.have.lengthOf(2);
     });
 
+    describe('props.disabled is falsey', () => {
+      it('does not have .DateRangePickerInput--disabled class ', () => {
+        const wrapper = shallow(<DateRangePickerInput id="date" disabled={false} />);
+        expect(wrapper.find('.DateRangePickerInput--disabled')).to.have.lengthOf(0);
+      });
+    });
+
+    describe('props.disabled is truthy', () => {
+      it('has .DateRangePickerInput--disabled class', () => {
+        const wrapper = shallow(<DateRangePickerInput id="date" disabled />);
+        expect(wrapper.find('.DateRangePickerInput--disabled')).to.have.lengthOf(1);
+      });
+    });
+
     it('has .DateRangePickerInput__arrow class', () => {
       const wrapper = shallow(<DateRangePickerInput />);
       expect(wrapper.find('.DateRangePickerInput__arrow')).to.have.lengthOf(1);

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -699,6 +699,96 @@ describe('DateRangePicker', () => {
     });
   });
 
+  describe('#onStartDateFocus', () => {
+    it('calls props.onFocusChange once', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
+      wrapper.instance().onStartDateFocus();
+      expect(onFocusChangeStub).to.have.property('callCount', 1);
+    });
+
+    it('calls props.onFocusChange with START_DATE as arg', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
+      wrapper.instance().onStartDateFocus();
+      expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+    });
+
+    describe('props.disabled = true', () => {
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(<DateRangePicker disabled onFocusChange={onFocusChangeStub} />);
+        wrapper.instance().onStartDateFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 0);
+      });
+    });
+  });
+
+  describe('#onEndDateFocus', () => {
+    it('calls props.onFocusChange once with arg END_DATE', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
+      wrapper.instance().onEndDateFocus();
+      expect(onFocusChangeStub).to.have.property('callCount', 1);
+      expect(onFocusChangeStub.getCall(0).args[0]).to.equal(END_DATE);
+    });
+
+    describe('props.startDate = moment', () => {
+      it('calls props.onFocusChange once with arg END_DATE', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            startDate={moment(today)}
+            onFocusChange={onFocusChangeStub}
+          />
+        );
+        wrapper.instance().onEndDateFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 1);
+        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(END_DATE);
+      });
+    });
+
+    describe('props.orientation = VERTICAL_ORIENTATION', () => {
+      it('calls props.onFocusChange once with arg START_DATE', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            orientation={VERTICAL_ORIENTATION}
+            onFocusChange={onFocusChangeStub}
+          />
+        );
+        wrapper.instance().onEndDateFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 1);
+        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+      });
+    });
+
+    describe('props.startDate = moment and props.orientation = VERTICAL_ORIENTATION', () => {
+      it('calls props.onFocusChange once with arg END_DATE', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            startDate={moment(today)}
+            orientation={VERTICAL_ORIENTATION}
+            onFocusChange={onFocusChangeStub}
+          />
+        );
+        wrapper.instance().onEndDateFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 1);
+        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(END_DATE);
+      });
+    });
+
+    describe('props.disabled = true', () => {
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(<DateRangePicker disabled onFocusChange={onFocusChangeStub} />);
+        wrapper.instance().onEndDateFocus();
+        expect(onFocusChangeStub.callCount).to.equal(0);
+      });
+    });
+  });
+
   describe('day modifier methods', () => {
     describe('#doesNotMeetMinimumNights', () => {
       const MIN_NIGHTS = 3;

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -354,6 +354,20 @@ describe('SingleDatePicker', () => {
       wrapper.instance().onFocus();
       expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(true);
     });
+
+    describe('props.disabled = true', () => {
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            disabled
+            onFocusChange={onFocusChangeStub}
+          />);
+        wrapper.instance().onFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 0);
+      });
+    });
   });
 
   describe('#onClearFocus', () => {


### PR DESCRIPTION
One our use cases requires disabling/preventing the user from opening the calendar. This adds the props flowing down from SingleDatePicker & DateRangePicker into DateInput. New classes for disabled are added where necessary.  Also added tests for classes & onFocusChange.

Thanks!

Fixes #6.