### PR TITLE
Include a link to gh-pages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The `phrases` prop is an object that contains all the English language phrases c
 ## Live Playground
 For examples of the datepicker in action,
 
+Go to [http://airbnb.io/react-dates]
+
+OR
+
 * `npm install`
 * `npm run storybook`
 * Visit `http://localhost:9001/`


### PR DESCRIPTION
Since storybook is already deployed to github pages, might as well provide a link to that so potential users can find a live demo without cloning the repo. Might recommend putting it up higher. For me, the first thing I love for is a live demo. But, with current README structure, this made the most sense. 

BTW really happy you guys OS'ed this. Very good chance I'll be using it.