### PR TITLE
Adds back DayPickerWidth initialization on componentDidMount

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -96,6 +96,7 @@ export default class DayPicker extends React.Component {
   componentDidMount() {
     if (this.isHorizontal()) {
       this.adjustDayPickerHeight();
+      this.initializeDayPickerWidth();
     }
   }
 


### PR DESCRIPTION
I realize while that only doing this in `componentWillReceiveProps` while it works for a component that shows/hides the `DayPicker`, it does not get triggered before the `DayPicker` is visible if you are using that component directly. D: So uh, let's fix that. 

Fixes #214 

to: @airbnb/webinfra @yangaobo 