### PR TITLE
Add directionAnchor prop to allow right-aligned Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ The `orientation` prop indicates whether months are stacked on top of each other
   orientation: PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION])
 ```
 
+The `anchorDirection` prop indicates whether the calendar is anchored to the right or left side of the input. You can import the `ANCHOR_LEFT` and `ANCHOR_RIGHT` constants from `react-dates/constants`. Defaults to `ANCHOR_LEFT`.
+```
+  direction: PropTypes.oneOf([ANCHOR_LEFT, ANCHOR_RIGHT])
+```
+
 `withPortal` was designed for use on mobile devices. Namely, if this prop is set to true, the `DayPicker` will be rendered centrally on the screen, above the current plane, with a transparent black background behind it. Clicking on the background will hide the `DayPicker`. This option is currently only available for a `DateRangePicker` with a horizontal orientation.
 ```
   withPortal: PropTypes.bool

--- a/constants.js
+++ b/constants.js
@@ -6,5 +6,8 @@ module.exports = {
   END_DATE: 'endDate',
 
   HORIZONTAL_ORIENTATION: 'horizontal',
-  VERTICAL_ORIENTATION: 'vertical'
+  VERTICAL_ORIENTATION: 'vertical',
+
+  ANCHOR_LEFT: 'left',
+  ANCHOR_RIGHT: 'right',
 };

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -21,7 +21,6 @@
   z-index: 1;
   position: absolute;
   top: 145%;
-  left: 0;
 
   &::before,
   &::after {
@@ -30,6 +29,14 @@
     position: absolute;
     bottom: auto;
   }
+}
+
+.DateRangePicker__picker--direction-left {
+    left: 0;
+}
+
+.DateRangePicker__picker--direction-right {
+    right: 0;
 }
 
 .DateRangePicker__picker--show {
@@ -55,34 +62,46 @@
 
 .DateRangePicker__picker--start::before,
 .DateRangePicker__picker--end::before {
-  top: -10px;
-  border: 10px solid transparent;
+  top: -$react-dates-width-tooltip-arrow / 2;
+  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
   border-top: 0;
   border-bottom-color: rgba(0, 0, 0, 0.1);
 }
 
-.DateRangePicker__picker--start::before {
+.DateRangePicker__picker--direction-left.DateRangePicker__picker--start::before {
   left: 22px;
 }
+.DateRangePicker__picker--direction-right.DateRangePicker__picker--start::before {
+    right: $react-dates-width-input + $react-dates-width-arrow + 22px;
+}
 
-.DateRangePicker__picker--end::before {
-  left: 162px;
+.DateRangePicker__picker--direction-left.DateRangePicker__picker--end::before {
+  left: $react-dates-width-arrow + $react-dates-width-input + 22px;
+}
+.DateRangePicker__picker--direction-right.DateRangePicker__picker--end::before {
+  right: 22px;
 }
 
 .DateRangePicker__picker--start::after,
 .DateRangePicker__picker--end::after {
-  top: -9px;
-  border: 9px solid transparent;
+  top: -$react-dates-width-tooltip-arrow / 2;
+  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
   border-top: 0;
   border-bottom-color: $react-dates-color-white;
 }
 
-.DateRangePicker__picker--start::after {
+.DateRangePicker__picker--direction-left.DateRangePicker__picker--start::after {
   left: 23px;
 }
+.DateRangePicker__picker--direction-right.DateRangePicker__picker--start::after {
+    right: $react-dates-width-input + $react-dates-width-arrow + 23px;
+}
 
-.DateRangePicker__picker--end::after {
-  left: 163px;
+.DateRangePicker__picker--direction-left.DateRangePicker__picker--end::after {
+    left: $react-dates-width-arrow + $react-dates-width-input + 23px;
+}
+.DateRangePicker__picker--direction-right.DateRangePicker__picker--end::after {
+    right: 23px;
 }
 
 .DateRangePicker__close {

--- a/css/DateRangePickerInput.scss
+++ b/css/DateRangePickerInput.scss
@@ -18,8 +18,8 @@
 .DateRangePickerInput__arrow svg {
   vertical-align: middle;
   fill: $react-dates-color-text;
-  height: 24px;
-  width: 24px;
+  height: $react-dates-width-arrow;
+  width: $react-dates-width-arrow;
 }
 
 .DateRangePickerInput__clear-dates {

--- a/css/SingleDatePicker.scss
+++ b/css/SingleDatePicker.scss
@@ -10,7 +10,6 @@
   z-index: 1;
   position: absolute;
   top: 145%;
-  left: 0;
 
   &::before,
   &::after {
@@ -25,7 +24,6 @@
     border: 10px solid transparent;
     border-top: 0;
     border-bottom-color: rgba(0, 0, 0, 0.1);
-    left: 22px;
   }
 
   &::after {
@@ -33,8 +31,27 @@
     border: 9px solid transparent;
     border-top: 0;
     border-bottom-color: #fff;
-    left: 23px;
   }
+}
+
+.SingleDatePicker__picker--direction-left {
+    left: 0;
+    &::before {
+        left: 22px;
+    }
+    &::after {
+        left: 23px;
+    }
+}
+
+.SingleDatePicker__picker--direction-right {
+    right: 0;
+    &::before {
+        right: 22px;
+    }
+    &::after {
+        right: 23px;
+    }
 }
 
 .SingleDatePicker__picker--show {

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,4 +1,6 @@
 $react-dates-width-input: 130px !default;
+$react-dates-width-arrow: 24px !default;
+$react-dates-width-tooltip-arrow: 20px !default;
 $react-dates-width-day-picker: 300px !default;
 
 $react-dates-color-primary: #00a699 !default;

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -27,6 +27,8 @@ import {
   END_DATE,
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
 } from '../../constants';
 
 const propTypes = DateRangePickerShape;
@@ -47,6 +49,7 @@ const defaultProps = {
   initialVisibleMonth: () => moment(),
 
   orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
   withPortal: false,
   withFullScreenPortal: false,
 
@@ -211,11 +214,19 @@ export default class DateRangePicker extends React.Component {
   }
 
   getDayPickerContainerClasses() {
-    const { focusedInput, orientation, withPortal, withFullScreenPortal } = this.props;
+    const {
+      focusedInput,
+      orientation,
+      withPortal,
+      withFullScreenPortal,
+      anchorDirection,
+    } = this.props;
     const { hoverDate } = this.state;
     const showDatepicker = focusedInput === START_DATE || focusedInput === END_DATE;
 
     const dayPickerClassName = cx('DateRangePicker__picker', {
+      'DateRangePicker__picker--direction-left': anchorDirection === ANCHOR_LEFT,
+      'DateRangePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
       'DateRangePicker__picker--show': showDatepicker,
       'DateRangePicker__picker--invisible': !showDatepicker,
       'DateRangePicker__picker--start': focusedInput === START_DATE,

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -18,7 +18,12 @@ import isSameDay from '../utils/isSameDay';
 
 import SingleDatePickerShape from '../shapes/SingleDatePickerShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
+} from '../../constants';
 
 const propTypes = SingleDatePickerShape;
 
@@ -36,6 +41,7 @@ const defaultProps = {
   enableOutsideDays: false,
   numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
   withPortal: false,
   withFullScreenPortal: false,
   initialVisibleMonth: () => moment(),
@@ -123,12 +129,14 @@ export default class SingleDatePicker extends React.Component {
   }
 
   getDayPickerContainerClasses() {
-    const { focused, orientation, withPortal, withFullScreenPortal } = this.props;
+    const { focused, orientation, withPortal, withFullScreenPortal, anchorDirection } = this.props;
     const { hoverDate } = this.state;
 
     const dayPickerClassName = cx('SingleDatePicker__picker', {
       'SingleDatePicker__picker--show': focused,
       'SingleDatePicker__picker--invisible': !focused,
+      'SingleDatePicker__picker--direction-left': anchorDirection === ANCHOR_LEFT,
+      'SingleDatePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
       'SingleDatePicker__picker--horizontal': orientation === HORIZONTAL_ORIENTATION,
       'SingleDatePicker__picker--vertical': orientation === VERTICAL_ORIENTATION,
       'SingleDatePicker__picker--portal': withPortal || withFullScreenPortal,

--- a/src/shapes/AnchorDirectionShape.js
+++ b/src/shapes/AnchorDirectionShape.js
@@ -1,0 +1,8 @@
+import { PropTypes } from 'react';
+
+import {
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
+} from '../../constants';
+
+export default PropTypes.oneOf([ANCHOR_LEFT, ANCHOR_RIGHT]);

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -3,6 +3,7 @@ import momentPropTypes from 'react-moment-proptypes';
 
 import FocusedInputShape from '../shapes/FocusedInputShape';
 import OrientationShape from '../shapes/OrientationShape';
+import anchorDirectionShape from '../shapes/AnchorDirectionShape';
 
 export default {
   startDate: momentPropTypes.momentObj,
@@ -18,7 +19,7 @@ export default {
   disabled: PropTypes.bool,
 
   orientation: OrientationShape,
-
+  anchorDirection: anchorDirectionShape,
   // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -2,6 +2,7 @@ import { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
 
 import OrientationShape from '../shapes/OrientationShape';
+import anchorDirectionShape from '../shapes/AnchorDirectionShape';
 
 export default {
   id: PropTypes.string.isRequired,
@@ -19,6 +20,7 @@ export default {
   numberOfMonths: PropTypes.number,
   orientation: OrientationShape,
   initialVisibleMonth: PropTypes.func,
+  anchorDirection: anchorDirectionShape,
 
   // portal options
   withPortal: PropTypes.bool,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@kadira/storybook';
 
-import { VERTICAL_ORIENTATION } from '../constants';
+import { VERTICAL_ORIENTATION, ANCHOR_RIGHT } from '../constants';
 
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
@@ -29,10 +29,25 @@ storiesOf('DateRangePicker', module)
       numberOfMonths={1}
     />
   ))
+  .add('anchored right', () => (
+    <div style={{ float: 'right' }}>
+      <DateRangePickerWrapper
+        anchorDirection={ANCHOR_RIGHT}
+      />
+    </div>
+  ))
   .add('vertical', () => (
     <DateRangePickerWrapper
       orientation={VERTICAL_ORIENTATION}
     />
+  ))
+  .add('vertical anchored right', () => (
+    <div style={{ float: 'right' }}>
+      <DateRangePickerWrapper
+        orientation={VERTICAL_ORIENTATION}
+        anchorDirection={ANCHOR_RIGHT}
+      />
+    </div>
   ))
   .add('horizontal with portal', () => (
     <DateRangePickerWrapper

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@kadira/storybook';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 
-import { VERTICAL_ORIENTATION } from '../constants';
+import { VERTICAL_ORIENTATION, ANCHOR_RIGHT } from '../constants';
 
 storiesOf('SingleDatePicker', module)
   .add('default', () => (
@@ -14,6 +14,13 @@ storiesOf('SingleDatePicker', module)
     <SingleDatePickerWrapper
       numberOfMonths={1}
     />
+  ))
+  .add('anchored right', () => (
+    <div style={{ float: 'right' }}>
+      <SingleDatePickerWrapper
+        anchorDirection={ANCHOR_RIGHT}
+      />
+    </div>
   ))
   .add('vertical', () => (
     <SingleDatePickerWrapper

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -19,6 +19,8 @@ import {
   VERTICAL_ORIENTATION,
   START_DATE,
   END_DATE,
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
 } from '../../constants';
 
 const today = moment().startOf('day');
@@ -66,6 +68,20 @@ describe('DateRangePicker', () => {
       it('renders <DayPicker /> with props.numberOfMonths === 2', () => {
         const wrapper = shallow(<DateRangePicker orientation={HORIZONTAL_ORIENTATION} />);
         expect(wrapper.find(DayPicker).props().numberOfMonths).to.equal(2);
+      });
+    });
+
+    describe('props.anchorDirection === ANCHOR_LEFT', () => {
+      it('renders .DateRangePicker__picker--direction-left class', () => {
+        const wrapper = shallow(<DateRangePicker anchorDirection={ANCHOR_LEFT} />);
+        expect(wrapper.find('.DateRangePicker__picker--direction-left')).to.have.length(1);
+      });
+    });
+
+    describe('props.orientation === ANCHOR_RIGHT', () => {
+      it('renders .DateRangePicker__picker--direction-right class', () => {
+        const wrapper = shallow(<DateRangePicker anchorDirection={ANCHOR_RIGHT} />);
+        expect(wrapper.find('.DateRangePicker__picker--direction-right')).to.have.length(1);
       });
     });
 

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -5,7 +5,12 @@ import sinon from 'sinon-sandbox';
 import moment from 'moment';
 import Portal from 'react-portal';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
+} from '../../constants';
 
 import DayPicker from '../../src/components/DayPicker';
 import OutsideClickHandler from '../../src/components/OutsideClickHandler';
@@ -67,6 +72,20 @@ describe('SingleDatePicker', () => {
           const wrapper =
             shallow(<SingleDatePicker id="date" orientation={VERTICAL_ORIENTATION} />);
           expect(wrapper.find('.SingleDatePicker__picker--vertical')).to.have.lengthOf(1);
+        });
+      });
+
+      describe('props.anchorDirection === ANCHOR_LEFT', () => {
+        it('renders .SingleDatePicker__picker--direction-left class', () => {
+          const wrapper = shallow(<SingleDatePicker anchorDirection={ANCHOR_LEFT} />);
+          expect(wrapper.find('.SingleDatePicker__picker--direction-left')).to.have.length(1);
+        });
+      });
+
+      describe('props.orientation === ANCHOR_RIGHT', () => {
+        it('renders .SingleDatePicker__picker--direction-right class', () => {
+          const wrapper = shallow(<SingleDatePicker anchorDirection={ANCHOR_RIGHT} />);
+          expect(wrapper.find('.SingleDatePicker__picker--direction-right')).to.have.length(1);
         });
       });
 


### PR DESCRIPTION
DateRangePicker and SingleDatePicker have a new prop, directionAnchor
that will align the components to the left/right side of the page.
This prop has two new constants, DIRECTION_ANCHOR_LEFT (default)
and DIRECTION_ANCHOR_RIGHT.

solves issue https://github.com/airbnb/react-dates/issues/71