### PR TITLE
Attaches DayPicker caret to inputs instead of the picker component

### DIFF
--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -14,6 +14,28 @@
   vertical-align: middle;
 }
 
+.DateInput--focused::before,
+.DateInput--focused::after {
+  content: "";
+  display: inline-block;
+  position: absolute;
+  top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-arrow / 2;
+  bottom: auto;
+  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
+  border-top: 0;
+  z-index: 2;
+}
+
+.DateInput--focused::before {
+  left: 22px;
+  border-bottom-color: rgba(0, 0, 0, 0.1);
+}
+
+.DateInput--focused::after {
+  left: 23px;
+  border-bottom-color: $react-dates-color-white;
+}
+
 .DateInput--disabled {
   background: $react-dates-color-gray-lighter;
 }

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -20,15 +20,7 @@
   background-color: $react-dates-color-white;
   z-index: 1;
   position: absolute;
-  top: 145%;
-
-  &::before,
-  &::after {
-    content: "";
-    display: inline-block;
-    position: absolute;
-    bottom: auto;
-  }
+  top: $react-dates-spacing-vertical-picker;
 }
 
 .DateRangePicker__picker--direction-left {
@@ -58,50 +50,6 @@
 
 .DateRangePicker__picker--full-screen-portal {
   background-color: $react-dates-color-white;
-}
-
-.DateRangePicker__picker--start::before,
-.DateRangePicker__picker--end::before {
-  top: -$react-dates-width-tooltip-arrow / 2;
-  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
-  border-top: 0;
-  border-bottom-color: rgba(0, 0, 0, 0.1);
-}
-
-.DateRangePicker__picker--direction-left.DateRangePicker__picker--start::before {
-  left: 22px;
-}
-.DateRangePicker__picker--direction-right.DateRangePicker__picker--start::before {
-    right: $react-dates-width-input + $react-dates-width-arrow + 22px;
-}
-
-.DateRangePicker__picker--direction-left.DateRangePicker__picker--end::before {
-  left: $react-dates-width-arrow + $react-dates-width-input + 22px;
-}
-.DateRangePicker__picker--direction-right.DateRangePicker__picker--end::before {
-  right: 22px;
-}
-
-.DateRangePicker__picker--start::after,
-.DateRangePicker__picker--end::after {
-  top: -$react-dates-width-tooltip-arrow / 2;
-  border: $react-dates-width-tooltip-arrow / 2 solid transparent;
-  border-top: 0;
-  border-bottom-color: $react-dates-color-white;
-}
-
-.DateRangePicker__picker--direction-left.DateRangePicker__picker--start::after {
-  left: 23px;
-}
-.DateRangePicker__picker--direction-right.DateRangePicker__picker--start::after {
-    right: $react-dates-width-input + $react-dates-width-arrow + 23px;
-}
-
-.DateRangePicker__picker--direction-left.DateRangePicker__picker--end::after {
-    left: $react-dates-width-arrow + $react-dates-width-input + 23px;
-}
-.DateRangePicker__picker--direction-right.DateRangePicker__picker--end::after {
-    right: 23px;
 }
 
 .DateRangePicker__close {

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -2,6 +2,7 @@ $react-dates-width-input: 130px !default;
 $react-dates-width-arrow: 24px !default;
 $react-dates-width-tooltip-arrow: 20px !default;
 $react-dates-width-day-picker: 300px !default;
+$react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;
 $react-dates-color-primary-dark: #00514a !default;

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -93,6 +93,7 @@ export default class DateInput extends React.Component {
     return (
       <div
         className={cx('DateInput', {
+          'DateInput--focused': focused,
           'DateInput--disabled': disabled,
         })}
         onClick={onFocus}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -229,8 +229,6 @@ export default class DateRangePicker extends React.Component {
       'DateRangePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
       'DateRangePicker__picker--show': showDatepicker,
       'DateRangePicker__picker--invisible': !showDatepicker,
-      'DateRangePicker__picker--start': focusedInput === START_DATE,
-      'DateRangePicker__picker--end': focusedInput === END_DATE,
       'DateRangePicker__picker--horizontal': orientation === HORIZONTAL_ORIENTATION,
       'DateRangePicker__picker--vertical': orientation === VERTICAL_ORIENTATION,
       'DateRangePicker__picker--portal': withPortal || withFullScreenPortal,

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -157,16 +157,6 @@ describe('DateRangePicker', () => {
         const wrapper = shallow(<DateRangePicker focusedInput={null} />);
         expect(wrapper.find('.DateRangePicker__picker--invisible')).to.have.length(1);
       });
-
-      it('has .DateRangePicker-picker--start class if props.focusedInput=START_DATE', () => {
-        const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
-        expect(wrapper.find('.DateRangePicker__picker--start')).to.have.length(1);
-      });
-
-      it('has .DateRangePicker-picker--end class if props.focusedInput=END_DATE', () => {
-        const wrapper = shallow(<DateRangePicker focusedInput={END_DATE} />);
-        expect(wrapper.find('.DateRangePicker__picker--end')).to.have.length(1);
-      });
     });
   });
 


### PR DESCRIPTION
So I've been thinking about this problem specifically for https://github.com/airbnb/react-dates/pull/83, and after @travisbloom introduced `anchorDirection` in (https://github.com/airbnb/react-dates/pull/72, it became pretty clear that we were doing a lot of grossness to make carets consistently align. Combine this with the fact that we have to override caret styles at Airbnb for medium breakpoints, and the point is that I was getting annoying.

While it makes some sense to attach the caret to the `DateRangePicker__picker`, I think it actually makes more sense for placement to attach them to the inputs. 

to: @airbnb/webinfra 