### PR TITLE
Fixes edge-case `CalendarMonth` height issue 

### DIFF
--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -24,13 +24,17 @@ export default function getCalendarMonthWeeks(month, enableOutsideDays) {
     }
   }
 
-  // days belonging to the next month
-  for (let k = currentDay.weekday(), count = 0; k < 7; k++, count++) {
-    const nextDay = enableOutsideDays && currentDay.clone().add(count, 'day');
-    currentWeek.push(nextDay);
-  }
+  // weekday() returns the index of the day of the week according to the locale
+  // this means if the week starts on Monday, weekday() will return 0 for a Monday date, not 1
+  if (currentDay.weekday() !== 0) {
+    // days belonging to the next month
+    for (let k = currentDay.weekday(), count = 0; k < 7; k++, count++) {
+      const nextDay = enableOutsideDays && currentDay.clone().add(count, 'day');
+      currentWeek.push(nextDay);
+    }
 
-  weeksInMonth.push(currentWeek);
+    weeksInMonth.push(currentWeek);
+  }
 
   return weeksInMonth;
 }

--- a/test/utils/getCalendarMonthWeeks_spec.js
+++ b/test/utils/getCalendarMonthWeeks_spec.js
@@ -55,9 +55,37 @@ describe('getCalendarMonthWeeks', () => {
       expect(containsFirstOfMonth).to.equal(true);
     });
 
-    it('contains last of the month', () => {
+    it('last week contains last of the month', () => {
       const lastOfMonth = today.clone().endOf('month');
       const containsLastOfMonth = weeks[weeksWithOutsideDays.length - 1]
+        .filter(day => lastOfMonth.isSame(day, 'day')).length > 0;
+      expect(containsLastOfMonth).to.equal(true);
+    });
+
+    it('last week contains last of the month if next month begins on Sunday', () => {
+      const december2016 = moment('2016-12-01');
+      const lastOfMonth = december2016.clone().endOf('month');
+      const weeksInDecember = getCalendarMonthWeeks(december2016);
+      const containsLastOfMonth = weeksInDecember[weeksInDecember.length - 1]
+        .filter(day => lastOfMonth.isSame(day, 'day')).length > 0;
+      expect(containsLastOfMonth).to.equal(true);
+    });
+
+    it('last week contains last of the month if next month begins on Monday', () => {
+      moment.locale('es');
+      const april2017 = moment('2017-04-01');
+      const lastOfMonth = april2017.clone().endOf('month');
+      const weeksInApril = getCalendarMonthWeeks(april2017);
+      const containsLastOfMonth = weeksInApril[weeksInApril.length - 1]
+        .filter(day => lastOfMonth.isSame(day, 'day')).length > 0;
+      expect(containsLastOfMonth).to.equal(true);
+    });
+
+    it('last week contains last of the month if next month begins on Saturday', () => {
+      const september2016 = moment('2016-09-01');
+      const lastOfMonth = september2016.clone().endOf('month');
+      const weeksInSeptember = getCalendarMonthWeeks(september2016);
+      const containsLastOfMonth = weeksInSeptember[weeksInSeptember.length - 1]
         .filter(day => lastOfMonth.isSame(day, 'day')).length > 0;
       expect(containsLastOfMonth).to.equal(true);
     });


### PR DESCRIPTION
I recently noticed that sometimes the height of the datepicker was not rendering correctly, specifically that the table seemed to be an extra row representing the full first week of the following month:
<img width="632" alt="screen shot 2016-09-02 at 4 10 45 pm" src="https://cloud.githubusercontent.com/assets/1383861/18220538/d7f5b06a-7127-11e6-8886-f3c84b9fd2a8.png">

Turns out, when the next month starts at the beginning of the week (according to whatever locale you're in), we still render that full week as outside days. 

I also discovered that this was a ticking time bomb as related to the tests for `getCalendarMonthWeeks` that would have started breaking in December. As a result I've added some tests to cover this edgecase as well.