### PR TITLE
Fix week header width issue over 2 months

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -26,11 +26,17 @@
   position: relative;
 }
 
+.DayPicker--horizontal .DayPicker__week-headers {
+  margin-left: 9px;
+}
+
 .DayPicker__week-header {
   color: $react-dates-color-placeholder-text;
   position: absolute;
+  width: $react-dates-width-day-picker;
   top: 62px;
   z-index: 2;
+  padding: 0 13px;
   text-align: left;
 
   ul {
@@ -46,18 +52,8 @@
   }
 }
 
-.DayPicker--horizontal .DayPicker__week-header {
-  padding: 0 22px 0 13px;
-
-  &:first-of-type {
-    padding: 0 13px 0 22px;
-  }
-}
-
 .DayPicker--vertical .DayPicker__week-header {
   margin-left: -1 * $react-dates-width-day-picker / 2;
-  padding: 0 13px;
-  width: $react-dates-width-day-picker;
   left: 50%;
 }
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -317,12 +317,8 @@ export default class DayPicker extends React.Component {
   }
 
   renderWeekHeader(index) {
-    const { numberOfMonths } = this.props;
-
-    const widthPercentage = 100 / numberOfMonths;
     const horizontalStyle = {
-      width: `${widthPercentage}%`,
-      left: `${widthPercentage * index}%`,
+      left: index * CALENDAR_MONTH_WIDTH,
     };
 
     const style = this.isHorizontal() ? horizontalStyle : {};

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -108,6 +108,9 @@ storiesOf('DateRangePicker', module)
   .addWithInfo('single month', () => (
     <DateRangePickerWrapper numberOfMonths={1} />
   ))
+  .addWithInfo('3 months', () => (
+    <DateRangePickerWrapper numberOfMonths={3} />
+  ))
   .addWithInfo('anchored right', () => (
     <div style={{ float: 'right' }}>
       <DateRangePickerWrapper


### PR DESCRIPTION
So I started thinking about https://github.com/airbnb/react-dates/issues/191 as well as @SecurityInsanity's solution https://github.com/airbnb/react-dates/pull/199

I think the end that I came to was that... the percentage code was trying too hard. The best bet for the week headers would be to get the style to match the actual `CalendarMonth`s directly, right?

Well, turns out we have access to the width we're using right now both in the css and in the JS (incidentally, it's not very moddable at presence), so let's just go with that. This change does that and thus allows for like a real, > 2 months implementation without looking gross.

to: @SecurityInsanity @airbnb/webinfra 