### PR TITLE
Updated toMomentObject to take advantage of moment format array

### DIFF
--- a/src/utils/toMomentObject.js
+++ b/src/utils/toMomentObject.js
@@ -3,16 +3,10 @@ import moment from 'moment';
 import { DISPLAY_FORMAT, ISO_FORMAT } from '../../constants';
 
 export default function toMomentObject(dateString, customFormat) {
-  if (customFormat) {
-    const customFormatDate = moment(dateString, customFormat, true);
-    if (customFormatDate.isValid()) return customFormatDate;
-  }
+  const dateFormats = customFormat ?
+    [customFormat, DISPLAY_FORMAT, ISO_FORMAT] :
+    [DISPLAY_FORMAT, ISO_FORMAT];
 
-  const date = moment(dateString, DISPLAY_FORMAT, true);
-  if (date.isValid()) return date;
-
-  const isoDate = moment(dateString, ISO_FORMAT, true);
-  if (isoDate.isValid()) return isoDate;
-
-  return null;
+  const date = moment(dateString, dateFormats, true);
+  return date.isValid() ? date : null;
 }


### PR DESCRIPTION
Moment can take an array of formats as outlined in
http://momentjs.com/docs/#/parsing/special-formats/

Using this makes the toMomentObject util easier to understand as it
reduces if return statements within the method.

All tests still pass with the refactor