### PR TITLE
Disable user-select on arrow buttons

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -29,9 +29,6 @@
   color: $react-dates-color-placeholder-text;
   cursor: pointer;
   line-height: 0.78;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 
   &:focus,

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -29,6 +29,10 @@
   color: $react-dates-color-placeholder-text;
   cursor: pointer;
   line-height: 0.78;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   &:focus,
   &:hover {


### PR DESCRIPTION
Disabled user-select to prevent text-selection when clicking rapidly on the arrows.

Screenshot of text-selection:

<img width="649" alt="screen shot 2016-09-01 at 12 35 38 am" src="https://cloud.githubusercontent.com/assets/59797/18155453/ce90d8d0-6fdb-11e6-84d1-6c6de69f1b72.png">
