### PR TITLE
Update CalendarMonth__caption class

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -31,7 +31,7 @@
   margin-top: 7px;
   font-size: 18px;
   padding: 15px 0 35px;
-
+  text-align: center;
   // necessary to not hide borders in FF
   margin-bottom: 2px;
 }


### PR DESCRIPTION
Bootstrap caused the caption to align left.  Adding a text-align:center makes sure that the Month caption is always aligned in the center.