### PR TITLE
Add minimum date option to SingleDatePicker 

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -44,8 +44,8 @@ const defaultProps = {
 
   isDayBlocked: () => false,
   disabledDays: [],
-  minDate: moment(),
-  isOutsideRange: (day, minDate) => !isInclusivelyAfterDay(day, minDate),
+  minimumDate: moment(),
+  isOutsideRange: (day, minimumDate) => !isInclusivelyAfterDay(day, minimumDate),
   enableOutsideDays: false,
   numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
@@ -104,11 +104,11 @@ export default class SingleDatePicker extends React.Component {
       keepOpenOnDateSelect,
       onDateChange,
       onFocusChange,
-      minDate,
+      minimumDate,
     } = this.props;
     const date = toMomentObject(dateString, this.getDisplayFormat());
 
-    const isValid = date && !isOutsideRange(date, minDate);
+    const isValid = date && !isOutsideRange(date, minimumDate);
     if (isValid) {
       onDateChange(date);
       if (!keepOpenOnDateSelect) onFocusChange({ focused: false });
@@ -212,8 +212,8 @@ export default class SingleDatePicker extends React.Component {
   }
 
   isBlocked(day) {
-    const { isDayBlocked, isOutsideRange, minDate } = this.props;
-    return isDayBlocked(day) || isOutsideRange(day, minDate);
+    const { isDayBlocked, isOutsideRange, minimumDate } = this.props;
+    return isDayBlocked(day) || isOutsideRange(day, minimumDate);
   }
 
   isHovered(day) {
@@ -254,14 +254,14 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
-      minDate,
+      minimumDate,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
     const modifiers = {
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
-      'blocked-out-of-range': day => isOutsideRange(day, minDate),
+      'blocked-out-of-range': day => isOutsideRange(day, minimumDate),
       valid: day => !this.isBlocked(day),
       hovered: day => this.isHovered(day),
       selected: day => this.isSelected(day),

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -44,8 +44,8 @@ const defaultProps = {
 
   isDayBlocked: () => false,
   disabledDays: [],
-  startDate: null,
-  isOutsideRange: (day, startDate) => !isInclusivelyAfterDay(day, startDate || moment()),
+  minDate: moment(),
+  isOutsideRange: (day, minDate) => !isInclusivelyAfterDay(day, minDate),
   enableOutsideDays: false,
   numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
@@ -99,10 +99,16 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onChange(dateString) {
-    const { isOutsideRange, keepOpenOnDateSelect, onDateChange, onFocusChange, startDate } = this.props;
+    const {
+      isOutsideRange,
+      keepOpenOnDateSelect,
+      onDateChange,
+      onFocusChange,
+      minDate,
+    } = this.props;
     const date = toMomentObject(dateString, this.getDisplayFormat());
 
-    const isValid = date && !isOutsideRange(date, startDate);
+    const isValid = date && !isOutsideRange(date, minDate);
     if (isValid) {
       onDateChange(date);
       if (!keepOpenOnDateSelect) onFocusChange({ focused: false });
@@ -206,8 +212,8 @@ export default class SingleDatePicker extends React.Component {
   }
 
   isBlocked(day) {
-    const { isDayBlocked, isOutsideRange, startDate } = this.props;
-    return isDayBlocked(day) || isOutsideRange(day, startDate);
+    const { isDayBlocked, isOutsideRange, minDate } = this.props;
+    return isDayBlocked(day) || isOutsideRange(day, minDate);
   }
 
   isHovered(day) {
@@ -248,14 +254,14 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
-      startDate
+      minDate,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
     const modifiers = {
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
-      'blocked-out-of-range': day => isOutsideRange(day, startDate),
+      'blocked-out-of-range': day => isOutsideRange(day, minDate),
       valid: day => !this.isBlocked(day),
       hovered: day => this.isHovered(day),
       selected: day => this.isSelected(day),

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -44,7 +44,8 @@ const defaultProps = {
 
   isDayBlocked: () => false,
   disabledDays: [],
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  startDate: null,
+  isOutsideRange: (day, startDate) => !isInclusivelyAfterDay(day, startDate || moment()),
   enableOutsideDays: false,
   numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
@@ -98,10 +99,10 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onChange(dateString) {
-    const { isOutsideRange, keepOpenOnDateSelect, onDateChange, onFocusChange } = this.props;
+    const { isOutsideRange, keepOpenOnDateSelect, onDateChange, onFocusChange, startDate } = this.props;
     const date = toMomentObject(dateString, this.getDisplayFormat());
 
-    const isValid = date && !isOutsideRange(date);
+    const isValid = date && !isOutsideRange(date, startDate);
     if (isValid) {
       onDateChange(date);
       if (!keepOpenOnDateSelect) onFocusChange({ focused: false });
@@ -205,8 +206,8 @@ export default class SingleDatePicker extends React.Component {
   }
 
   isBlocked(day) {
-    const { isDayBlocked, isOutsideRange } = this.props;
-    return isDayBlocked(day) || isOutsideRange(day);
+    const { isDayBlocked, isOutsideRange, startDate } = this.props;
+    return isDayBlocked(day) || isOutsideRange(day, startDate);
   }
 
   isHovered(day) {
@@ -247,13 +248,14 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
+      startDate
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
     const modifiers = {
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
-      'blocked-out-of-range': day => isOutsideRange(day),
+      'blocked-out-of-range': day => isOutsideRange(day, startDate),
       valid: day => !this.isBlocked(day),
       hovered: day => this.isHovered(day),
       selected: day => this.isSelected(day),

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -139,6 +139,6 @@ storiesOf('SingleDatePicker', module)
   ))
   .add('with minimum date specified', () => (
     <SingleDatePickerWrapper
-      minDate={moment().add(1, 'week')}
+      minimumDate={moment().add(1, 'week')}
     />
   ));

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -136,4 +136,9 @@ storiesOf('SingleDatePicker', module)
       numberOfMonths={1}
       enableOutsideDays
     />
+  ))
+  .add('with minimum date specified', () => (
+    <SingleDatePickerWrapper
+      minDate={moment().add(1, 'week')}
+    />
   ));


### PR DESCRIPTION
Hi guys,
I couldn't set a specific start date to `<SingleDatePicker />` and then I realized [I was not the only one](https://github.com/airbnb/react-dates/issues/156), so I basically added a `minDate` prop that allows you to set a range of available dates starting from the minimum date provided.

It could be pretty useful in case you have to handle departure / return fields using SingleDatePicker instead of DateRangePicker.