### PR TITLE
Fixes DayPicker height issue on open

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -108,8 +108,8 @@ export default class DayPicker extends React.Component {
     return shallowCompare(this, nextProps, nextState);
   }
 
-  componentDidUpdate() {
-    if (this.state.monthTransition) {
+  componentDidUpdate(prevProps, prevState) {
+    if (this.state.monthTransition || !this.state.currentMonth.isSame(prevState.currentMonth)) {
       if (this.isHorizontal()) {
         this.adjustDayPickerHeight();
       }

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -149,7 +149,7 @@ storiesOf('DateRangePicker', module)
   ))
   .add('with month specified on open', () => (
     <DateRangePickerWrapper
-      initialVisibleMonth={() => moment('01 2017', 'MM YYYY')}
+      initialVisibleMonth={() => moment('04 2017', 'MM YYYY')}
     />
   ))
   .add('blocks fridays', () => (


### PR DESCRIPTION
When the initialVisibleMonth has a different height than the current month, the DayPicker does not adjust immediately. I noticed this in prod on airbnb.com. Whoops!

to: @airbnb/webinfra 