### PR TITLE
added hidePickerOnClear prop which when true hides the date picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ The `phrases` prop is an object that contains all the English language phrases c
   }),
 ```
 
+** Display picker when clicked on clear button: **
+
+The `reopenPickerOnClearDates` helps to control whether to show the date picker when the clear option is clicked. This is set to `false` by default
+which means that the picker does not open when the clear button is clicked by default. To display the picker one must explicitly set it to `true`.
+
+```
+    reopenPickerOnClearDates: PropTypes.bool
+```
+
 ### `SingleDatePicker`
 This fully-controlled component is designed to allow a user to select a single date.
 

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -43,6 +43,7 @@ const defaultProps = {
   numberOfMonths: 2,
   showClearDates: false,
   disabled: false,
+  reopenPickerOnClearDates: false,
 
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
@@ -233,8 +234,11 @@ export default class DateRangePicker extends React.Component {
   }
 
   clearDates() {
-    this.props.onDatesChange({ startDate: null, endDate: null });
-    this.props.onFocusChange(START_DATE);
+    const { onDatesChange, reopenPickerOnClearDates, onFocusChange } = this.props;
+    onDatesChange({ startDate: null, endDate: null });
+    if (reopenPickerOnClearDates) {
+      onFocusChange(START_DATE);
+    }
   }
 
   doesNotMeetMinimumNights(day) {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -12,6 +12,7 @@ export default {
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
+  reopenPickerOnClearDates: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   showClearDates: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -53,6 +53,12 @@ storiesOf('DateRangePicker', module)
       showClearDates
     />
   ))
+  .add('with clear dates button (Picker Displayed)', () => (
+    <DateRangePickerWrapper
+      showClearDates
+      reopenPickerOnClearDates
+    />
+  ))
   .add('non-english locale', () => {
     moment.locale('zh-cn');
     return (

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -154,19 +154,40 @@ describe('DateRangePicker', () => {
   });
 
   describe('#clearDates', () => {
-    describe('props.onFocusChange', () => {
-      it('is called once', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
-        wrapper.instance().clearDates();
-        expect(onFocusChangeStub.callCount).to.equal(1);
-      });
+    describe('props.reopenPickerOnClearDates is truthy', () => {
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDates
+            />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
 
-      it('is called with arg START_DATE', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
-        wrapper.instance().clearDates();
-        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+        it('is called with arg START_DATE', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDates
+            />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+        });
+      });
+    });
+
+    describe('props.reopenPickerOnClearDates is falsy', () => {
+      describe('props.onFocusChange', () => {
+        it('is not called', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
       });
     });
 


### PR DESCRIPTION
This PR is in response to the issue #68 . As requested a prop hidePickerOnClear has been added which governs whether the picker will be shown when clear is clicked. 

By default the value is set to false. 