### PR TITLE
Export date comparison methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,20 @@ The `monthFormat` prop abides by [moment's date formatting rules](http://momentj
   monthFormat: PropTypes.string,
 ```
 
+## Utility Methods
+
+### Date Comparison
+
+We provide four utility methods for date comparison:
+```
+  isInclusivelyAfterDay
+  isInclusivelyBeforeDay
+  isNextDay
+  isSameDay
+```
+
+Each of these methods takes in two moment objects and returns a boolean, indicating whether the first argument is inclusively after, inclusively before, the day immediately after, or the same day as the second argument.
+
 ## Theming
 
 react-dates comes with a set of SCSS variables that can be overridden to add your own project-specific theming. Override any variables found in `css/variables.scss` with your own and then import `~react-dates/css/styles.scss` (and `~react-dates/css/variables.scss` if you're only overriding a few). If you were using [sass-loader](https://github.com/jtangelder/sass-loader) with webpack, the code below would properly override the selected variables:

--- a/index.js
+++ b/index.js
@@ -7,12 +7,17 @@ var CalendarMonthGrid = require('./lib/components/CalendarMonthGrid').default;
 var CalendarMonth = require('./lib/components/CalendarMonth').default;
 var CalendarDay = require('./lib/components/CalendarDay').default;
 
+var DateRangePickerShape = require('./lib/shapes/DateRangePickerShape').default;
+var SingleDatePickerShape = require('./lib/shapes/SingleDatePickerShape').default;
+
+var isInclusivelyAfterDay = require('./lib/utils/isInclusivelyAfterDay').default;
+var isInclusivelyBeforeDay = require('./lib/utils/isInclusivelyBeforeDay').default;
+var isNextDay = require('./lib/utils/isNextDay').default;
+var isSameDay = require('./lib/utils/isSameDay').default;
+
 var toISODateString = require('./lib/utils/toISODateString').default;
 var toLocalizedDateString = require('./lib/utils/toLocalizedDateString').default;
 var toMomentObject = require('./lib/utils/toMomentObject').default;
-
-var DateRangePickerShape = require('./lib/shapes/DateRangePickerShape').default;
-var SingleDatePickerShape = require('./lib/shapes/SingleDatePickerShape').default;
 
 var constants = require('./lib/constants');
 
@@ -27,12 +32,18 @@ module.exports = {
   CalendarMonth: CalendarMonth,
   CalendarDay: CalendarDay,
 
+  DateRangePickerShape: DateRangePickerShape,
+  SingleDatePickerShape: SingleDatePickerShape,
+
+  isInclusivelyAfterDay: isInclusivelyAfterDay,
+  isInclusivelyBeforeDay: isInclusivelyBeforeDay,
+  isNextDay: isNextDay,
+  isSameDay: isSameDay,
+
   toISODateString: toISODateString,
   toLocalizedDateString: toLocalizedDateString,
   toMomentObject: toMomentObject,
 
-  DateRangePickerShape: DateRangePickerShape,
-  SingleDatePickerShape: SingleDatePickerShape,
 
   constants: constants
 };


### PR DESCRIPTION
This PR exports the following date comparison methods as utility classes:
```
  isInclusivelyAfterDay
  isInclusivelyBeforeDay
  isNextDay
  isSameDay
```
