### PR TITLE
Remove jQuery as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ node_modules
 
 # build folder
 lib
+.idea
 
 # gh-pages
 _gh-pages

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure packages are installed with correct version numbers by running:
   Which produces and runs a command like:
 
   ```sh
-  npm install --save-dev react-dates jquery@>=#.# moment@>=#.## react@>=#.## react-dom@>=#.## react-addons-shallow-compare@>=#.##
+  npm install --save-dev react-dates moment@>=#.## react@>=#.## react-dom@>=#.## react-addons-shallow-compare@>=#.##
   ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-portal": "^2.2.1"
   },
   "peerDependencies": {
-    "jquery": ">=2.1",
     "moment": ">=2.10",
     "react": ">=0.14",
     "react-dom": ">=0.14",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "git-directory-deploy": "^1.5.1",
     "imports-loader": "^0.6.5",
     "in-publish": "^2.0.0",
-    "jquery": "^3.1.0",
     "mocha": "^3.0.2",
     "mocha-wrap": "^2.0.5",
     "moment": "^2.14.1",

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -241,11 +241,10 @@ export default class DayPicker extends React.Component {
 
   adjustDayPickerHeight() {
     const transitionContainer = ReactDOM.findDOMNode(this.refs.transitionContainer);
-    const calendarMonths = transitionContainer.querySelectorAll('.CalendarMonth');
     const heights = [];
 
     // convert node list to array
-    Array.prototype.slice.call(calendarMonths).forEach((el) => {
+    [...transitionContainer.querySelectorAll('.CalendarMonth')].forEach((el) => {
       if (el.getAttribute('data-visible') === 'true') {
         heights.push(this.getMonthHeight(el));
       }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -24,8 +24,6 @@ const MONTH_PADDING = 23;
 const PREV_TRANSITION = 'prev';
 const NEXT_TRANSITION = 'next';
 
-const slice = Array.prototype.slice;
-
 const propTypes = {
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
@@ -114,10 +112,10 @@ export default class DayPicker extends React.Component {
     const grid = el.querySelector('.js-CalendarMonth__grid');
 
     // Need to separate out table children for FF
+    // Add an additional +1 for the border
     return (
       this.calculateDimension(caption, 'height', 'outer', true) +
-      this.calculateDimension(grid, 'height') +
-      1 // for border
+      this.calculateDimension(grid, 'height') + 1
     );
   }
 
@@ -243,9 +241,11 @@ export default class DayPicker extends React.Component {
 
   adjustDayPickerHeight() {
     const transitionContainer = ReactDOM.findDOMNode(this.refs.transitionContainer);
+    const calendarMonths = transitionContainer.querySelectorAll('.CalendarMonth');
     const heights = [];
 
-    slice.call(transitionContainer.querySelectorAll('.CalendarMonth')).forEach((el) => {
+    // convert node list to array
+    Array.prototype.slice.call(calendarMonths).forEach((el) => {
       if (el.getAttribute('data-visible') === 'true') {
         heights.push(this.getMonthHeight(el));
       }
@@ -255,7 +255,7 @@ export default class DayPicker extends React.Component {
 
     if (newMonthHeight !== this.calculateDimension(transitionContainer, 'height')) {
       this.monthHeight = newMonthHeight;
-      transitionContainer.style.height = newMonthHeight;
+      transitionContainer.style.height = `${newMonthHeight}px`;
     }
   }
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -114,7 +114,7 @@ export default class DayPicker extends React.Component {
     // Need to separate out table children for FF
     // Add an additional +1 for the border
     return (
-      this.calculateDimension(caption, 'height', 'outer', true) +
+      this.calculateDimension(caption, 'height', true, true) +
       this.calculateDimension(grid, 'height') + 1
     );
   }
@@ -129,28 +129,31 @@ export default class DayPicker extends React.Component {
     });
   }
 
-  calculateDimension(el, axis, range = 'inner', withMargin = false) {
+  calculateDimension(el, axis, borderBox = false, withMargin = false) {
     if (!el) {
       return 0;
     }
 
-    const style = window.getComputedStyle(el);
     const axisStart = (axis === 'width') ? 'Left' : 'Top';
     const axisEnd = (axis === 'width') ? 'Right' : 'Bottom';
-    const extraSize = (
-      parseFloat(style[`padding${axisStart}`]) +
-      parseFloat(style[`padding${axisEnd}`]) +
-      parseFloat(style[`border${axisStart}Width`]) +
-      parseFloat(style[`border${axisEnd}Width`])
-    );
-    let size = parseFloat(style[axis]);
 
-    if (range === 'outer' && style.boxSizing === 'content-box') {
-      size += extraSize;
-    } else if (range === 'inner' && style.boxSizing === 'border-box') {
-      size -= extraSize;
+    // Only read styles if we need to
+    const style = (!borderBox || withMargin) ? window.getComputedStyle(el) : {};
+
+    // Offset includes border and padding
+    let size = (axis === 'width') ? el.offsetWidth : el.offsetHeight;
+
+    // Get the inner size
+    if (!borderBox) {
+      size -= (
+        parseFloat(style[`padding${axisStart}`]) +
+        parseFloat(style[`padding${axisEnd}`]) +
+        parseFloat(style[`border${axisStart}Width`]) +
+        parseFloat(style[`border${axisEnd}Width`])
+      );
     }
 
+    // Apply margin
     if (withMargin) {
       size += (
         parseFloat(style[`margin${axisStart}`]) +
@@ -173,7 +176,7 @@ export default class DayPicker extends React.Component {
     this.dayPickerWidth = this.calculateDimension(
       ReactDOM.findDOMNode(this.refs.calendarMonthGrid).querySelector('.CalendarMonth'),
       'width',
-      'outer'
+      true
     );
   }
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -322,4 +322,60 @@ describe('DayPicker', () => {
       });
     });
   });
+
+  /* Requires a DOM
+  describe('#calculateDimension', () => {
+    let dimensionInstance = null;
+    let testElement = null;
+
+    beforeEach(() => {
+      dimensionInstance = shallow(<DayPicker />).instance();
+      testElement = document.createElement('div');
+
+      testElement.style.width = '100px';
+      testElement.style.height = '250px';
+      testElement.style.padding = '15px 10px';
+      testElement.style.border = '1px solid red';
+      testElement.style.margin = '3px 6px 5px 2px';
+      testElement.boxSizing = 'border-box';
+    });
+
+    it('returns 0 for an empty element', () => {
+      expect(dimensionInstance.calculateDimension(null, 'width')).to.equal(0);
+    });
+
+    it('calculates border-box height', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'height', true)).to.equal(282);
+    });
+
+    it('calculates border-box height with margin', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'height', true, true)).to.equal(290);
+    });
+
+    it('calculates border-box width', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'width', true)).to.equal(122);
+    });
+
+    it('calculates border-box width with margin', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'width', true, true)).to.equal(130);
+    });
+
+    it('calculates content-box height', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'height')).to.equal(250);
+    });
+
+    it('calculates content-box height with margin', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'height', false, true))
+        .to.equal(258);
+    });
+
+    it('calculates content-box width', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'width')).to.equal(100);
+    });
+
+    it('calculates content-box width with margin', () => {
+      expect(dimensionInstance.calculateDimension(testElement, 'width', false, true)).to.equal(108);
+    });
+  });
+  */
 });


### PR DESCRIPTION
This PR removes jQuery as a dependency and replaces the outer/inner width/height methods with a single function that handles all scenarios. Will need to do further testing in browser and within unit tests to verify the numbers are correct.