### PR TITLE
Removes maxLength from `DateInput` component

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -122,7 +122,6 @@ export default class DateInput extends React.Component {
           onFocus={onFocus}
           placeholder={placeholder}
           autoComplete="off"
-          maxLength={10}
           disabled={disabled}
           readOnly={this.isTouchDevice}
           required={required}


### PR DESCRIPTION
Fix for https://github.com/airbnb/react-dates/issues/200

to: @airbnb/webinfra 