### PR TITLE
Add week number support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - node_js: "node"
-      env: KARMA=true
+#    - node_js: "node"
+#      env: KARMA=true
     - node_js: "node"
       env: LINT=true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,25 @@ node_js:
   - "4.2"
   - "iojs"
 before_script:
-  - if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then export DISPLAY=:99.0; fi
-  - if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then sh -e /etc/init.d/xvfb start; fi
-  - if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then sleep 3; fi
-script: 'if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then npm test; else npm run tests-only; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then export DISPLAY=:99.0; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then sh -e /etc/init.d/xvfb start; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = 6 ]; then sleep 3; fi'
+script:
+  - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
+  - 'if [ -n "${TEST-}" ]; then npm run tests-only ; fi'
+  - 'if [ -n "${KARMA-}" ]; then npm run tests-karma ; fi'
 env:
-  - REACT=0.14
+  global:
+    - REACT=0.14
+  matrix:
+    - TEST=true
 sudo: false
 matrix:
   fast_finish: true
+  include:
+    - node_js: "node"
+      env: KARMA=true
+    - node_js: "node"
+      env: LINT=true
   allow_failures:
     - node_js: "iojs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v2.2.0
+ - [fix] Fix height issue where an extra table row was being rendered for some months ([#57](https://github.com/airbnb/react-dates/pull/57))
+ - [fix] Disables user-select on navigation ([#74](https://github.com/airbnb/react-dates/pull/74))
+ - [new] Allows for a custom date display format ([#52](https://github.com/airbnb/react-dates/pull/52))
+
 ## v2.1.1
  - [fix] Fix initial day of month to utc to fix daylight savings time problem in Brazil and other locales
  - [fix] Remove jQuery as a dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v3.0.0
+ - [breaking] Move the constants file to the top-level ([#53](https://github.com/airbnb/react-dates/pull/53))
+ - [breaking] Add `reopenPickerOnClearDates` prop so that the DateRangePicker no longer automatically reopens when clearing dates ([#75](https://github.com/airbnb/react-dates/pull/75))
+
 ## v2.2.0
  - [fix] Fix height issue where an extra table row was being rendered for some months ([#57](https://github.com/airbnb/react-dates/pull/57))
  - [fix] Disables user-select on navigation ([#74](https://github.com/airbnb/react-dates/pull/74))

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ The `phrases` prop is an object that contains all the English language phrases c
   }),
 ```
 
+** Display picker when clicked on clear button: **
+
+The `reopenPickerOnClearDates` helps to control whether to show the date picker when the clear option is clicked. This is set to `false` by default
+which means that the picker does not open when the clear button is clicked by default. To display the picker one must explicitly set it to `true`.
+
+```
+    reopenPickerOnClearDates: PropTypes.bool
+```
+
 ### `SingleDatePicker`
 This fully-controlled component is designed to allow a user to select a single date.
 

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,10 @@
+module.exports = {
+  DISPLAY_FORMAT: 'L',
+  ISO_FORMAT: 'YYYY-MM-DD',
+
+  START_DATE: 'startDate',
+  END_DATE: 'endDate',
+
+  HORIZONTAL_ORIENTATION: 'horizontal',
+  VERTICAL_ORIENTATION: 'vertical'
+};

--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -43,11 +43,6 @@
   cursor: default;
   width: 39px;
   height: 38px;
-
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
 }
 
 // This order is important.

--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -41,8 +41,8 @@
   box-sizing: border-box;
   color: $react-dates-color-gray;
   cursor: default;
-  width: 39px;
-  height: 38px;
+  width: $react-dates-width-day;
+  height: $react-dates-height-day;;
 }
 
 // This order is important.
@@ -52,8 +52,8 @@
   box-sizing: border-box;
   color: $react-dates-color-gray;
   cursor: pointer;
-  width: 39px;
-  height: 38px;
+  width: $react-dates-width-day;
+  height: $react-dates-height-day;;
 
   &:active {
     background: darken($react-dates-color-white, 5%);

--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -36,6 +36,20 @@
   margin-bottom: 2px;
 }
 
+.CalendarMonth__weeknumber {
+  padding: 0;
+  box-sizing: border-box;
+  color: $react-dates-color-gray;
+  cursor: default;
+  width: 39px;
+  height: 38px;
+
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}
+
 // This order is important.
 .CalendarMonth__day {
   border: 1px solid lighten($react-dates-color-border-light, 3);

--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -1,5 +1,3 @@
-$react-dates-width-day-picker: 300px;
-
 .CalendarMonthGrid {
   background: #fff;
   z-index: 0;
@@ -13,10 +11,8 @@ $react-dates-width-day-picker: 300px;
 .CalendarMonthGrid--horizontal {
   position: absolute;
   left: 9px;
-  width: 4 * $react-dates-width-day-picker;
 }
 
 .CalendarMonthGrid--vertical {
-  width: $react-dates-width-day-picker;
   margin: 0 auto;
 }

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -29,6 +29,7 @@
   color: $react-dates-color-placeholder-text;
   cursor: pointer;
   line-height: 0.78;
+  user-select: none;
   -webkit-user-select: none; /* Chrome/Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+ */

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -29,7 +29,9 @@
   color: $react-dates-color-placeholder-text;
   cursor: pointer;
   line-height: 0.78;
-  user-select: none;
+  -webkit-user-select: none; /* Chrome/Safari */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* IE10+ */
 
   &:focus,
   &:hover {

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -144,9 +144,11 @@
 }
 
 .DayPicker--vertical .DayPicker__week-header {
-  margin-left: -1 * $react-dates-width-day-picker / 2;
+  transform: translate(-50%, 0);
+  -moz-transform: translate(-50%, 0);
+  -webkit-transform: translate(-50%, 0);
+  -ms-transform: translate(-50%, 0);
   padding: 0 13px;
-  width: $react-dates-width-day-picker;
   left: 50%;
 }
 

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -114,6 +114,10 @@
   top: 62px;
   z-index: 2;
   text-align: left;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 
   ul {
     list-style: none;

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -20,3 +20,6 @@ $react-dates-color-placeholder-text: #757575 !default;
 $react-dates-color-text: #484848 !default;
 $react-dates-color-text-focus: #007a87 !default;
 $react-dates-color-focus: #99ede6 !default;
+
+$react-dates-width-day: 39px !default;
+$react-dates-height-day: 38px !default;

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,5 +1,4 @@
 $react-dates-width-input: 130px !default;
-$react-dates-width-day-picker: 300px !default;
 
 $react-dates-color-primary: #00a699 !default;
 $react-dates-color-primary-dark: #00514a !default;

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ var toISODateString = require('./lib/utils/toISODateString').default;
 var toLocalizedDateString = require('./lib/utils/toLocalizedDateString').default;
 var toMomentObject = require('./lib/utils/toMomentObject').default;
 
-var constants = require('./lib/constants');
 
 module.exports = {
   DateRangePicker: DateRangePicker,
@@ -43,7 +42,4 @@ module.exports = {
   toISODateString: toISODateString,
   toLocalizedDateString: toLocalizedDateString,
   toMomentObject: toMomentObject,
-
-
-  constants: constants
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "karma-webpack": "^1.8.0",
     "mocha": "^3.0.2",
     "mocha-wrap": "^2.0.5",
-    "moment": "^2.14.1",
+    "moment": "~2.14.1",
     "node-sass": "^3.8.0",
     "raw-loader": "^0.5.1",
     "react": "^15.2.1",
@@ -93,7 +93,7 @@
     "react-portal": "^2.2.1"
   },
   "peerDependencies": {
-    "moment": ">=2.10",
+    "moment": ">=2.10 && < 2.15.0",
     "react": ">=0.14",
     "react-dom": ">=0.14",
     "react-addons-shallow-compare": ">=0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -9,7 +9,7 @@ import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = {
   month: momentPropTypes.momentObj,

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -15,6 +15,7 @@ const propTypes = {
   month: momentPropTypes.momentObj,
   isVisible: PropTypes.bool,
   enableOutsideDays: PropTypes.bool,
+  withWeekNumbers: PropTypes.bool,
   modifiers: PropTypes.object,
   orientation: OrientationShape,
   onDayClick: PropTypes.func,
@@ -34,6 +35,7 @@ const defaultProps = {
   month: moment(),
   isVisible: true,
   enableOutsideDays: false,
+  withWeekNumbers: false,
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   onDayClick() {},
@@ -53,11 +55,26 @@ export function getModifiersForDay(modifiers, day) {
   return day ? Object.keys(modifiers).filter(key => modifiers[key](day)) : [];
 }
 
+export function getWeekNumberForWeek(week) {
+  if (week && Array.isArray(week)) {
+    const validDays = week.filter((d) => (d));
+    if (validDays[0] && moment.isMoment(validDays[0])) {
+      const firstDayOfWeek = validDays[0].clone().startOf('week');
+
+      return firstDayOfWeek.week();
+    }
+    return null;
+  }
+
+  return null;
+}
+
 export default function CalendarMonth(props) {
   const {
     month,
     monthFormat,
     orientation,
+    withWeekNumbers,
     isVisible,
     modifiers,
     enableOutsideDays,
@@ -87,6 +104,12 @@ export default function CalendarMonth(props) {
         <tbody className="js-CalendarMonth__grid">
           {getCalendarMonthWeeks(month, enableOutsideDays).map((week, i) =>
             <tr key={i}>
+
+              {withWeekNumbers ?
+                <td className="CalendarMonth__weeknumber" key={-1}>
+                  <small>{getWeekNumberForWeek(week)}</small>
+                </td> : null}
+
               {week.map((day, j) => {
                 const modifiersForDay = getModifiersForDay(modifiers, day);
                 const className = cx('CalendarMonth__day', {

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -7,6 +7,8 @@ import CalendarDay from './CalendarDay';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 
+import getWeekNumberForWeek from '../utils/getWeekNumberForWeek';
+
 import OrientationShape from '../shapes/OrientationShape';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
@@ -53,20 +55,6 @@ const defaultProps = {
 
 export function getModifiersForDay(modifiers, day) {
   return day ? Object.keys(modifiers).filter(key => modifiers[key](day)) : [];
-}
-
-export function getWeekNumberForWeek(week) {
-  if (week && Array.isArray(week)) {
-    const validDays = week.filter((d) => (d));
-    if (validDays[0] && moment.isMoment(validDays[0])) {
-      const firstDayOfWeek = validDays[0].clone().startOf('week');
-
-      return firstDayOfWeek.week();
-    }
-    return null;
-  }
-
-  return null;
 }
 
 export default function CalendarMonth(props) {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -12,7 +12,7 @@ import getTransformStyles from '../utils/getTransformStyles';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = {
   enableOutsideDays: PropTypes.bool,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -10,6 +10,8 @@ import CalendarMonth from './CalendarMonth';
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 
+import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
+
 import OrientationShape from '../shapes/OrientationShape';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
@@ -19,6 +21,7 @@ const propTypes = {
   firstVisibleMonthIndex: PropTypes.number,
   initialMonth: momentPropTypes.momentObj,
   isAnimating: PropTypes.bool,
+  withWeekNumbers: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   modifiers: PropTypes.object,
   orientation: OrientationShape,
@@ -41,6 +44,7 @@ const defaultProps = {
   enableOutsideDays: false,
   firstVisibleMonthIndex: 0,
   initialMonth: moment(),
+  withWeekNumbers: false,
   isAnimating: false,
   numberOfMonths: 1,
   modifiers: {},
@@ -59,6 +63,19 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
 };
+
+function getCalendarMonthGridWidthStyle(orientation, withWeekNumbers) {
+  const calendarMonthWidth = getCalendarMonthWidth(withWeekNumbers);
+
+  switch (orientation) {
+    case HORIZONTAL_ORIENTATION:
+      return { width: 4 * calendarMonthWidth };
+    case VERTICAL_ORIENTATION:
+      return { width: calendarMonthWidth };
+    default:
+      return {};
+  }
+}
 
 export default class CalendarMonthGrid extends React.Component {
   constructor(props) {
@@ -103,6 +120,7 @@ export default class CalendarMonthGrid extends React.Component {
       isAnimating,
       modifiers,
       numberOfMonths,
+      withWeekNumbers,
       monthFormat,
       orientation,
       transformValue,
@@ -131,6 +149,7 @@ export default class CalendarMonthGrid extends React.Component {
           isVisible={isVisible}
           enableOutsideDays={enableOutsideDays}
           modifiers={modifiers}
+          withWeekNumbers={withWeekNumbers}
           monthFormat={monthFormat}
           orientation={orientation}
           onDayMouseEnter={onDayMouseEnter}
@@ -156,7 +175,10 @@ export default class CalendarMonthGrid extends React.Component {
       <div
         ref={ref => { this.containerRef = ref; }}
         className={className}
-        style={getTransformStyles(transformValue)}
+        style={Object.assign(
+          getTransformStyles(transformValue),
+          getCalendarMonthGridWidthStyle(orientation, withWeekNumbers)
+        )}
         onTransitionEnd={onMonthTransitionEnd}
       >
         {months}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -10,7 +10,7 @@ import CalendarMonth from './CalendarMonth';
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 
-import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
+import getCalendarMonthGridWidthStyle from '../utils/getCalendarMonthGridWidthStyle';
 
 import OrientationShape from '../shapes/OrientationShape';
 
@@ -63,19 +63,6 @@ const defaultProps = {
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
 };
-
-function getCalendarMonthGridWidthStyle(orientation, withWeekNumbers) {
-  const calendarMonthWidth = getCalendarMonthWidth(withWeekNumbers);
-
-  switch (orientation) {
-    case HORIZONTAL_ORIENTATION:
-      return { width: 4 * calendarMonthWidth };
-    case VERTICAL_ORIENTATION:
-      return { width: calendarMonthWidth };
-    default:
-      return {};
-  }
-}
 
 export default class CalendarMonthGrid extends React.Component {
   constructor(props) {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -27,7 +27,7 @@ import {
   END_DATE,
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
-} from '../constants';
+} from '../../constants';
 
 const propTypes = DateRangePickerShape;
 

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -54,6 +54,7 @@ const defaultProps = {
   onNextMonthClick() {},
 
   // i18n
+  displayFormat: moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
@@ -196,6 +197,14 @@ export default class DateRangePicker extends React.Component {
     if (!this.props.disabled) {
       this.props.onFocusChange(START_DATE);
     }
+  }
+
+  getDateString(date) {
+    const { displayFormat } = this.props;
+    if (displayFormat) {
+      return date && date.format(displayFormat);
+    }
+    return toLocalizedDateString(date);
   }
 
   getDayPickerContainerClasses() {
@@ -384,8 +393,8 @@ export default class DateRangePicker extends React.Component {
       withFullScreenPortal,
     } = this.props;
 
-    const startDateString = toLocalizedDateString(startDate);
-    const endDateString = toLocalizedDateString(endDate);
+    const startDateString = this.getDateString(startDate);
+    const endDateString = this.getDateString(endDate);
 
     const onOutsideClick = !withPortal && !withFullScreenPortal ? this.onOutsideClick : () => {};
 

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -136,9 +136,9 @@ export default class DateRangePicker extends React.Component {
   }
 
   onEndDateChange(endDateString) {
-    const endDate = toMomentObject(endDateString);
+    const { startDate, isOutsideRange, onDatesChange, onFocusChange, displayFormat } = this.props;
+    const endDate = toMomentObject(endDateString, displayFormat);
 
-    const { startDate, isOutsideRange, onDatesChange, onFocusChange } = this.props;
     const isEndDateValid = endDate && !isOutsideRange(endDate) &&
       !isInclusivelyBeforeDay(endDate, startDate);
     if (isEndDateValid) {
@@ -173,7 +173,8 @@ export default class DateRangePicker extends React.Component {
   }
 
   onStartDateChange(startDateString) {
-    const startDate = toMomentObject(startDateString);
+    const { displayFormat } = this.props;
+    const startDate = toMomentObject(startDateString, displayFormat);
 
     let { endDate } = this.props;
     const { isOutsideRange, onDatesChange, onFocusChange } = this.props;
@@ -201,7 +202,7 @@ export default class DateRangePicker extends React.Component {
 
   getDateString(date) {
     const { displayFormat } = this.props;
-    if (displayFormat) {
+    if (date && displayFormat) {
       return date && date.format(displayFormat);
     }
     return toLocalizedDateString(date);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -43,6 +43,7 @@ const defaultProps = {
   numberOfMonths: 2,
   showClearDates: false,
   disabled: false,
+  reopenPickerOnClearDates: false,
 
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
@@ -233,8 +234,11 @@ export default class DateRangePicker extends React.Component {
   }
 
   clearDates() {
-    this.props.onDatesChange({ startDate: null, endDate: null });
-    this.props.onFocusChange(START_DATE);
+    const { onDatesChange, reopenPickerOnClearDates, onFocusChange } = this.props;
+    onDatesChange({ startDate: null, endDate: null });
+    if (reopenPickerOnClearDates) {
+      onFocusChange(START_DATE);
+    }
   }
 
   doesNotMeetMinimumNights(day) {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -48,6 +48,7 @@ const defaultProps = {
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
   withFullScreenPortal: false,
+  withWeekNumbers: false,
 
   onDatesChange() {},
   onFocusChange() {},
@@ -324,6 +325,7 @@ export default class DateRangePicker extends React.Component {
       onNextMonthClick,
       withPortal,
       withFullScreenPortal,
+      withWeekNumbers,
       enableOutsideDays,
     } = this.props;
 
@@ -365,6 +367,7 @@ export default class DateRangePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          withWeekNumbers={withWeekNumbers}
           onOutsideClick={onOutsideClick}
         />
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -5,7 +5,7 @@ import DateInput from './DateInput';
 import RightArrow from '../svg/arrow-right.svg';
 import CloseButton from '../svg/close.svg';
 
-import { START_DATE, END_DATE } from '../constants';
+import { START_DATE, END_DATE } from '../../constants';
 
 const propTypes = {
   startDateId: PropTypes.string,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -16,7 +16,7 @@ import getTransformStyles from '../utils/getTransformStyles';
 
 import OrientationShape from '../shapes/OrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const CALENDAR_MONTH_WIDTH = 300;
 const DAY_PICKER_PADDING = 9;

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -14,11 +14,12 @@ import ChevronDown from '../svg/chevron-down.svg';
 
 import getTransformStyles from '../utils/getTransformStyles';
 
+import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
+
 import OrientationShape from '../shapes/OrientationShape';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
-const CALENDAR_MONTH_WIDTH = 300;
 const DAY_PICKER_PADDING = 9;
 const MONTH_PADDING = 23;
 const PREV_TRANSITION = 'prev';
@@ -30,6 +31,7 @@ const propTypes = {
   modifiers: PropTypes.object,
   orientation: OrientationShape,
   withPortal: PropTypes.bool,
+  withWeekNumbers: PropTypes.bool,
   onDayClick: PropTypes.func,
   onDayMouseDown: PropTypes.func,
   onDayMouseUp: PropTypes.func,
@@ -52,6 +54,7 @@ const defaultProps = {
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
+  withWeekNumbers: false,
   onDayClick() {},
   onDayMouseDown() {},
   onDayMouseUp() {},
@@ -295,7 +298,7 @@ export default class DayPicker extends React.Component {
   }
 
   renderWeekHeader(index) {
-    const { numberOfMonths } = this.props;
+    const { numberOfMonths, withWeekNumbers } = this.props;
 
     const widthPercentage = 100 / numberOfMonths;
     const horizontalStyle = {
@@ -303,9 +306,16 @@ export default class DayPicker extends React.Component {
       left: `${widthPercentage * index}%`,
     };
 
-    const style = this.isHorizontal() ? horizontalStyle : {};
+    const style = this.isHorizontal() ? horizontalStyle : {
+      width: getCalendarMonthWidth(withWeekNumbers),
+    };
 
     const header = [];
+
+    if (withWeekNumbers) {
+      header.push(<li key={-1} />);
+    }
+
     for (let i = 0; i < 7; i++) {
       header.push(
         <li key={i}>
@@ -335,6 +345,7 @@ export default class DayPicker extends React.Component {
       orientation,
       modifiers,
       withPortal,
+      withWeekNumbers,
       onDayClick,
       onDayMouseDown,
       onDayMouseUp,
@@ -371,18 +382,20 @@ export default class DayPicker extends React.Component {
       'transition-container--vertical': this.isVertical(),
     });
 
-    const horizontalWidth = (CALENDAR_MONTH_WIDTH * numberOfMonths) + (2 * DAY_PICKER_PADDING);
+    const calendarMonthWidth = getCalendarMonthWidth(withWeekNumbers);
+
+    const horizontalWidth = ((calendarMonthWidth * numberOfMonths) + (2 * DAY_PICKER_PADDING));
 
     // this is a kind of made-up value that generally looks good. we'll
     // probably want to let the user set this explicitly.
-    const verticalHeight = 1.75 * CALENDAR_MONTH_WIDTH;
+    const verticalHeight = 1.75 * calendarMonthWidth;
 
     const dayPickerStyle = {
       width: this.isHorizontal() && horizontalWidth,
 
       // These values are to center the datepicker (approximately) on the page
       marginLeft: this.isHorizontal() && withPortal && -horizontalWidth / 2,
-      marginTop: this.isHorizontal() && withPortal && -CALENDAR_MONTH_WIDTH / 2,
+      marginTop: this.isHorizontal() && withPortal && -calendarMonthWidth / 2,
     };
 
     const transitionContainerStyle = {
@@ -418,6 +431,7 @@ export default class DayPicker extends React.Component {
               modifiers={modifiers}
               orientation={orientation}
               withPortal={withPortal}
+              withWeekNumbers={withWeekNumbers}
               numberOfMonths={numberOfMonths}
               onDayClick={onDayClick}
               onDayMouseDown={onDayMouseDown}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -67,9 +67,9 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onChange(dateString) {
-    const date = toMomentObject(dateString);
+    const { displayFormat, isOutsideRange, onDateChange, onFocusChange } = this.props;
+    const date = toMomentObject(dateString, displayFormat);
 
-    const { isOutsideRange, onDateChange, onFocusChange } = this.props;
     const isValid = date && !isOutsideRange(date);
     if (isValid) {
       onDateChange(date);
@@ -114,7 +114,7 @@ export default class SingleDatePicker extends React.Component {
 
   getDateString(date) {
     const { displayFormat } = this.props;
-    if (displayFormat) {
+    if (date && displayFormat) {
       return date && date.format(displayFormat);
     }
     return toLocalizedDateString(date);

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -18,7 +18,7 @@ import isSameDay from '../utils/isSameDay';
 
 import SingleDatePickerShape from '../shapes/SingleDatePickerShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 const propTypes = SingleDatePickerShape;
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -43,6 +43,7 @@ const defaultProps = {
   onNextMonthClick() {},
 
   // i18n
+  displayFormat: moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
@@ -109,6 +110,14 @@ export default class SingleDatePicker extends React.Component {
     if (!focused) return;
 
     onFocusChange({ focused: false });
+  }
+
+  getDateString(date) {
+    const { displayFormat } = this.props;
+    if (displayFormat) {
+      return date && date.format(displayFormat);
+    }
+    return toLocalizedDateString(date);
   }
 
   getDayPickerContainerClasses() {
@@ -227,7 +236,7 @@ export default class SingleDatePicker extends React.Component {
 
     const onOutsideClick = withPortal || withFullScreenPortal ? () => {} : this.onClearFocus;
 
-    const dateValue = toLocalizedDateString(date);
+    const dateString = this.getDateString(date);
 
     return (
       <div className="SingleDatePicker">
@@ -237,7 +246,7 @@ export default class SingleDatePicker extends React.Component {
             placeholder={placeholder}
             focused={focused}
             disabled={disabled}
-            dateValue={dateValue}
+            dateValue={dateString}
             onChange={this.onChange}
             onFocus={this.onFocus}
             onKeyDownShiftTab={this.onClearFocus}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -38,6 +38,7 @@ const defaultProps = {
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
   withFullScreenPortal: false,
+  withWeekNumbers: false,
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -176,6 +177,7 @@ export default class SingleDatePicker extends React.Component {
       onNextMonthClick,
       withPortal,
       withFullScreenPortal,
+      withWeekNumbers,
     } = this.props;
 
     const modifiers = {
@@ -204,6 +206,7 @@ export default class SingleDatePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          withWeekNumbers={withWeekNumbers}
           onOutsideClick={onOutsideClick}
         />
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,8 +1,0 @@
-export const DISPLAY_FORMAT = 'L';
-export const ISO_FORMAT = 'YYYY-MM-DD';
-
-export const START_DATE = 'startDate';
-export const END_DATE = 'endDate';
-
-export const HORIZONTAL_ORIENTATION = 'horizontal';
-export const VERTICAL_ORIENTATION = 'vertical';

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -12,6 +12,7 @@ export default {
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
+  reopenPickerOnClearDates: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   showClearDates: PropTypes.bool,
   disabled: PropTypes.bool,

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -23,6 +23,8 @@ export default {
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
 
+  withWeekNumbers: PropTypes.bool,
+
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
   endDateId: PropTypes.string,

--- a/src/shapes/FocusedInputShape.js
+++ b/src/shapes/FocusedInputShape.js
@@ -3,6 +3,6 @@ import { PropTypes } from 'react';
 import {
   START_DATE,
   END_DATE,
-} from '../constants';
+} from '../../constants';
 
 export default PropTypes.oneOf([START_DATE, END_DATE]);

--- a/src/shapes/OrientationShape.js
+++ b/src/shapes/OrientationShape.js
@@ -3,6 +3,6 @@ import { PropTypes } from 'react';
 import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
-} from '../constants';
+} from '../../constants';
 
 export default PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]);

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -23,6 +23,8 @@ export default {
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
 
+  withWeekNumbers: PropTypes.bool,
+
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 

--- a/src/utils/getCalendarMonthGridWidthStyle.js
+++ b/src/utils/getCalendarMonthGridWidthStyle.js
@@ -1,0 +1,16 @@
+import getCalendarMonthWidth from './getCalendarMonthWidth';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+
+export default function getCalendarMonthGridWidthStyle(orientation, withWeekNumbers) {
+  const calendarMonthWidth = getCalendarMonthWidth(withWeekNumbers);
+
+  switch (orientation) {
+    case HORIZONTAL_ORIENTATION:
+      return { width: 4 * calendarMonthWidth };
+    case VERTICAL_ORIENTATION:
+      return { width: calendarMonthWidth };
+    default:
+      return {};
+  }
+}
+

--- a/src/utils/getCalendarMonthWidth.js
+++ b/src/utils/getCalendarMonthWidth.js
@@ -1,0 +1,7 @@
+const CALENDAR_MONTH_WIDTH = 300;
+const WEEK_NUMBER_WIDTH = 38;
+
+export default function getCalendarMonthWidth(withWeekNumbers) {
+  return withWeekNumbers ?
+      CALENDAR_MONTH_WIDTH + WEEK_NUMBER_WIDTH : CALENDAR_MONTH_WIDTH;
+}

--- a/src/utils/getWeekNumberForWeek.js
+++ b/src/utils/getWeekNumberForWeek.js
@@ -1,0 +1,5 @@
+export default function getWeekNumberForWeek(week) {
+  const validDays = week.filter((d) => (d));
+
+  return validDays[0].week();
+}

--- a/src/utils/toISODateString.js
+++ b/src/utils/toISODateString.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { ISO_FORMAT } from '../constants';
+import { ISO_FORMAT } from '../../constants';
 
 export default function toLocalizedDateString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);

--- a/src/utils/toLocalizedDateString.js
+++ b/src/utils/toLocalizedDateString.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { DISPLAY_FORMAT } from '../constants';
+import { DISPLAY_FORMAT } from '../../constants';
 
 export default function toLocalizedDateString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);

--- a/src/utils/toMomentObject.js
+++ b/src/utils/toMomentObject.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { DISPLAY_FORMAT, ISO_FORMAT } from '../constants';
+import { DISPLAY_FORMAT, ISO_FORMAT } from '../../constants';
 
 export default function toMomentObject(dateString, customFormat) {
   if (customFormat) {

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@kadira/storybook';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -68,6 +68,11 @@ storiesOf('DateRangePicker', module)
       />
     );
   })
+  .add('with custom display format', () => (
+    <DateRangePickerWrapper
+      displayFormat="MMM D"
+    />
+  ))
   .add('with minimum nights set', () => (
     <DateRangePickerWrapper
       minimumNights={3}

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -53,6 +53,12 @@ storiesOf('DateRangePicker', module)
       showClearDates
     />
   ))
+  .add('with clear dates button (Picker Displayed)', () => (
+    <DateRangePickerWrapper
+      showClearDates
+      reopenPickerOnClearDates
+    />
+  ))
   .add('non-english locale', () => {
     moment.locale('zh-cn');
     return (

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -40,7 +40,9 @@ storiesOf('DateRangePicker', module)
     />
   ))
   .add('horizontal with fullscreen portal', () => (
-    <DateRangePickerWrapper withFullScreenPortal />
+    <DateRangePickerWrapper 
+      withFullScreenPortal 
+    />
   ))
   .add('vertical with full screen portal', () => (
     <DateRangePickerWrapper
@@ -106,5 +108,10 @@ storiesOf('DateRangePicker', module)
   .add('blocks fridays', () => (
     <DateRangePickerWrapper
       isDayBlocked={day => moment.weekdays(day.weekday()) === 'Friday'}
+    />
+  ))
+  .add('with week numbers', () => (
+    <DateRangePickerWrapper
+      withWeekNumbers
     />
   ));

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import DayPicker from '../src/components/DayPicker';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 storiesOf('DayPicker', module)
   .add('default', () => (

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -11,6 +11,12 @@ storiesOf('DayPicker', module)
   .add('more than one month', () => (
     <DayPicker numberOfMonths={2} />
   ))
+  .add('with week numbers', () => (
+    <DayPicker
+      numberOfMonths={2}
+      withWeekNumbers
+    />
+  ))
   .add('vertical', () => (
     <DayPicker
       numberOfMonths={2}
@@ -24,4 +30,11 @@ storiesOf('DayPicker', module)
         orientation={VERTICAL_ORIENTATION}
       />
     </div>
+  ))
+  .add('vertical with week numbers', () => (
+    <DayPicker
+      numberOfMonths={2}
+      orientation={VERTICAL_ORIENTATION}
+      withWeekNumbers
+    />
   ));

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -46,6 +46,11 @@ storiesOf('SingleDatePicker', module)
       />
     );
   })
+  .add('with custom display format', () => (
+    <SingleDatePickerWrapper
+      displayFormat="MMM D"
+    />
+  ))
   .add('with outside days enabled', () => (
     <SingleDatePickerWrapper
       numberOfMonths={1}

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@kadira/storybook';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION } from '../constants';
 
 storiesOf('SingleDatePicker', module)
   .add('default', () => (

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -56,4 +56,9 @@ storiesOf('SingleDatePicker', module)
       numberOfMonths={1}
       enableOutsideDays
     />
+  ))
+  .add('with week numbers', () => (
+    <SingleDatePickerWrapper
+      withWeekNumbers
+    />
   ));

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import CalendarMonth from '../../src/components/CalendarMonth';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 import getTransformStyles from '../../src/utils/getTransformStyles';
 

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 import CalendarMonth, { getModifiersForDay } from '../../src/components/CalendarMonth';
 
 describe('CalendarMonth', () => {

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
 import CalendarMonth, { getModifiersForDay } from '../../src/components/CalendarMonth';
 
 describe('CalendarMonth', () => {
@@ -91,6 +91,36 @@ describe('CalendarMonth', () => {
 
       const filteredModifiers = getModifiersForDay(modifiers, moment());
       expect(filteredModifiers).not.to.include(modifierKey);
+    });
+  });
+
+  describe('#getWeekNumberForWeek', () => {
+    it('returns null if week is not passed in', () => {
+      const weekNumber = getWeekNumberForWeek();
+      expect(weekNumber).to.equal(null);
+    });
+
+    it('returns null if empty week is passed in', () => {
+      const week = [];
+      const weekNumber = getWeekNumberForWeek(week);
+      expect(weekNumber).to.equal(null);
+    });
+
+    it('returns null if not valid week is passed in', () => {
+      const week = [false];
+      const weekNumber = getWeekNumberForWeek(week);
+      expect(weekNumber).to.equal(null);
+    });
+
+    it('returns right week number if not valid week is passed in', () => {
+      // week number is highly depend on local
+      // http://momentjs.com/docs/#/get-set/week/
+      moment.locale('en');
+
+      const day = moment('12-25-1995', 'MM-DD-YYYY');
+      const week = [false, false, false, day];
+      const weekNumber = getWeekNumberForWeek(week);
+      expect(weekNumber).to.equal(52);
     });
   });
 });

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -4,7 +4,10 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+
 import CalendarMonth, { getModifiersForDay } from '../../src/components/CalendarMonth';
+
+import getWeekNumberForWeek from '../../src/utils/getWeekNumberForWeek';
 
 describe('CalendarMonth', () => {
   describe('#render', () => {
@@ -95,23 +98,6 @@ describe('CalendarMonth', () => {
   });
 
   describe('#getWeekNumberForWeek', () => {
-    it('returns null if week is not passed in', () => {
-      const weekNumber = getWeekNumberForWeek();
-      expect(weekNumber).to.equal(null);
-    });
-
-    it('returns null if empty week is passed in', () => {
-      const week = [];
-      const weekNumber = getWeekNumberForWeek(week);
-      expect(weekNumber).to.equal(null);
-    });
-
-    it('returns null if not valid week is passed in', () => {
-      const week = [false];
-      const weekNumber = getWeekNumberForWeek(week);
-      expect(weekNumber).to.equal(null);
-    });
-
     it('returns right week number if not valid week is passed in', () => {
       // week number is highly depend on local
       // http://momentjs.com/docs/#/get-set/week/

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 import CalendarMonth, { getModifiersForDay } from '../../src/components/CalendarMonth';
 

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -19,7 +19,7 @@ import {
   VERTICAL_ORIENTATION,
   START_DATE,
   END_DATE,
-} from '../../src/constants';
+} from '../../constants';
 
 const today = moment().startOf('day');
 

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -400,6 +400,52 @@ describe('DateRangePicker', () => {
       });
     });
 
+    describe('matches custom display format', () => {
+      const customFormat = 'MM[foobar]DD';
+      const customFormatDateString = moment(today).add(5, 'days').format(customFormat);
+      it('calls props.onDatesChange with correct arguments', () => {
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            displayFormat={customFormat}
+            onDatesChange={onDatesChangeStub}
+          />
+        );
+        wrapper.instance().onEndDateChange(customFormatDateString);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+
+        const { startDate, endDate } = onDatesChangeStub.getCall(0).args[0];
+        expect(startDate).to.equal(wrapper.instance().props.startDate);
+        expect(endDate.format(customFormat)).to.equal(customFormatDateString);
+      });
+
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              displayFormat={customFormat}
+              onFocusChange={onFocusChangeStub}
+            />
+          );
+          wrapper.instance().onEndDateChange(customFormatDateString);
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
+
+        it('is called with null arg', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              displayFormat={customFormat}
+              onFocusChange={onFocusChangeStub}
+            />
+          );
+          wrapper.instance().onEndDateChange(customFormatDateString);
+          expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+        });
+      });
+    });
+
     describe('is not a valid date string', () => {
       const invalidDateString = 'foo';
       it('calls props.onDatesChange', () => {
@@ -641,6 +687,52 @@ describe('DateRangePicker', () => {
             wrapper.instance().onStartDateChange(validFutureDateString);
             expect(onFocusChangeStub.calledWith(END_DATE)).to.equal(true);
           });
+        });
+      });
+    });
+
+    describe('matches custom display format', () => {
+      const customFormat = 'MM[foobar]DD';
+      const customFormatDateString = moment(today).add(5, 'days').format(customFormat);
+      it('calls props.onDatesChange with correct arguments', () => {
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            displayFormat={customFormat}
+            onDatesChange={onDatesChangeStub}
+          />
+        );
+        wrapper.instance().onStartDateChange(customFormatDateString);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+
+        const { startDate, endDate } = onDatesChangeStub.getCall(0).args[0];
+        expect(startDate.format(customFormat)).to.equal(customFormatDateString);
+        expect(endDate).to.equal(wrapper.instance().props.endDate);
+      });
+
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              displayFormat={customFormat}
+              onFocusChange={onFocusChangeStub}
+            />
+          );
+          wrapper.instance().onStartDateChange(customFormatDateString);
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
+
+        it('is called with END_DATE arg', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              displayFormat={customFormat}
+              onFocusChange={onFocusChangeStub}
+            />
+          );
+          wrapper.instance().onStartDateChange(customFormatDateString);
+          expect(onFocusChangeStub.calledWith(END_DATE)).to.equal(true);
         });
       });
     });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -154,19 +154,40 @@ describe('DateRangePicker', () => {
   });
 
   describe('#clearDates', () => {
-    describe('props.onFocusChange', () => {
-      it('is called once', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
-        wrapper.instance().clearDates();
-        expect(onFocusChangeStub.callCount).to.equal(1);
-      });
+    describe('props.reopenPickerOnClearDates is truthy', () => {
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDates
+            />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
 
-      it('is called with arg START_DATE', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
-        wrapper.instance().clearDates();
-        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+        it('is called with arg START_DATE', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePicker
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDates
+            />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+        });
+      });
+    });
+
+    describe('props.reopenPickerOnClearDates is falsy', () => {
+      describe('props.onFocusChange', () => {
+        it('is not called', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(<DateRangePicker onFocusChange={onFocusChangeStub} />);
+          wrapper.instance().clearDates();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
       });
     });
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme';
 
 import DayPicker from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 describe('DayPicker', () => {
   describe('#render', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -176,6 +176,55 @@ describe('SingleDatePicker', () => {
       });
     });
 
+    describe('matches custom display format', () => {
+      const customFormat = 'MM[foobar]DD';
+      const customFormatDateString = moment().add(5, 'days').format(customFormat);
+      it('calls props.onDateChange once', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow(<SingleDatePicker
+          id="date"
+          displayFormat={customFormat}
+          onDateChange={onDateChangeStub}
+        />);
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onDateChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onDateChange with date as arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow(<SingleDatePicker
+          id="date"
+          displayFormat={customFormat}
+          onDateChange={onDateChangeStub}
+        />);
+        wrapper.instance().onChange(customFormatDateString);
+        const formattedFirstArg = onDateChangeStub.getCall(0).args[0].format(customFormat);
+        expect(formattedFirstArg).to.equal(customFormatDateString);
+      });
+
+      it('calls props.onFocusChange once', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(<SingleDatePicker
+          id="date"
+          displayFormat={customFormat}
+          onFocusChange={onFocusChangeStub}
+        />);
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onFocusChange with { focused: false } as arg', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(<SingleDatePicker
+          id="date"
+          displayFormat={customFormat}
+          onFocusChange={onFocusChangeStub}
+        />);
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
+      });
+    });
+
     describe('invalid date string', () => {
       const invalidDateString = 'foobar';
       it('calls props.onDateChange once', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon-sandbox';
 import moment from 'moment';
 import Portal from 'react-portal';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../src/constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
 import DayPicker from '../../src/components/DayPicker';
 import OutsideClickHandler from '../../src/components/OutsideClickHandler';


### PR DESCRIPTION
Adds week number in front of every week line in the first column.
It uses a new withWeekNumbers prop on every component, that toggles the
feature.
It supports both horizontal and vertical datepickers.
