### PR TITLE
Show Clear Date for SingleDatePicker

### DIFF
--- a/css/SingleDatePickerInput.scss
+++ b/css/SingleDatePickerInput.scss
@@ -1,5 +1,38 @@
 @import 'variables';
 
 .SingleDatePickerInput {
+  background-color: $react-dates-color-white;
   border: 1px solid $react-dates-color-border;
+}
+
+.SingleDatePickerInput__clear-date {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+
+  cursor: pointer;
+  display: inline-block;
+  vertical-align: middle;
+  padding: 10px;
+  margin: 0 10px 0 5px;
+}
+
+.SingleDatePickerInput__clear-date svg {
+  fill: $react-dates-color-gray-light;
+  height: 12px;
+  width: 15px;
+  vertical-align: middle;
+}
+
+.SingleDatePickerInput__clear-date--hide {
+  visibility: hidden;
+}
+
+.SingleDatePickerInput__clear-date:focus,
+.SingleDatePickerInput__clear-date--hover {
+  background: $react-dates-color-border;
+  border-radius: 50%;
 }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -32,6 +32,8 @@ const defaultProps = {
   focused: false,
   disabled: false,
   required: false,
+  showClearDate: false,
+  reopenPickerOnClearDate: false,
 
   onDateChange() {},
   onFocusChange() {},
@@ -56,6 +58,7 @@ const defaultProps = {
   monthFormat: 'MMMM YYYY',
   phrases: {
     closeDatePicker: 'Close',
+    clearDate: 'Clear Date',
   },
 };
 
@@ -73,6 +76,7 @@ export default class SingleDatePicker extends React.Component {
     this.onChange = this.onChange.bind(this);
     this.onFocus = this.onFocus.bind(this);
     this.onClearFocus = this.onClearFocus.bind(this);
+    this.clearDate = this.clearDate.bind(this);
   }
 
   onChange(dateString) {
@@ -149,6 +153,14 @@ export default class SingleDatePicker extends React.Component {
   getDisplayFormat() {
     const { displayFormat } = this.props;
     return typeof displayFormat === 'string' ? displayFormat : displayFormat();
+  }
+
+  clearDate() {
+    const { onDateChange, reopenPickerOnClearDate, onFocusChange } = this.props;
+    onDateChange(null);
+    if (reopenPickerOnClearDate) {
+      onFocusChange({ focused: true });
+    }
   }
 
   isBlocked(day) {
@@ -248,7 +260,9 @@ export default class SingleDatePicker extends React.Component {
       focused,
       disabled,
       required,
+      showClearDate,
       date,
+      phrases,
       anchorDirection,
       withPortal,
       withFullScreenPortal,
@@ -281,6 +295,9 @@ export default class SingleDatePicker extends React.Component {
             disabled={disabled}
             required={required}
             showCaret={!withPortal && !withFullScreenPortal}
+            phrases={phrases}
+            onClearDate={this.clearDate}
+            showClearDate={showClearDate}
             dateValue={dateString}
             onChange={this.onChange}
             onFocus={this.onFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react';
+import cx from 'classnames';
 
 import DateInput from './DateInput';
+import CloseButton from '../svg/close.svg';
 
 const propTypes = {
   id: PropTypes.string.isRequired,
@@ -11,11 +13,18 @@ const propTypes = {
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   showCaret: PropTypes.bool,
+  showClearDate: PropTypes.bool,
 
   onChange: PropTypes.func,
+  onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
+
+  // i18n
+  phrases: PropTypes.shape({
+    clearDate: PropTypes.node,
+  }),
 };
 
 const defaultProps = {
@@ -31,41 +40,92 @@ const defaultProps = {
   onFocus() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
+
+  // i18n
+  phrases: {
+    clearDate: 'Clear Date',
+  },
 };
 
-export default function SingleDatePickerInput(props) {
-  const {
-    id,
-    placeholder,
-    dateValue,
-    focused,
-    disabled,
-    required,
-    showCaret,
-    onChange,
-    onFocus,
-    onKeyDownShiftTab,
-    onKeyDownTab,
-  } = props;
+export default class SingleDatePickerInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isClearDateHovered: false,
+    };
 
-  return (
-    <div className="SingleDatePickerInput">
-      <DateInput
-        id={id}
-        placeholder={placeholder} // also used as label
-        dateValue={dateValue}
-        focused={focused}
-        disabled={disabled}
-        required={required}
-        showCaret={showCaret}
+    this.onClearDateMouseEnter = this.onClearDateMouseEnter.bind(this);
+    this.onClearDateMouseLeave = this.onClearDateMouseLeave.bind(this);
+  }
 
-        onChange={onChange}
-        onFocus={onFocus}
-        onKeyDownShiftTab={onKeyDownShiftTab}
-        onKeyDownTab={onKeyDownTab}
-      />
-    </div>
-  );
+  onClearDateMouseEnter() {
+    this.setState({
+      isClearDateHovered: true,
+    });
+  }
+
+  onClearDateMouseLeave() {
+    this.setState({
+      isClearDateHovered: false,
+    });
+  }
+
+  render() {
+    const { isClearDateHovered } = this.state;
+    const {
+      id,
+      placeholder,
+      dateValue,
+      focused,
+      disabled,
+      required,
+      showCaret,
+      showClearDate,
+      phrases,
+      onClearDate,
+      onChange,
+      onFocus,
+      onKeyDownShiftTab,
+      onKeyDownTab,
+    } = this.props;
+
+    return (
+      <div className="SingleDatePickerInput">
+        <DateInput
+          id={id}
+          placeholder={placeholder} // also used as label
+          dateValue={dateValue}
+          focused={focused}
+          disabled={disabled}
+          required={required}
+          showCaret={showCaret}
+
+          onChange={onChange}
+          onFocus={onFocus}
+          onKeyDownShiftTab={onKeyDownShiftTab}
+          onKeyDownTab={onKeyDownTab}
+        />
+
+        {showClearDate &&
+          <button
+            type="button"
+            className={cx('SingleDatePickerInput__clear-date', {
+              'SingleDatePickerInput__clear-date--hide': !dateValue,
+              'SingleDatePickerInput__clear-date--hover': isClearDateHovered,
+            })}
+            onMouseEnter={this.onClearDateMouseEnter}
+            onMouseLeave={this.onClearDateMouseLeave}
+            onClick={onClearDate}
+          >
+            <span className="screen-reader-only">
+              {phrases.clearDate}
+            </span>
+            <CloseButton />
+          </button>
+        }
+      </div>
+    );
+  }
 }
 
 SingleDatePickerInput.propTypes = propTypes;

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -9,6 +9,8 @@ export default {
   placeholder: PropTypes.string,
   date: momentPropTypes.momentObj,
   focused: PropTypes.bool,
+  showClearDate: PropTypes.bool,
+  reopenPickerOnClearDates: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
 

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -65,6 +65,17 @@ storiesOf('SingleDatePicker', module)
       withFullScreenPortal
     />
   ))
+  .add('with clear dates button', () => (
+    <SingleDatePickerWrapper
+      showClearDate
+    />
+  ))
+  .add('with clear dates button (Picker Displayed)', () => (
+    <SingleDatePickerWrapper
+      showClearDate
+      reopenPickerOnClearDate
+    />
+  ))
   .add('with month specified on open', () => (
     <SingleDatePickerWrapper
       initialVisibleMonth={() => moment('01 2017', 'MM YYYY')}

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon-sandbox';
 
 import SingleDatePickerInput from '../../src/components/SingleDatePickerInput';
 
@@ -9,6 +10,117 @@ describe('SingleDatePickerInput', () => {
     it('is .SingleDatePickerInput class', () => {
       const wrapper = shallow(<SingleDatePickerInput id="date" />);
       expect(wrapper.is('.SingleDatePickerInput')).to.equal(true);
+    });
+  });
+
+  describe('clear date', () => {
+    describe('props.showClearDate is falsey', () => {
+      it('does not have .SingleDatePickerInput__clear-date class', () => {
+        const wrapper = shallow(<SingleDatePickerInput showClearDate={false} />);
+        expect(wrapper.find('.SingleDatePickerInput__clear-date')).to.have.lengthOf(0);
+      });
+    });
+
+    describe('props.showClearDate is truthy', () => {
+      it('has .SingleDatePickerInput__clear-date class', () => {
+        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        expect(wrapper.find('.SingleDatePickerInput__clear-date')).to.have.lengthOf(1);
+      });
+
+      it('has .SingleDatePickerInput__clear-date--hover class if state.isClearDateHovered',
+        () => {
+          const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+          wrapper.setState({ isClearDateHovered: true });
+          expect(wrapper.find('.SingleDatePickerInput__clear-date--hover')).to.have.lengthOf(1);
+        });
+
+      it('no .SingleDatePickerInput__clear-date--hover class if !state.isClearDateHovered',
+        () => {
+          const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+          wrapper.setState({ isClearDateHovered: false });
+          expect(wrapper.find('.SingleDatePickerInput__clear-date--hover')).to.have.lengthOf(0);
+        });
+
+      it('has .SingleDatePickerInput__clear-date--hide class if there is no date',
+        () => {
+          const wrapper = shallow(
+            <SingleDatePickerInput showClearDate dateValue={null} />
+          );
+          expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(1);
+        });
+
+      it('does not have .SingleDatePickerInput__clear-date--hide class if there is a date',
+        () => {
+          const wrapper = shallow(
+            <SingleDatePickerInput showClearDate dateValue="2016-07-13" />
+          );
+          expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
+        });
+    });
+  });
+
+  describe('#onClearDateMouseEnter', () => {
+    it('sets state.isClearDateHovered to true', () => {
+      const wrapper = shallow(<SingleDatePickerInput />);
+      wrapper.setState({ isClearDateHovered: false });
+      wrapper.instance().onClearDateMouseEnter();
+      expect(wrapper.state().isClearDateHovered).to.equal(true);
+    });
+  });
+
+  describe('#onClearDateMouseLeave', () => {
+    it('sets state.isClearDateHovered to false', () => {
+      const wrapper = shallow(<SingleDatePickerInput />);
+      wrapper.setState({ isClearDateHovered: true });
+      wrapper.instance().onClearDateMouseLeave();
+      expect(wrapper.state().isClearDateHovered).to.equal(false);
+    });
+  });
+
+  describe('clear date interactions', () => {
+    describe('onClick', () => {
+      it('props.onClearDate gets triggered', () => {
+        const onClearDateSpy = sinon.spy();
+        const wrapper = shallow(
+          <SingleDatePickerInput
+            onClearDate={onClearDateSpy}
+            showClearDate
+          />
+        );
+        const clearDateWrapper = wrapper.find('.SingleDatePickerInput__clear-date');
+        clearDateWrapper.simulate('click');
+        expect(onClearDateSpy.called).to.equal(true);
+      });
+    });
+
+    describe('onMouseEnter', () => {
+      it('onClearDateMouseEnter gets triggered', () => {
+        const onClearDateMouseEnterSpy = sinon.spy(
+          SingleDatePickerInput.prototype,
+          'onClearDateMouseEnter'
+        );
+        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        const clearDateWrapper = wrapper.find('.SingleDatePickerInput__clear-date');
+
+        clearDateWrapper.simulate('mouseEnter');
+
+        expect(onClearDateMouseEnterSpy.called).to.equal(true);
+      });
+    });
+
+    describe('onMouseLeave', () => {
+      it('onClearDateMouseLeave gets triggered', () => {
+        const onClearDateMouseLeaveSpy = sinon.spy(
+          SingleDatePickerInput.prototype,
+          'onClearDateMouseLeave'
+        );
+        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        const clearDateWrapper = wrapper.find('.SingleDatePickerInput__clear-date');
+
+        clearDateWrapper.simulate('mouseLeave');
+
+        expect(onClearDateMouseLeaveSpy.called).to.equal(true);
+      });
     });
   });
 });

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -427,6 +427,41 @@ describe('SingleDatePicker', () => {
     });
   });
 
+  describe('#clearDate', () => {
+    describe('props.reopenPickerOnClearDate is truthy', () => {
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <SingleDatePicker
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDate
+            />);
+          wrapper.instance().clearDate();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
+      });
+    });
+
+    describe('props.reopenPickerOnClearDate is falsy', () => {
+      describe('props.onFocusChange', () => {
+        it('is not called', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow(<SingleDatePicker onFocusChange={onFocusChangeStub} />);
+          wrapper.instance().clearDate();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
+      });
+    });
+
+    it('calls props.onDateChange with null date', () => {
+      const onDateChangeStub = sinon.stub();
+      const wrapper = shallow(<SingleDatePicker onDateChange={onDateChangeStub} />);
+      wrapper.instance().clearDate();
+      expect(onDateChangeStub.callCount).to.equal(1);
+    });
+  });
+
   describe('#isBlocked', () => {
     afterEach(() => {
       sinon.restore();


### PR DESCRIPTION
fixes #141 

This PR adds in the ability to specify `showClearDates` for the `SingleDatePicker` which is `showClearDates` from `DateRangePicker`. The main goal here is obviously to create a button which allows the user to clear the date value inside of the `SingleDatePicker`.

The way I set this up should be mostly identical to `DateRangePicker`, really the only major thing I changes was changing the usage of the word "dates" to: "date" as it just seems to "fit better" :tm: . Needless to say the functionality of the button itself, as well as the reopen on clear feature should be completely identical. Just clearing the single date, instead of multiple dates.
