### PR TITLE
Remove pointer events from previous (invisible) month

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -9,6 +9,7 @@
     position: absolute;
     z-index: -1;
     opacity: 0;
+    pointer-events: none;
   }
 
   table {


### PR DESCRIPTION
This is a problem if previous month has more week rows than the current month.