### PR TITLE
Wait for mouseup event (not mousedown) to trigger selection on the calendar.

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -199,7 +199,7 @@ export default class DateRangePicker extends React.Component {
           numberOfMonths={numberOfMonths}
           onDayMouseEnter={this.onDayMouseEnter}
           onDayMouseLeave={this.onDayMouseLeave}
-          onDayMouseDown={this.onDayClick}
+          onDayMouseUp={this.onDayClick}
           onDayTouchTap={this.onDayClick}
           onPrevMonthClick={onPrevMonthClick}
           onNextMonthClick={onNextMonthClick}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -270,7 +270,7 @@ export default class DayPickerRangeController extends React.Component {
         numberOfMonths={numberOfMonths}
         onDayMouseEnter={this.onDayMouseEnter}
         onDayMouseLeave={this.onDayMouseLeave}
-        onDayMouseDown={this.onDayClick}
+        onDayMouseUp={this.onDayClick}
         onDayTouchTap={this.onDayClick}
         onPrevMonthClick={onPrevMonthClick}
         onNextMonthClick={onNextMonthClick}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -277,7 +277,7 @@ export default class SingleDatePicker extends React.Component {
           numberOfMonths={numberOfMonths}
           onDayMouseEnter={this.onDayMouseEnter}
           onDayMouseLeave={this.onDayMouseLeave}
-          onDayMouseDown={this.onDayClick}
+          onDayMouseUp={this.onDayClick}
           onDayTouchTap={this.onDayClick}
           onPrevMonthClick={onPrevMonthClick}
           onNextMonthClick={onNextMonthClick}


### PR DESCRIPTION
Hello! Unsolicited diff here.  I'll make an issue first if you'd prefer :)

The calendar currently listens for a `mousedown` event in order to trigger the selection of a date.   This of course works just fine, but it is against the common UX of most buttons -- the user should be able to "back out" of the action by dragging their cursor away from the target element while still moused down.  If the user releases the mouse while outside of the button, then the button's action isn't fired.

This pr resolves this by listening instead to `mouseup` to trigger the date selection.

One thing to note is that the calendar itself will close if the user clicks a day, then drags all the way outside the calendar, and then releases the mouse (and does not select day).  I believe this is the proper behavior from a ux perspective, but I wanted to mention it since it is changed behavior from master.

As a side note, I've run into several UI issues with the library and have decided not to use it in production.  I haven't been able to reproduce these issues in isolation (clean slate app rendering just the calendar), but I'll update if I'm able to. It was just too much of a hassle tracking down the issues in my own app, which is fairly simple...