### PR TITLE
force correct text-align on calendar

### DIFF
--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -3,6 +3,7 @@ $react-dates-width-day-picker: 300px;
 .CalendarMonthGrid {
   background: #fff;
   z-index: 0;
+  text-align: initial;
 }
 
 .CalendarMonthGrid--animating {


### PR DESCRIPTION
If DatePicker is placed in div with a different text-align, for example text-align:center, css class inheritance from parent will break the calendar month picker & make dates invisible. This fixes the problem.