### PR TITLE
Fixes issues with displayFormat prop's default values by using a thunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+ - [new] Allow `displayFormat` prop to take a function as well as a string ([#98](https://github.com/airbnb/react-dates/pull/98))
+ - [fix] Default value for `displayFormat` now actually returns moment's `L` format based on the locale ([#98](https://github.com/airbnb/react-dates/pull/98)))
+
 ## v3.0.0
  - [breaking] Move the constants file to the top-level ([#53](https://github.com/airbnb/react-dates/pull/53))
  - [breaking] Add `reopenPickerOnClearDates` prop so that the DateRangePicker no longer automatically reopens when clearing dates ([#75](https://github.com/airbnb/react-dates/pull/75))

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ If you need to do something when the user navigates between months (for instance
 
 While we have reasonable defaults for english, we understand that that's not the only language in the world! :) At Airbnb, more than 50% of users visit our site in a language other than english. Thus, in addition to supporting moment locales, the `DateRangePicker` accepts a number of props to allow for this.
 
+The `displayFormat` prop is either a string that abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) or a function that returns a string that follows these rules. It defaults to the value of moment's `L` format in whatever locale you happen to be in at the time of render.
+```
+  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+```
+
 The `monthFormat` prop abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) and indicates the format in which to display dates at the top of each calendar. It defaults to `MMMM YYYY`.
 ```
   monthFormat: PropTypes.string,
@@ -287,6 +292,11 @@ If you need to do something when the user navigates between months (for instance
 ```
 
 **Internationalization:**
+
+The `displayFormat` prop is either a string that abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) or a function that returns a string that follows these rules. It defaults to the value of moment's `L` format in whatever locale you happen to be in at the time of render.
+```
+  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+```
 
 The `monthFormat` prop abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) and indicates the format in which to display dates at the top of each calendar. It defaults to `MMMM YYYY`.
 ```

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -55,7 +55,7 @@ const defaultProps = {
   onNextMonthClick() {},
 
   // i18n
-  displayFormat: moment.localeData().longDateFormat('L'),
+  displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
@@ -137,8 +137,9 @@ export default class DateRangePicker extends React.Component {
   }
 
   onEndDateChange(endDateString) {
-    const { startDate, isOutsideRange, onDatesChange, onFocusChange, displayFormat } = this.props;
-    const endDate = toMomentObject(endDateString, displayFormat);
+    const { startDate, isOutsideRange, onDatesChange, onFocusChange } = this.props;
+
+    const endDate = toMomentObject(endDateString, this.getDisplayFormat());
 
     const isEndDateValid = endDate && !isOutsideRange(endDate) &&
       !isInclusivelyBeforeDay(endDate, startDate);
@@ -174,8 +175,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   onStartDateChange(startDateString) {
-    const { displayFormat } = this.props;
-    const startDate = toMomentObject(startDateString, displayFormat);
+    const startDate = toMomentObject(startDateString, this.getDisplayFormat());
 
     let { endDate } = this.props;
     const { isOutsideRange, onDatesChange, onFocusChange } = this.props;
@@ -202,7 +202,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   getDateString(date) {
-    const { displayFormat } = this.props;
+    const displayFormat = this.getDisplayFormat();
     if (date && displayFormat) {
       return date && date.format(displayFormat);
     }
@@ -231,6 +231,11 @@ export default class DateRangePicker extends React.Component {
 
   getDayPickerDOMNode() {
     return ReactDOM.findDOMNode(this.dayPicker);
+  }
+
+  getDisplayFormat() {
+    const { displayFormat } = this.props;
+    return typeof displayFormat === 'string' ? displayFormat : displayFormat();
   }
 
   clearDates() {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -43,7 +43,7 @@ const defaultProps = {
   onNextMonthClick() {},
 
   // i18n
-  displayFormat: moment.localeData().longDateFormat('L'),
+  displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
@@ -67,8 +67,8 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onChange(dateString) {
-    const { displayFormat, isOutsideRange, onDateChange, onFocusChange } = this.props;
-    const date = toMomentObject(dateString, displayFormat);
+    const { isOutsideRange, onDateChange, onFocusChange } = this.props;
+    const date = toMomentObject(dateString, this.getDisplayFormat());
 
     const isValid = date && !isOutsideRange(date);
     if (isValid) {
@@ -113,7 +113,7 @@ export default class SingleDatePicker extends React.Component {
   }
 
   getDateString(date) {
-    const { displayFormat } = this.props;
+    const displayFormat = this.getDisplayFormat();
     if (date && displayFormat) {
       return date && date.format(displayFormat);
     }
@@ -135,6 +135,11 @@ export default class SingleDatePicker extends React.Component {
     });
 
     return dayPickerClassName;
+  }
+
+  getDisplayFormat() {
+    const { displayFormat } = this.props;
+    return typeof displayFormat === 'string' ? displayFormat : displayFormat();
   }
 
   isBlocked(day) {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -34,6 +34,7 @@ export default {
   onNextMonthClick: PropTypes.func,
 
   // i18n
+  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape({
     closeDatePicker: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -27,6 +27,7 @@ export default {
   onNextMonthClick: PropTypes.func,
 
   // i18n
+  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape({
     closeDatePicker: PropTypes.node,


### PR DESCRIPTION
to: @ljharb 

When attempting to bump the version of `react-dates` used on Airbnb, we noticed that the display format for the `DateRangePicker` and `SingleDatePicker` components was often returning nonsense because moment's locale was not yet set. Similarly, live right now on the storybook, you can see that the format doesn't work at all for the non-english locale example. This fixes this issue.