### PR TITLE
fix width when more than two months

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -41,16 +41,20 @@
 
   li {
     display: inline-block;
-    width: 39px;
+    width: 40px;
     text-align: center;
   }
 }
 
 .DayPicker--horizontal .DayPicker__week-header {
-  padding: 0 22px 0 13px;
+  padding: 0 22px 0 9px;
 
   &:first-of-type {
-    padding: 0 13px 0 22px;
+    padding: 0 13px 0 16px;
+  }
+
+  &:last-of-type {
+    padding: 0 13px 0 9px;
   }
 }
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -314,7 +314,7 @@ export default class DayPicker extends React.Component {
 
     const widthPercentage = 100 / numberOfMonths;
     const horizontalStyle = {
-      width: `${widthPercentage}%`,
+      width: `${widthPercentage + 1}%`,
       left: `${widthPercentage * index}%`,
     };
 

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -34,6 +34,12 @@ storiesOf('DayPicker', module)
   .add('more than one month', () => (
     <DayPicker numberOfMonths={2} />
   ))
+  .add('more than two months', () => (
+    <DayPicker numberOfMonths={3} />
+  ))
+  .add('more than three months', () => (
+    <DayPicker numberOfMonths={4} />
+  ))
   .add('vertical', () => (
     <DayPicker
       numberOfMonths={2}


### PR DESCRIPTION
fixes #191 (or I should say attempts to).

So this commit fixes weekday headers wrapping when have more than two months, with a couple caveats.

- This leaves a weird `${widthPercentage + 1}` inside the `width` part of a style block. I'm not a huge fan of this, because our width just needs to be a tiny bit larger, but adding that what anywhere such as:

  `const widthPercentage = (100 / numberOfMonths) + 1;` or `const widthPercentage = 101 / numberOfMonths;` all screw very much so with the calculation of `left`, and ends up becoming an uglier solution (IMO).

- The calculation of `left` seems to be off just a tiny bit for any odd month past 3. This is currently in master, as well I attempted to make it a little better, but that "little" better really is only a "little". However rendering more than 4 months seems very rare, and only would really work on screen resolutions greater than 1920.

Admittedly I'm not fully happy with this solution, but banging my head against a wall with math doesn't seem to be leading to any _better_ solutions. So I'm hoping someone will be smarter than I, and help point something out or build off the work I've done. 