### PR TITLE
Move constants to top level directory

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,10 @@
+module.exports = {
+  DISPLAY_FORMAT: 'L',
+  ISO_FORMAT: 'YYYY-MM-DD',
+
+  START_DATE: 'startDate',
+  END_DATE: 'endDate',
+
+  HORIZONTAL_ORIENTATION: 'horizontal',
+  VERTICAL_ORIENTATION: 'vertical'
+};

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ var toISODateString = require('./lib/utils/toISODateString').default;
 var toLocalizedDateString = require('./lib/utils/toLocalizedDateString').default;
 var toMomentObject = require('./lib/utils/toMomentObject').default;
 
-var constants = require('./lib/constants');
 
 module.exports = {
   DateRangePicker: DateRangePicker,
@@ -43,7 +42,4 @@ module.exports = {
   toISODateString: toISODateString,
   toLocalizedDateString: toLocalizedDateString,
   toMomentObject: toMomentObject,
-
-
-  constants: constants
 };

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -9,7 +9,7 @@ import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = {
   month: momentPropTypes.momentObj,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -12,7 +12,7 @@ import getTransformStyles from '../utils/getTransformStyles';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = {
   enableOutsideDays: PropTypes.bool,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -27,7 +27,7 @@ import {
   END_DATE,
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
-} from '../constants';
+} from '../../constants';
 
 const propTypes = DateRangePickerShape;
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -5,7 +5,7 @@ import DateInput from './DateInput';
 import RightArrow from '../svg/arrow-right.svg';
 import CloseButton from '../svg/close.svg';
 
-import { START_DATE, END_DATE } from '../constants';
+import { START_DATE, END_DATE } from '../../constants';
 
 const propTypes = {
   startDateId: PropTypes.string,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -16,7 +16,7 @@ import getTransformStyles from '../utils/getTransformStyles';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const CALENDAR_MONTH_WIDTH = 300;
 const DAY_PICKER_PADDING = 9;

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -18,7 +18,7 @@ import isSameDay from '../utils/isSameDay';
 
 import SingleDatePickerShape from '../shapes/SingleDatePickerShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = SingleDatePickerShape;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,0 @@
-export const DISPLAY_FORMAT = 'L';
-export const ISO_FORMAT = 'YYYY-MM-DD';
-
-export const START_DATE = 'startDate';
-export const END_DATE = 'endDate';
-
-export const HORIZONTAL_ORIENTATION = 'horizontal';
-export const VERTICAL_ORIENTATION = 'vertical';

--- a/src/shapes/FocusedInputShape.js
+++ b/src/shapes/FocusedInputShape.js
@@ -3,6 +3,6 @@ import { PropTypes } from 'react';
 import {
   START_DATE,
   END_DATE,
-} from '../constants';
+} from '../../constants';
 
 export default PropTypes.oneOf([START_DATE, END_DATE]);

--- a/src/shapes/OrientationShape.js
+++ b/src/shapes/OrientationShape.js
@@ -3,6 +3,6 @@ import { PropTypes } from 'react';
 import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
-} from '../constants';
+} from '../../constants';
 
 export default PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]);

--- a/src/utils/toISODateString.js
+++ b/src/utils/toISODateString.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { ISO_FORMAT } from '../constants';
+import { ISO_FORMAT } from '../../constants';
 
 export default function toLocalizedDateString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);

--- a/src/utils/toLocalizedDateString.js
+++ b/src/utils/toLocalizedDateString.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { DISPLAY_FORMAT } from '../constants';
+import { DISPLAY_FORMAT } from '../../constants';
 
 export default function toLocalizedDateString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);

--- a/src/utils/toMomentObject.js
+++ b/src/utils/toMomentObject.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { DISPLAY_FORMAT, ISO_FORMAT } from '../constants';
+import { DISPLAY_FORMAT, ISO_FORMAT } from '../../constants';
 
 export default function toMomentObject(dateString, customFormat) {
   if (customFormat) {

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@kadira/storybook';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import DayPicker from '../src/components/DayPicker';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 storiesOf('DayPicker', module)
   .add('default', () => (

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@kadira/storybook';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 storiesOf('SingleDatePicker', module)
   .add('default', () => (

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import CalendarMonth from '../../src/components/CalendarMonth';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 import getTransformStyles from '../../src/utils/getTransformStyles';
 

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 import CalendarMonth, { getModifiersForDay } from '../../src/components/CalendarMonth';
 
 describe('CalendarMonth', () => {

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -19,7 +19,7 @@ import {
   VERTICAL_ORIENTATION,
   START_DATE,
   END_DATE,
-} from '../../src/constants';
+} from '../../constants';
 
 const today = moment().startOf('day');
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme';
 
 import DayPicker from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 describe('DayPicker', () => {
   describe('#render', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon-sandbox';
 import moment from 'moment';
 import Portal from 'react-portal';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 import DayPicker from '../../src/components/DayPicker';
 import OutsideClickHandler from '../../src/components/OutsideClickHandler';


### PR DESCRIPTION
This is to allow for `import { START_DATE END_DATE } from 'react-dates/constants';` and it makes sense for it not to need transpilation since the file is literally a collection of strings. However, it is breaking.