### PR TITLE
Hides the TetherComponent appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## Unreleased
+ - [fix] Allows for elements to be interacted with when rendered beneath the tether component ([]())
+
 ## v3.3.2
  - [fix] Responsive the `DateRangePicker` and `SingleDatePicker` components ([#80](https://github.com/airbnb/react-dates/pull/83))
 

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -16,6 +16,14 @@
   display: inline-block;
 }
 
+.DateRangePicker__tether--show {
+  visibility: visible;
+}
+
+.DateRangePicker__tether--invisible {
+  visibility: hidden;
+}
+
 .DateRangePicker__picker {
   z-index: 1;
 }
@@ -26,14 +34,6 @@
 
 .DateRangePicker__picker--direction-right {
     right: 0;
-}
-
-.DateRangePicker__picker--show {
-  visibility: visible;
-}
-
-.DateRangePicker__picker--invisible {
-  visibility: hidden;
 }
 
 .DateRangePicker__picker--portal {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -218,20 +218,16 @@ export default class DateRangePicker extends React.Component {
 
   getDayPickerContainerClasses() {
     const {
-      focusedInput,
       orientation,
       withPortal,
       withFullScreenPortal,
       anchorDirection,
     } = this.props;
     const { hoverDate } = this.state;
-    const showDatepicker = focusedInput === START_DATE || focusedInput === END_DATE;
 
     const dayPickerClassName = cx('DateRangePicker__picker', {
       'DateRangePicker__picker--direction-left': anchorDirection === ANCHOR_LEFT,
       'DateRangePicker__picker--direction-right': anchorDirection === ANCHOR_RIGHT,
-      'DateRangePicker__picker--show': showDatepicker,
-      'DateRangePicker__picker--invisible': !showDatepicker,
       'DateRangePicker__picker--horizontal': orientation === HORIZONTAL_ORIENTATION,
       'DateRangePicker__picker--vertical': orientation === VERTICAL_ORIENTATION,
       'DateRangePicker__picker--portal': withPortal || withFullScreenPortal,
@@ -424,11 +420,17 @@ export default class DateRangePicker extends React.Component {
     const startDateString = this.getDateString(startDate);
     const endDateString = this.getDateString(endDate);
 
+    const showDatepicker = focusedInput === START_DATE || focusedInput === END_DATE;
     const tetherPinDirection = anchorDirection === ANCHOR_LEFT ? ANCHOR_RIGHT : ANCHOR_LEFT;
 
     return (
       <div className="DateRangePicker">
         <TetherComponent
+          classPrefix="DateRangePicker__tether"
+          className={cx({
+            'DateRangePicker__tether--show': showDatepicker,
+            'DateRangePicker__tether--invisible': !showDatepicker,
+          })}
           attachment={`top ${anchorDirection}`}
           targetAttachment={`bottom ${anchorDirection}`}
           offset="-23px 0"

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -20,9 +20,33 @@ const datesList = [
   moment().add(13, 'days'),
 ];
 
+const TestInput = props => (
+  <div style={{ marginTop: 16 }} >
+    <input
+      {...props}
+      type="text"
+      style={{
+        height: 48,
+        width: 284,
+        fontSize: 18,
+        fontWeight: 200,
+        padding: '12px 16px',
+      }}
+    />
+  </div>
+);
+
 storiesOf('DateRangePicker', module)
   .add('default', () => (
     <DateRangePickerWrapper />
+  ))
+  .add('as part of a form', () => (
+    <div>
+      <DateRangePickerWrapper />
+      <TestInput placeholder="Input 1" />
+      <TestInput placeholder="Input 2" />
+      <TestInput placeholder="Input 3" />
+    </div>
   ))
   .add('single month', () => (
     <DateRangePickerWrapper

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -149,12 +149,12 @@ describe('DateRangePicker', () => {
     describe('props.focusedInput', () => {
       it('shows datepicker if props.focusedInput != null', () => {
         const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
-        expect(wrapper.find('.DateRangePicker__picker--show')).to.have.length(1);
+        expect(wrapper.find('.DateRangePicker__tether--show')).to.have.length(1);
       });
 
       it('hides datepicker if props.focusedInput = null', () => {
         const wrapper = shallow(<DateRangePicker focusedInput={null} />);
-        expect(wrapper.find('.DateRangePicker__picker--invisible')).to.have.length(1);
+        expect(wrapper.find('.DateRangePicker__tether--invisible')).to.have.length(1);
       });
     });
   });


### PR DESCRIPTION
FIx for https://github.com/airbnb/react-dates/issues/125

Ooops, while the `DateRangePicker__picker--show` and `DateRangePicker__picker--invisible` do the right thing, when they are wrapped in a top-level div without these restrictions, they actually prevent point-events on anything rendered beneath them. This is... pretty bad. 

This fixes the problem by applying the show/hide logic directly to the `TetherComponent`. I also updated the tests and added a story to make sure you can interact with other form elements rendered beneath the datepicker.

to: @airbnb/webinfra @ingro @zeroasterisk @tvanro 