### PR TITLE
Add bottom panel prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ The `anchorDirection` prop indicates whether the calendar is anchored to the rig
   withFullScreenPortal: PropTypes.bool
 ```
 
+The `bottomPanel` prop accepts a React element that will be displayed below `DayPicker`.
+```
+  bottomPanel: PropTypes.element
+```
+
 **Input presentation:**
 
 The `startDateId` and `endDateId` props are assigned to the actual `<input>` DOM elements for accessibility reasons. They default to the values of the `START_DATE` and `END_DATE` constants.

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -57,6 +57,7 @@ const defaultProps = {
   horizontalMargin: 0,
   withPortal: false,
   withFullScreenPortal: false,
+  bottomPanel: null,
 
   onDatesChange() {},
   onFocusChange() {},
@@ -390,6 +391,7 @@ export default class DateRangePicker extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      bottomPanel,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -453,6 +455,12 @@ export default class DateRangePicker extends React.Component {
             </span>
             <CloseButton />
           </button>
+        }
+
+        {bottomPanel &&
+          <div className="DateRangePicker__bottom-panel">
+            {bottomPanel}
+          </div>
         }
       </div>
     );

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -26,6 +26,7 @@ export default {
   // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  bottomPanel: PropTypes.element,
 
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -109,6 +109,20 @@ storiesOf('DateRangePicker', module)
       withFullScreenPortal
     />
   ))
+  .add('horizontal with bottom panel', () => (
+    <DateRangePickerWrapper
+      bottomPanel={
+        <div style={{
+          backgroundColor: 'white',
+          width: '100%',
+          padding: '0.5em',
+          textAlign: 'center',
+        }}>
+          This is the bottom panel
+        </div>
+      }
+    />
+  ))
   .add('with clear dates button', () => (
     <DateRangePickerWrapper
       showClearDates

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -140,6 +140,15 @@ describe('DateRangePicker', () => {
       });
     });
 
+    describe('props.bottomPanel', () => {
+      it('renders a custom bottomPanel', () => {
+        const wrapper = shallow(
+          <DateRangePicker bottomPanel={<div className="bottomPanel" />} />
+        );
+        expect(wrapper.find('.bottomPanel')).to.have.length(1);
+      });
+    });
+
     describe('props.focusedInput', () => {
       it('shows datepicker if props.focusedInput != null', () => {
         const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);


### PR DESCRIPTION
to: @majapw 

Adds `bottomPanel` prop addressing [comments from previous PR](https://github.com/airbnb/react-dates/pull/162#discussion_r86472391). With the new tether changes, I no longer need the margin top property.