### PR TITLE
Adjusts DayPicker height and initializes width when DayPicker is about to be shown

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -96,16 +96,22 @@ export default class DayPicker extends React.Component {
   componentDidMount() {
     if (this.isHorizontal()) {
       this.adjustDayPickerHeight();
-      this.initializeDayPickerWidth();
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.hasSetInitialVisibleMonth && !nextProps.hidden) {
-      this.hasSetInitialVisibleMonth = true;
-      this.setState({
-        currentMonth: nextProps.initialVisibleMonth(),
-      });
+    if (!nextProps.hidden) {
+      if (!this.hasSetInitialVisibleMonth) {
+        this.hasSetInitialVisibleMonth = true;
+        this.setState({
+          currentMonth: nextProps.initialVisibleMonth(),
+        });
+      }
+
+      if (!this.dayPickerWidth && this.isHorizontal()) {
+        this.initializeDayPickerWidth();
+        this.adjustDayPickerHeight();
+      }
     }
   }
 

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -21,7 +21,7 @@ const datesList = [
 ];
 
 const TestInput = props => (
-  <div style={{ marginTop: 16 }} >
+  <div style={{ marginTop: 16 }}>
     <input
       {...props}
       type="text"
@@ -35,32 +35,67 @@ const TestInput = props => (
     />
   </div>
 );
-const TestPrevIcon = props => (
-  <span style={{
+
+const TestPrevIcon = () => (
+  <span
+    style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
-      padding: '3px'
+      padding: '3px',
     }}
   >
     Prev
   </span>
 );
-const TestNextIcon = props => (
-  <span style={{
-    border: '1px solid #dce0e0',
-    backgroundColor: '#fff',
-    color: '#484848',
-    padding: '3px'
+
+const TestNextIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
     }}
   >
     Next
   </span>
 );
 
+class TestWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      showDatePicker: false,
+    };
+  }
+
+  render() {
+    const { showDatePicker } = this.state;
+    const display = showDatePicker ? 'block' : 'none';
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() => this.setState({ showDatePicker: !showDatePicker })}
+        >
+          Show me!
+        </button>
+
+        <div style={{ display }}>
+          <DateRangePickerWrapper />
+        </div>
+      </div>
+    );
+  }
+}
+
 storiesOf('DateRangePicker', module)
   .addWithInfo('default', () => (
     <DateRangePickerWrapper />
+  ))
+  .addWithInfo('hidden with display: none', () => (
+    <TestWrapper />
   ))
   .addWithInfo('as part of a form', () => (
     <div>
@@ -161,7 +196,7 @@ storiesOf('DateRangePicker', module)
   ))
   .addWithInfo('allows all days', () => (
     <DateRangePickerWrapper
-      isOutsideRange={day => false}
+      isOutsideRange={() => false}
     />
   ))
   .addWithInfo('allows next two weeks only', () => (


### PR DESCRIPTION
This should hopefully fix https://github.com/airbnb/react-dates/issues/177 and also https://github.com/airbnb/react-dates/issues/105 and https://github.com/airbnb/react-dates/issues/46. Lol. Lots of dupes.

The idea is that while we use `visibility: hidden` in place of `display: none` when hiding the `DayPicker` so we can measure it properly, we can't actually guarantee that some parent isn't hiding the whole thing using `display: none` (in some modal implementations, for instance). This alleviates the issue somewhat by doing these DOM calculations right before we show the `DayPicker` (which can only happen when you click on or focus on a visible `DateRangePicker` component).

@subicura does this fix your issue?

Please take a look @airbnb/webinfra!