### PR TITLE
Allows selecting the end date first for unattached vertically oriented datepickers

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -159,10 +159,10 @@ export default class DateRangePicker extends React.Component {
   }
 
   onEndDateFocus() {
-    const { startDate, onFocusChange, orientation, disabled } = this.props;
+    const { startDate, onFocusChange, withFullScreenPortal, disabled } = this.props;
 
-    if (!startDate && orientation === VERTICAL_ORIENTATION && !disabled) {
-      // Since the vertical datepicker is full screen, we never want to focus the end date first
+    if (!startDate && withFullScreenPortal && !disabled) {
+      // When the datepicker is full screen, we never want to focus the end date first
       // because there's no indication that that is the case once the datepicker is open and it
       // might confuse the user
       onFocusChange(START_DATE);

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -894,12 +894,12 @@ describe('DateRangePicker', () => {
       });
     });
 
-    describe('props.orientation = VERTICAL_ORIENTATION', () => {
+    describe('props.withFullScreenPortal is truthy', () => {
       it('calls props.onFocusChange once with arg START_DATE', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
           <DateRangePicker
-            orientation={VERTICAL_ORIENTATION}
+            withFullScreenPortal
             onFocusChange={onFocusChangeStub}
           />
         );


### PR DESCRIPTION
This was behavior from back when we assume the vertical orientation would only ever be used on mobile devices and with a portal. This fixes the assumption.

to: @airbnb/webinfra 
