### PR TITLE
Fix DateRangePicker not passing onDay handlers

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -181,6 +181,10 @@ export default class DateRangePicker extends React.Component {
       endDate,
       minimumNights,
       keepOpenOnDateSelect,
+      onDayMouseEnter,
+      onDayMouseLeave,
+      onDayMouseDown,
+      onDayTouchTap,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -197,10 +201,10 @@ export default class DateRangePicker extends React.Component {
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
           numberOfMonths={numberOfMonths}
-          onDayMouseEnter={this.onDayMouseEnter}
-          onDayMouseLeave={this.onDayMouseLeave}
-          onDayMouseDown={this.onDayClick}
-          onDayTouchTap={this.onDayClick}
+          onDayMouseEnter={onDayMouseEnter}
+          onDayMouseLeave={onDayMouseLeave}
+          onDayMouseDown={onDayMouseDown}
+          onDayTouchTap={onDayTouchTap}
           onPrevMonthClick={onPrevMonthClick}
           onNextMonthClick={onNextMonthClick}
           onDatesChange={onDatesChange}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -37,6 +37,10 @@ export default {
   onFocusChange: PropTypes.func,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onDayMouseEnter: PropTypes.func,
+  onDayMouseLeave: PropTypes.func,
+  onDayMouseDown: PropTypes.func,
+  onDayTouchTap: PropTypes.func,
 
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),


### PR DESCRIPTION
Originally the DateRangerPicker did not map the onDay handlers correctly.
This passes the handlers properly to the next component.