### PR TITLE
Add bottomPanel and portalMarginTop props

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ The `anchorDirection` prop indicates whether the calendar is anchored to the rig
   withFullScreenPortal: PropTypes.bool
 ```
 
+The `bottomPanel` prop accepts a React element that will be displayed below `DayPicker`.
+```
+  bottomPanel: PropTypes.element
+```
+
+The `portalMarginTop` prop sets the space between `DateRangePickerInput` and the `DayPicker` popout.
+```
+  portalMarginTop: PropTypes.number
+```
+
 **Input presentation:**
 
 The `startDateId` and `endDateId` props are assigned to the actual `<input>` DOM elements for accessibility reasons. They default to the values of the `START_DATE` and `END_DATE` constants.

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -50,11 +50,13 @@ const defaultProps = {
   initialVisibleMonth: () => moment(),
   navPrev: null,
   navNext: null,
+  portalMarginTop: 23,
 
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   withPortal: false,
   withFullScreenPortal: false,
+  bottomPanel: null,
 
   onDatesChange() {},
   onFocusChange() {},
@@ -346,6 +348,7 @@ export default class DateRangePicker extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      bottomPanel,
     } = this.props;
 
     const modifiers = {
@@ -405,6 +408,8 @@ export default class DateRangePicker extends React.Component {
             <CloseButton />
           </button>
         }
+
+        {bottomPanel}
       </div>
     );
   }
@@ -423,6 +428,7 @@ export default class DateRangePicker extends React.Component {
       anchorDirection,
       withPortal,
       withFullScreenPortal,
+      portalMarginTop,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -441,7 +447,7 @@ export default class DateRangePicker extends React.Component {
           })}
           attachment={`top ${anchorDirection}`}
           targetAttachment={`bottom ${anchorDirection}`}
-          offset="-23px 0"
+          offset={`-${portalMarginTop}px 0`}
           constraints={[{
             to: 'scrollParent',
             attachment: 'none',

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -24,6 +24,8 @@ export default {
   // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  bottomPanel: PropTypes.element,
+  portalMarginTop: PropTypes.number,
 
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -31,6 +31,7 @@ export default {
   // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  portalMarginTop: PropTypes.number,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -109,6 +109,23 @@ storiesOf('DateRangePicker', module)
       withFullScreenPortal
     />
   ))
+  .add('horizontal with bottom panel', () => (
+    <DateRangePickerWrapper
+      bottomPanel={
+        <div style={{
+          backgroundColor: 'white',
+          width: '100%',
+          padding: '0.5em',
+          textAlign: 'center',
+        }}>
+          This is the bottom panel
+        </div>
+      }
+    />
+  ))
+  .add('with custom space between input and portal DayPicker', () => (
+    <DateRangePickerWrapper portalMarginTop={0} />
+  ))
   .add('with clear dates button', () => (
     <DateRangePickerWrapper
       showClearDates

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -146,6 +146,24 @@ describe('DateRangePicker', () => {
       });
     });
 
+    describe('props.bottomPanel', () => {
+      it('renders a custom bottomPanel', () => {
+        const wrapper = shallow(
+          <DateRangePicker bottomPanel={<div className="bottomPanel" />} />
+        );
+        expect(wrapper.find('.bottomPanel')).to.have.length(1);
+      });
+    });
+
+    describe('props.portalMarginTop', () => {
+      it('renders a custom bottomPanel', () => {
+        const wrapper = shallow(
+          <DateRangePicker bottomPanel={<div className="bottomPanel" />} />
+        );
+        expect(wrapper.find('.bottomPanel')).to.have.length(1);
+      });
+    });
+
     describe('props.focusedInput', () => {
       it('shows datepicker if props.focusedInput != null', () => {
         const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);


### PR DESCRIPTION
to: @majapw 

Adds `bottomPanel` property for adding elements below `DayPicker` and `portalMarginTop` for tweaking space between input and portal/daypicker.