### PR TITLE
Remove invokation of responsivizePickerPosition from componentDidMount

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -290,8 +290,8 @@ export default class DateRangePicker extends React.Component {
     if (!withPortal && !withFullScreenPortal) {
       const containerRect = this.dayPickerContainer.getBoundingClientRect();
       const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
-      const containerEdge = isAnchoredLeft ? containerRect[ANCHOR_RIGHT] :
-        containerRect[ANCHOR_LEFT];
+      const containerEdge =
+        isAnchoredLeft ? containerRect[ANCHOR_RIGHT] : containerRect[ANCHOR_LEFT];
 
       this.setState({
         dayPickerContainerStyles: getResponsiveContainerStyles(

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -283,23 +283,25 @@ export default class DateRangePicker extends React.Component {
   }
 
   responsivizePickerPosition() {
-    const { anchorDirection, horizontalMargin } = this.props;
+    const { anchorDirection, horizontalMargin, withPortal, withFullScreenPortal } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
     const isAnchoredLeft = anchorDirection === ANCHOR_LEFT;
+    if (!withPortal && !withFullScreenPortal) {
+      const containerRect = this.dayPickerContainer.getBoundingClientRect();
+      const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
+      const containerEdge = isAnchoredLeft ? containerRect[ANCHOR_RIGHT] :
+        containerRect[ANCHOR_LEFT];
 
-    const containerRect = this.dayPickerContainer.getBoundingClientRect();
-    const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
-    const containerEdge = isAnchoredLeft ? containerRect[ANCHOR_RIGHT] : containerRect[ANCHOR_LEFT];
-
-    this.setState({
-      dayPickerContainerStyles: getResponsiveContainerStyles(
-        anchorDirection,
-        currentOffset,
-        containerEdge,
-        horizontalMargin
-      ),
-    });
+      this.setState({
+        dayPickerContainerStyles: getResponsiveContainerStyles(
+          anchorDirection,
+          currentOffset,
+          containerEdge,
+          horizontalMargin
+        ),
+      });
+    }
   }
 
   doesNotMeetMinimumNights(day) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -88,8 +88,11 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentDidMount() {
+    const { withPortal, withFullScreenPortal } = this.props;
     window.addEventListener('resize', this.responsivizePickerPosition);
-    this.responsivizePickerPosition();
+    if (!withPortal && !withFullScreenPortal) {
+      this.responsivizePickerPosition();
+    }
   }
 
   /* istanbul ignore next */

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -88,11 +88,8 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentDidMount() {
-    const { withPortal, withFullScreenPortal } = this.props;
     window.addEventListener('resize', this.responsivizePickerPosition);
-    if (!withPortal && !withFullScreenPortal) {
-      this.responsivizePickerPosition();
-    }
+    this.responsivizePickerPosition();
   }
 
   /* istanbul ignore next */
@@ -188,23 +185,26 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   responsivizePickerPosition() {
-    const { anchorDirection, horizontalMargin } = this.props;
+    const { anchorDirection, horizontalMargin, withPortal, withFullScreenPortal } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
     const isAnchoredLeft = anchorDirection === ANCHOR_LEFT;
 
-    const containerRect = this.dayPickerContainer.getBoundingClientRect();
-    const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
-    const containerEdge = isAnchoredLeft ? containerRect[ANCHOR_RIGHT] : containerRect[ANCHOR_LEFT];
+    if (!withPortal && !withFullScreenPortal) {
+      const containerRect = this.dayPickerContainer.getBoundingClientRect();
+      const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
+      const containerEdge =
+        isAnchoredLeft ? containerRect[ANCHOR_RIGHT] : containerRect[ANCHOR_LEFT];
 
-    this.setState({
-      dayPickerContainerStyles: getResponsiveContainerStyles(
-        anchorDirection,
-        currentOffset,
-        containerEdge,
-        horizontalMargin
-      ),
-    });
+      this.setState({
+        dayPickerContainerStyles: getResponsiveContainerStyles(
+          anchorDirection,
+          currentOffset,
+          containerEdge,
+          horizontalMargin
+        ),
+      });
+    }
   }
 
   isBlocked(day) {


### PR DESCRIPTION
This addressed the issue #181 on the storyboard, but should the method responsivizePickerPosition be invoked from an other method?