### PR TITLE
Set input value to use ISO format by default

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -6,7 +6,8 @@ import isTouchDevice from '../utils/isTouchDevice';
 const propTypes = {
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
-  dateValue: PropTypes.string,
+  displayValue: PropTypes.string,
+  inputValue: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -20,7 +21,8 @@ const propTypes = {
 
 const defaultProps = {
   placeholder: 'Select Date',
-  dateValue: '',
+  displayValue: '',
+  inputValue: '',
   focused: false,
   disabled: false,
   required: false,
@@ -46,7 +48,7 @@ export default class DateInput extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!this.props.dateValue && nextProps.dateValue) {
+    if (!this.props.displayValue && nextProps.displayValue) {
       this.setState({
         dateString: '',
       });
@@ -88,7 +90,8 @@ export default class DateInput extends React.Component {
     const {
       id,
       placeholder,
-      dateValue,
+      displayValue,
+      inputValue,
       focused,
       showCaret,
       onFocus,
@@ -96,7 +99,8 @@ export default class DateInput extends React.Component {
       required,
     } = this.props;
 
-    const value = dateValue || dateString;
+    const displayText = displayValue || inputValue || dateString || placeholder || '';
+    const value = inputValue || displayValue || '';
 
     return (
       <div
@@ -134,7 +138,7 @@ export default class DateInput extends React.Component {
             'DateInput__display-text--disabled': disabled,
           })}
         >
-          {value || placeholder}
+          {displayText}
         </div>
       </div>
     );

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -23,7 +23,9 @@ const propTypes = {
   onClearDates: PropTypes.func,
 
   startDate: PropTypes.string,
+  startDateValue: PropTypes.string,
   endDate: PropTypes.string,
+  endDateValue: PropTypes.string,
 
   isStartDateFocused: PropTypes.bool,
   isEndDateFocused: PropTypes.bool,
@@ -52,7 +54,9 @@ const defaultProps = {
   onClearDates() {},
 
   startDate: '',
+  startDateValue: '',
   endDate: '',
+  endDateValue: '',
 
   isStartDateFocused: false,
   isEndDateFocused: false,
@@ -91,9 +95,10 @@ export default class DateRangePickerInput extends React.Component {
   }
 
   render() {
-    const { startDateString, endDateString, isClearDatesHovered } = this.state;
+    const { isClearDatesHovered } = this.state;
     const {
       startDate,
+      startDateValue,
       startDateId,
       startDatePlaceholderText,
       isStartDateFocused,
@@ -101,6 +106,7 @@ export default class DateRangePickerInput extends React.Component {
       onStartDateFocus,
       onStartDateShiftTab,
       endDate,
+      endDateValue,
       endDateId,
       endDatePlaceholderText,
       isEndDateFocused,
@@ -115,9 +121,6 @@ export default class DateRangePickerInput extends React.Component {
       phrases,
     } = this.props;
 
-    const startDateValue = startDate || startDateString;
-    const endDateValue = endDate || endDateString;
-
     return (
       <div
         className={cx('DateRangePickerInput', {
@@ -127,7 +130,8 @@ export default class DateRangePickerInput extends React.Component {
         <DateInput
           id={startDateId}
           placeholder={startDatePlaceholderText}
-          dateValue={startDateValue}
+          displayValue={startDate}
+          inputValue={startDateValue}
           focused={isStartDateFocused}
           disabled={disabled}
           required={required}
@@ -145,7 +149,8 @@ export default class DateRangePickerInput extends React.Component {
         <DateInput
           id={endDateId}
           placeholder={endDatePlaceholderText}
-          dateValue={endDateValue}
+          displayValue={endDate}
+          inputValue={endDateValue}
           focused={isEndDateFocused}
           disabled={disabled}
           required={required}
@@ -160,7 +165,7 @@ export default class DateRangePickerInput extends React.Component {
           <button
             type="button"
             className={cx('DateRangePickerInput__clear-dates', {
-              'DateRangePickerInput__clear-dates--hide': !(startDateValue || endDateValue),
+              'DateRangePickerInput__clear-dates--hide': !(startDate || endDate),
               'DateRangePickerInput__clear-dates--hover': isClearDatesHovered,
             })}
             onMouseEnter={this.onClearDatesMouseEnter}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -7,6 +7,7 @@ import DateRangePickerInput from './DateRangePickerInput';
 
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
+import toISODateString from '../utils/toISODateString';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isInclusivelyBeforeDay from '../utils/isInclusivelyBeforeDay';
@@ -194,15 +195,19 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
+    const startDateValue = toISODateString(startDate);
     const endDateString = this.getDateString(endDate);
+    const endDateValue = toISODateString(endDate);
 
     return (
       <DateRangePickerInput
         startDate={startDateString}
+        startDateValue={startDateValue}
         startDateId={startDateId}
         startDatePlaceholderText={startDatePlaceholderText}
         isStartDateFocused={isStartDateFocused}
         endDate={endDateString}
+        endDateValue={endDateValue}
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}
         isEndDateFocused={isEndDateFocused}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -6,6 +6,7 @@ import includes from 'array-includes';
 
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
+import toISODateString from '../utils/toISODateString';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
 
 import SingleDatePickerInput from './SingleDatePickerInput';
@@ -335,6 +336,7 @@ export default class SingleDatePicker extends React.Component {
     } = this.props;
 
     const dateString = this.getDateString(date);
+    const dateValue = toISODateString(date);
 
     return (
       <div className="SingleDatePicker">
@@ -348,7 +350,8 @@ export default class SingleDatePicker extends React.Component {
           phrases={phrases}
           onClearDate={this.clearDate}
           showClearDate={showClearDate}
-          dateValue={dateString}
+          displayValue={dateString}
+          inputValue={dateValue}
           onChange={this.onChange}
           onFocus={this.onFocus}
           onKeyDownShiftTab={this.onClearFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -7,8 +7,8 @@ import CloseButton from '../svg/close.svg';
 const propTypes = {
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
-  dateValue: PropTypes.string,
-  border: PropTypes.bool,
+  displayValue: PropTypes.string,
+  inputValue: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -29,8 +29,8 @@ const propTypes = {
 
 const defaultProps = {
   placeholder: 'Select Date',
-  dateValue: '',
-  border: false,
+  displayValue: '',
+  inputValue: '',
   focused: false,
   disabled: false,
   required: false,
@@ -77,7 +77,8 @@ export default class SingleDatePickerInput extends React.Component {
     const {
       id,
       placeholder,
-      dateValue,
+      displayValue,
+      inputValue,
       focused,
       disabled,
       required,
@@ -96,7 +97,8 @@ export default class SingleDatePickerInput extends React.Component {
         <DateInput
           id={id}
           placeholder={placeholder} // also used as label
-          dateValue={dateValue}
+          displayValue={displayValue}
+          inputValue={inputValue}
           focused={focused}
           disabled={disabled}
           required={required}
@@ -112,7 +114,7 @@ export default class SingleDatePickerInput extends React.Component {
           <button
             type="button"
             className={cx('SingleDatePickerInput__clear-date', {
-              'SingleDatePickerInput__clear-date--hide': !dateValue,
+              'SingleDatePickerInput__clear-date--hide': !displayValue,
               'SingleDatePickerInput__clear-date--hover': isClearDateHovered,
             })}
             onMouseEnter={this.onClearDateMouseEnter}

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -44,6 +44,18 @@ describe('DateInput', () => {
         const wrapper = shallow(<DateInput id="date" />);
         expect(wrapper.find('input').is('.DateInput__input')).to.equal(true);
       });
+
+      it('has value === props.inputValue if prop is passed in', () => {
+        const INPUT_VALUE = 'foobar';
+        const wrapper = shallow(<DateInput id="date" inputValue={INPUT_VALUE} />);
+        expect(wrapper.find('input').props().value).to.equal(INPUT_VALUE);
+      });
+
+      it('has value === props.displayValue if inputValue is not passed in', () => {
+        const DISPLAY_VALUE = 'foobar';
+        const wrapper = shallow(<DateInput id="date" displayValue={DISPLAY_VALUE} />);
+        expect(wrapper.find('input').props().value).to.equal(DISPLAY_VALUE);
+      });
     });
 
     describe('display text', () => {
@@ -52,18 +64,18 @@ describe('DateInput', () => {
         expect(wrapper.find('.DateInput__display-text')).to.have.lengthOf(1);
       });
 
-      describe('props.dateValue is falsey', () => {
+      describe('props.displayValue is falsey', () => {
         it('does not have .DateInput__display-text__has-input class', () => {
-          const wrapper = shallow(<DateInput id="date" dateValue={null} />);
+          const wrapper = shallow(<DateInput id="date" displayValue={null} />);
           const hasInputDisplayTextWrapper =
             wrapper.find('.DateInput__display-text--has-input');
           expect(hasInputDisplayTextWrapper).to.have.lengthOf(0);
         });
       });
 
-      describe('props.dateValue is truthy', () => {
+      describe('props.displayValue is truthy', () => {
         it('has .DateInput__display-text--has-input class', () => {
-          const wrapper = shallow(<DateInput id="date" dateValue="1991-07-13" />);
+          const wrapper = shallow(<DateInput id="date" displayValue="1991-07-13" />);
           const hasInputDisplayTextWrapper =
             wrapper.find('.DateInput__display-text--has-input');
           expect(hasInputDisplayTextWrapper).to.have.lengthOf(1);

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -43,13 +43,14 @@ describe('SingleDatePickerInput', () => {
 
       it('has .SingleDatePickerInput__clear-date--hide class if there is no date',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate dateValue={null} />);
+          const wrapper = shallow(<SingleDatePickerInput showClearDate displayValue={null} />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(1);
         });
 
       it('does not have .SingleDatePickerInput__clear-date--hide class if there is a date',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate dateValue="2016-07-13" />);
+          const wrapper =
+            shallow(<SingleDatePickerInput showClearDate displayValue="2016-07-13" />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
         });
     });


### PR DESCRIPTION
If we don't add a layer of abstraction to format the date client side, the input value will be submitted directly to the server. As a result, I think we should not be using the display format but rather a standardized ISO-8601 format. 

to: @jeffsee55 @airbnb/webinfra 