### PR TITLE
Add initialVisibleMonth fn prop to DayPicker

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -311,6 +311,8 @@ export default class DateRangePicker extends React.Component {
       withPortal,
       withFullScreenPortal,
       enableOutsideDays,
+      initialVisibleMonth,
+      focused,
     } = this.props;
 
     const modifiers = {
@@ -351,6 +353,8 @@ export default class DateRangePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          focused={focused}
+          initialVisibleMonth={initialVisibleMonth}
           onOutsideClick={onOutsideClick}
         />
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -32,6 +32,8 @@ const propTypes = {
   modifiers: PropTypes.object,
   orientation: OrientationShape,
   withPortal: PropTypes.bool,
+  focused: PropTypes.bool,
+  initialVisibleMonth: PropTypes.func,
   onDayClick: PropTypes.func,
   onDayMouseDown: PropTypes.func,
   onDayMouseUp: PropTypes.func,
@@ -54,6 +56,8 @@ const defaultProps = {
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
+  focused: true,
+  initialVisibleMonth: () => moment(),
   onDayClick() {},
   onDayMouseDown() {},
   onDayMouseUp() {},
@@ -73,8 +77,9 @@ const defaultProps = {
 export default class DayPicker extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
-      currentMonth: moment(),
+      currentMonth: props.focused ? props.initialVisibleMonth() : null,
       monthTransition: null,
       translationValue: 0,
     };
@@ -88,6 +93,14 @@ export default class DayPicker extends React.Component {
     if (this.isHorizontal()) {
       this.adjustDayPickerHeight();
       this.initializeDayPickerWidth();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (!this.state.currentMonth && nextProps.focused) {
+      this.setState({
+        currentMonth: nextProps.initialVisibleMonth(),
+      });
     }
   }
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -169,6 +169,8 @@ export default class SingleDatePicker extends React.Component {
       onNextMonthClick,
       withPortal,
       withFullScreenPortal,
+      focused,
+      initialVisibleMonth,
     } = this.props;
 
     const modifiers = {
@@ -197,6 +199,8 @@ export default class SingleDatePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          focused={focused}
+          initialVisibleMonth={initialVisibleMonth}
           onOutsideClick={onOutsideClick}
         />
 

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -27,6 +27,7 @@ export default {
   endDateId: PropTypes.string,
   endDatePlaceholderText: PropTypes.string,
 
+  initialVisibleMonth: PropTypes.func,
   onDatesChange: PropTypes.func,
   onFocusChange: PropTypes.func,
   onPrevMonthClick: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -18,6 +18,7 @@ export default {
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: OrientationShape,
+  initialVisibleMonth: PropTypes.func,
 
   // portal options
   withPortal: PropTypes.bool,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -88,6 +88,11 @@ storiesOf('DateRangePicker', module)
       isDayBlocked={day1 => datesList.some(day2 => isSameDay(day1, day2))}
     />
   ))
+  .add('with month specified on open', () => (
+    <DateRangePickerWrapper
+      initialVisibleMonth={() => moment('01 2017', 'MM YYYY')}
+    />
+  ))
   .add('blocks fridays', () => (
     <DateRangePickerWrapper
       isDayBlocked={day => moment.weekdays(day.weekday()) === 'Friday'}

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
+import moment from 'moment';
 import { mount, shallow } from 'enzyme';
 
 import DayPicker from '../../src/components/DayPicker';
@@ -237,6 +238,20 @@ describe('DayPicker', () => {
           mount(<DayPicker orientation={VERTICAL_ORIENTATION} />);
           expect(initializeDayPickerWidthSpy.called).to.equal(false);
         });
+      });
+    });
+
+    describe('#componentWillReceiveProps', () => {
+      const initialVisibleMonth = () => moment('01 2016', 'MM YYYY');
+      it('will set initialVisibleMonth when focused is toggled', () => {
+        const wrapper = mount(
+          <DayPicker focused={false} initialVisibleMonth={initialVisibleMonth} />
+        );
+        expect(wrapper.state('visibleMonth')).to.be(null);
+        wrapper.setProps({
+          focused: true,
+        });
+        expect(wrapper.state('visibleMonth').isSame(initialVisibleMonth())).to.be(true);
       });
     });
 


### PR DESCRIPTION
Related to https://github.com/airbnb/react-dates/issues/17
Adds a new prop to DateRangePicker, SingleDatePicker, and DayPicker
that passes a fn to DayPicker. On the initial focus, that fn will be called
and set the initial month to the returned moment object.
