### PR TITLE
removes check if initial month was set before

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -76,7 +76,6 @@ export default class DayPicker extends React.Component {
   constructor(props) {
     super(props);
 
-    this.hasSetInitialVisibleMonth = !props.hidden;
     this.state = {
       currentMonth: props.hidden ? moment() : props.initialVisibleMonth(),
       monthTransition: null,
@@ -96,8 +95,7 @@ export default class DayPicker extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.hasSetInitialVisibleMonth && !nextProps.hidden) {
-      this.hasSetInitialVisibleMonth = true;
+    if (!nextProps.hidden) {
       this.setState({
         currentMonth: nextProps.initialVisibleMonth(),
       });


### PR DESCRIPTION
Fixes the issue on not being able to update current month more then once. https://github.com/airbnb/react-dates/issues/175