### PR TITLE
Fixes issues where input was being refocused when the window is blurred and refocused

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 import cx from 'classnames';
 
 import isTouchDevice from '../utils/isTouchDevice';
@@ -56,10 +55,13 @@ export default class DateInput extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { focused } = this.props;
-    if (prevProps.focused !== focused && focused) {
-      const startDateInput = ReactDOM.findDOMNode(this.inputRef);
-      startDateInput.focus();
-      startDateInput.select();
+    if (prevProps.focused === focused) return;
+
+    if (focused) {
+      this.inputRef.focus();
+      this.inputRef.select();
+    } else {
+      this.inputRef.blur();
     }
   }
 


### PR DESCRIPTION
Fix for #120 

So we've spent a bit of time digging around and the main issue is that when you leave the page and then return, `document.activeElement` is *still* the `<input />` and so it triggers the focus listener. Our original instinct was just to blur the `input` when the window itself was blurred, we realized eventually that the real issue is that what is focused according to our react code is getting out of sync with what is focused according to the DOM. 

We already had some code that would focus and select the input if that's the way `props.focused` had changed... so now we've added some code that blurs the input if `props.focused` had changed to false. This seems to solve #120 pretty completely (for both the SDP and the DRP).

to: @ljharb @backwardok 
cc: @jkudish @Valentin1918