### PR TITLE
Custom display formatting

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -43,6 +43,7 @@ const defaultProps = {
   onNextMonthClick() {},
 
   // i18n
+  displayLabel: null,
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
@@ -126,6 +127,16 @@ export default class SingleDatePicker extends React.Component {
     });
 
     return dayPickerClassName;
+  }
+
+  getDisplayValue(date) {
+    const { displayLabel } = this.props;
+
+    if (displayLabel) {
+      return displayLabel(date);
+    }
+
+    return toLocalizedDateString(date);
   }
 
   isBlocked(day) {
@@ -227,7 +238,7 @@ export default class SingleDatePicker extends React.Component {
 
     const onOutsideClick = withPortal || withFullScreenPortal ? () => {} : this.onClearFocus;
 
-    const dateValue = toLocalizedDateString(date);
+    const dateValue = this.getDisplayValue(date);
 
     return (
       <div className="SingleDatePicker">

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -27,6 +27,7 @@ export default {
   onNextMonthClick: PropTypes.func,
 
   // i18n
+  displayLabel: PropTypes.func,
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape({
     closeDatePicker: PropTypes.node,

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -51,4 +51,30 @@ storiesOf('SingleDatePicker', module)
       numberOfMonths={1}
       enableOutsideDays
     />
-  ));
+  ))
+  .add('with custom display label', () => {
+    moment.locale('en', {
+      calendar: {
+        sameDay: '[Now]',
+        nextDay: '[Tomorrow]',
+        nextWeek: 'dddd',
+        lastDay: '[Yesterday]',
+        lastWeek: '[last] dddd',
+        sameElse: 'L',
+      }
+    });
+
+    function parseDate(date) {
+      if (!date) {
+        return null;
+      }
+
+      return date.calendar();
+    }
+
+    return (
+      <SingleDatePickerWrapper
+        displayLabel={parseDate}
+      />
+    )
+  });


### PR DESCRIPTION
I have a use-case where I need to set a custom label (e.g. “Now”) if the selected date is set to Today. This is very similar to #52 except `displayFormat` is expecting a string, so you don’t get a lot of flexibility.

This PR gives you a bit more control over display label formatting.

I think the ultimate solution would be merging `displayLabel` and `displayFormat` (from #52) into a single prop, which would expect either a string or a function. Something in the lines of:

```
...

getDateString(date) {
  const { displayFormat } = this.props;

  if (typeof displayFormat === 'function') {
    return displayFormat(date);
  } else if (typeof displayFormat === ‘string’) {
    return date && date.format(displayFormat);
  }

  return toLocalizedDateString(date);
}

...
```

Thoughts?


Example:
![airbnb-datepicker](https://cloud.githubusercontent.com/assets/5294717/18291974/e057539c-7458-11e6-880f-b1bb77e2ddbd.gif)