### PR TITLE
refactor: remove array-includes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "webpack": "^1.13.2"
   },
   "dependencies": {
-    "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "react-moment-proptypes": "^1.2.0",
     "react-portal": "^2.2.1"

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
-import includes from 'array-includes';
 
 import isTouchDevice from '../utils/isTouchDevice';
 import toMomentObject from '../utils/toMomentObject';
@@ -95,7 +94,7 @@ export default class DateRangePicker extends React.Component {
 
   onDayClick(day, modifiers, e) {
     if (e) e.preventDefault();
-    if (includes(modifiers, 'blocked')) return;
+    if (~modifiers.indexOf('blocked')) return;
 
     const { focusedInput } = this.props;
     let { startDate, endDate } = this.props;

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
-import includes from 'array-includes';
 
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
@@ -89,7 +88,7 @@ export default class SingleDatePicker extends React.Component {
 
   onDayClick(day, modifiers, e) {
     if (e) e.preventDefault();
-    if (includes(modifiers, 'blocked')) return;
+    if (~modifiers.indexOf('blocked')) return;
 
     this.props.onDateChange(day);
     this.props.onFocusChange({ focused: null });


### PR DESCRIPTION
I saw no need for the array-includes dependency if you can fallback to a simple `indexOf`

Notice: The builds fails currently because of something else