### PR TITLE
Use safe-publish-latest in prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "version:major": "npm --no-git-tag-version version major",
     "preversion": "npm run test && npm run check-changelog && npm run check-only-changelog-changed",
     "postversion": "git commit package.json CHANGELOG.md -m \"Version $npm_package_version\" && npm run tag && git push && git push --tags && npm publish",
-    "prepublish": "in-publish && npm run build || not-in-publish",
+    "prepublish": "in-publish && safe-publish-latest && npm run build || not-in-publish",
     "check-changelog": "expr $(git status --porcelain 2>/dev/null| grep \"^\\s*M.*CHANGELOG.md\" | wc -l) >/dev/null || (echo 'Please edit CHANGELOG.md' && exit 1)",
     "check-only-changelog-changed": "(expr $(git status --porcelain 2>/dev/null| grep -v \"CHANGELOG.md\" | wc -l) >/dev/null && echo 'Only CHANGELOG.md may have uncommitted changes' && exit 1) || exit 0"
   },
@@ -70,6 +70,7 @@
     "react-addons-test-utils": "^15.2.1",
     "react-dom": "^15.2.1",
     "react-svg-loader": "^1.1.1",
+    "safe-publish-latest": "^1.0.1",
     "sass-loader": "^4.0.0",
     "sinon": "^1.17.5",
     "sinon-sandbox": "^1.0.2",


### PR DESCRIPTION
This ensures that when you npm publish, the "latest" tag is only set for
the truly latest version.