### PR TITLE
Modifies all dates in the calendar to have their time set to noon

### DIFF
--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -1,8 +1,8 @@
 export default function getCalendarMonthWeeks(month, enableOutsideDays) {
   // set utc offset to get correct dates in future (when timezone changes)
-  const baseDate = month.clone().utcOffset(month.utcOffset());
-  const firstOfMonth = baseDate.clone().startOf('month');
-  const lastOfMonth = baseDate.clone().endOf('month');
+  const baseDate = month.clone();
+  const firstOfMonth = baseDate.clone().startOf('month').hour(12);
+  const lastOfMonth = baseDate.clone().endOf('month').hour(12);
 
   const currentDay = firstOfMonth.clone();
   let currentWeek = [];

--- a/src/utils/toMomentObject.js
+++ b/src/utils/toMomentObject.js
@@ -8,5 +8,5 @@ export default function toMomentObject(dateString, customFormat) {
     [DISPLAY_FORMAT, ISO_FORMAT];
 
   const date = moment(dateString, dateFormats, true);
-  return date.isValid() ? date : null;
+  return date.isValid() ? date.hour(12) : null;
 }

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -12,6 +12,7 @@ import DayPicker from '../../src/components/DayPicker';
 
 import OutsideClickHandler from '../../src/components/OutsideClickHandler';
 
+import isSameDay from '../../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../../src/utils/isInclusivelyAfterDay';
 
 import {
@@ -417,7 +418,7 @@ describe('DateRangePicker', () => {
 
         const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
         expect(onDatesChangeArgs.startDate).to.equal(wrapper.props().startDate);
-        expect(onDatesChangeArgs.endDate.isSame(validFutureDateString)).to.equal(true);
+        expect(isSameDay(onDatesChangeArgs.endDate, moment(validFutureDateString))).to.equal(true);
       });
 
       describe('props.onFocusChange', () => {
@@ -651,7 +652,8 @@ describe('DateRangePicker', () => {
           expect(onDatesChangeStub.callCount).to.equal(1);
 
           const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
-          expect(onDatesChangeArgs.startDate.isSame(validFutureDateString)).to.equal(true);
+          const futureDate = moment(validFutureDateString);
+          expect(isSameDay(onDatesChangeArgs.startDate, futureDate)).to.equal(true);
           expect(onDatesChangeArgs.endDate).to.equal(endDate);
         });
 
@@ -696,7 +698,8 @@ describe('DateRangePicker', () => {
           expect(onDatesChangeStub.callCount).to.equal(1);
 
           const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
-          expect(onDatesChangeArgs.startDate.isSame(validFutureDateString)).to.equal(true);
+          const futureDate = moment(validFutureDateString);
+          expect(isSameDay(onDatesChangeArgs.startDate, futureDate)).to.equal(true);
           expect(onDatesChangeArgs.endDate).to.equal(null);
         });
 

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -17,6 +17,8 @@ import OutsideClickHandler from '../../src/components/OutsideClickHandler';
 import SingleDatePickerInput from '../../src/components/SingleDatePickerInput';
 import SingleDatePicker from '../../src/components/SingleDatePicker';
 
+import isSameDay from '../../src/utils/isSameDay';
+
 describe('SingleDatePicker', () => {
   describe('#render', () => {
     it('is .SingleDatePicker class', () => {
@@ -177,7 +179,8 @@ describe('SingleDatePicker', () => {
         const onDateChangeStub = sinon.stub();
         const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
         wrapper.instance().onChange(futureDateString);
-        expect(onDateChangeStub.getCall(0).args[0].isSame(futureDateString)).to.equal(true);
+        const newDate = onDateChangeStub.getCall(0).args[0];
+        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
       });
 
       it('calls props.onFocusChange once', () => {

--- a/test/utils/getCalendarMonthWeeks_spec.js
+++ b/test/utils/getCalendarMonthWeeks_spec.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
+import isSameDay from '../../src/utils/isSameDay';
 import getCalendarMonthWeeks from '../../src/utils/getCalendarMonthWeeks';
 
 const today = moment();
@@ -25,6 +26,40 @@ describe('getCalendarMonthWeeks', () => {
     });
 
     expect(isIncluded).to.equal(true);
+  });
+
+  it('all days have a time of 12PM', () => {
+    weeks.forEach((week) => {
+      week.forEach((day) => {
+        if (day) {
+          expect(day.hours()).to.equal(12);
+        }
+      });
+    });
+  });
+
+  describe('Daylight Savings Time issues', () => {
+    it('last of February does not equal first of March', () => {
+      const february = getCalendarMonthWeeks(today.clone().month(1));
+      const lastWeekOfFebruary = february[february.length - 1].filter(Boolean);
+      const lastOfFebruary = lastWeekOfFebruary[lastWeekOfFebruary.length - 1];
+
+      const march = getCalendarMonthWeeks(today.clone().month(2));
+      const firstOfMarch = march[0].filter(Boolean)[0];
+
+      expect(isSameDay(lastOfFebruary, firstOfMarch)).to.equal(false);
+    });
+
+    it('last of March does not equal first of April', () => {
+      const march = getCalendarMonthWeeks(today.clone().month(2));
+      const lastWeekOfMarch = march[march.length - 1].filter(Boolean);
+      const lastOfMarch = lastWeekOfMarch[lastWeekOfMarch.length - 1];
+
+      const april = getCalendarMonthWeeks(today.clone().month(3));
+      const firstOfApril = april[0].filter(Boolean)[0];
+
+      expect(isSameDay(lastOfMarch, firstOfApril)).to.equal(false);
+    });
   });
 
   describe('enableOutsideDays arg is false', () => {

--- a/test/utils/toMomentObject_spec.js
+++ b/test/utils/toMomentObject_spec.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
+import isSameDay from '../../src/utils/isSameDay';
 import toMomentObject from '../../src/utils/toMomentObject';
 
 describe('toMomentObject', () => {
@@ -20,6 +21,10 @@ describe('toMomentObject', () => {
     expect(toMomentObject()).to.equal(null);
   });
 
+  it('output has time of 12PM', () => {
+    expect(toMomentObject('1991-07-13').hour()).to.equal(12);
+  });
+
   it('parses custom format', () => {
     const date = toMomentObject('1991---13/07', 'YYYY---DD/MM');
 
@@ -27,6 +32,16 @@ describe('toMomentObject', () => {
     expect(date.month()).to.equal(6); // moment months are zero-indexed
     expect(date.date()).to.equal(13);
     expect(date.year()).to.equal(1991);
+  });
+
+  describe('Daylight Savings Time issues', () => {
+    it('last of February does not equal first of March', () => {
+      expect(isSameDay(toMomentObject('2017-02-28'), toMomentObject('2017-03-01'))).to.equal(false);
+    });
+
+    it('last of March does not equal first of April', () => {
+      expect(isSameDay(toMomentObject('2017-03-31'), toMomentObject('2017-04-01'))).to.equal(false);
+    });
   });
 
   describe('Catalan locale', () => {


### PR DESCRIPTION
This is a fix for https://github.com/airbnb/react-dates/issues/110

I also double-checked this change in the Brazilian time zone and noted that there is no reoccurrence of the DST bug that caused there to be an extra day in the month of October. It might be good to double-check Australia as well.

I'm not like incredibly happy about this, but it seems to work. :|

to: @timReynolds @ljharb 
FYI: @airbnb/webinfra @wmartins 