### PR TITLE
Update `react-portal` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "react-moment-proptypes": "^1.2.0",
-    "react-portal": "^2.2.1"
+    "react-portal": "^3.0.0"
   },
   "peerDependencies": {
     "moment": "2.10 - 2.14 || ^2.15.1",


### PR DESCRIPTION
`react-portal` v2 was relying on private React APIs and was broken with React v15.4.0.

It just simplified a few things in v3 and there's no breaking change for `react-dates`.