### PR TITLE
Fixes issue where a system without autoprefixing will not allow for month transitions in safari

### DIFF
--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -6,6 +6,8 @@ $react-dates-width-day-picker: 300px;
 }
 
 .CalendarMonthGrid--animating {
+  -webkit-transition: transform 0.2s ease-in-out;
+  -moz-transition: transform 0.2s ease-in-out;
   transition: transform 0.2s ease-in-out;
   z-index: 1;
 }


### PR DESCRIPTION
Fixes #195 

So I believe that adding this prefixes on the transition css prop should fix the issue @awhenderson was having where their implementation would not transition properly in Safari. I think that we have an autoprefixer at airbnb that automagically does this for us, but given that not everyone has this set-up, this should patch the problem for now. 

@awhenderson let me know if this fixes your issue! 

to: @airbnb/webinfra 