### PR TITLE
Fix utcOffset to get future dates correctly (fixes #55)

### DIFF
--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -1,6 +1,7 @@
 export default function getCalendarMonthWeeks(month, enableOutsideDays) {
-  const firstOfMonth = month.clone().startOf('month');
-  const lastOfMonth = month.clone().endOf('month');
+  const baseDate = month.clone().utcOffset(month.utcOffset());
+  const firstOfMonth = baseDate.clone().startOf('month');
+  const lastOfMonth = baseDate.clone().endOf('month');
 
   const currentDay = firstOfMonth.clone();
   let currentWeek = [];

--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -1,4 +1,5 @@
 export default function getCalendarMonthWeeks(month, enableOutsideDays) {
+  // set utc offset to get correct dates in future (when timezone changes)
   const baseDate = month.clone().utcOffset(month.utcOffset());
   const firstOfMonth = baseDate.clone().startOf('month');
   const lastOfMonth = baseDate.clone().endOf('month');


### PR DESCRIPTION
In order to fix #55, we realized that we can't use `moment#add` to get future dates (when using non utc dates). In the case of Brazil, the timezone will be changed at some month (in 2016, it is in October), and that may be causing the problems with `moment#add`.

Related: https://github.com/airbnb/react-dates/issues/55#issuecomment-244483584

Since `moment#add` will work with utc dates, the strategy is to try to use utc dates in `getCalendarMonthWeeks` function. But, we can't just add `.utc()` to `firstOfMonth` and `lastOfMonth`, since we would end up messing up the dates, as `.utc()` will do a conversion, we could end up using wrong months there (the previous month in `firstOfMonth` or the next month in `lastOfMonth`).

So, this pull request fixes that by doing the following operations:

1. Set a base date `baseDate` with a fixed utcOffset (it will set the `utc` flag in the moment object, and set the utc offset as the current utc offset).
2. Use this base date to derivate `firstOfMonth` and `lastOfMonth` (both, now utc dates).
3. Now, moment "knows" how to do `moment#add` properly.

Tested that using the following timezones: `America/Sao_Paulo`, `Europe/Athens`.

(Thank you for your help @majapw!)