### PR TITLE
Set vertical day picker height using number of months

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -57,6 +57,56 @@
   left: 50%;
 }
 
+.DayPicker.DayPicker--scrollable {
+  height: 100%;
+
+  .DayPicker__week-header {
+    top: 0;
+    display: table-row;
+    border-bottom: 1px solid $react-dates-color-border;
+    background: white;
+  }
+
+  .CalendarMonth__caption {
+    padding-bottom: 5px;
+    padding-top: 5px;
+  }
+
+  .transition-container--vertical {
+    padding-top: 20px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    overflow-y: scroll;
+  }
+
+  .DayPickerNavigation__prev {
+    display: none;
+  }
+
+  .DayPickerNavigation__next {
+    width: 100%;
+  }
+
+  .DayPickerNavigation--vertical {
+    position: relative;
+  }
+
+  .CalendarMonthGrid--vertical {
+    overflow-y: scroll;
+  }
+
+  &.DayPicker--vertical .DayPicker__week-header {
+    margin-left: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+  }
+}
+
 .transition-container {
   position: relative;
   overflow: hidden;

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -41,6 +41,7 @@ const propTypes = {
   withPortal: PropTypes.bool,
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  scrollable: PropTypes.bool,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -81,6 +82,7 @@ const defaultProps = {
   hidden: false,
 
   initialVisibleMonth: () => moment(),
+  scrollable: false,
 
   navPrev: null,
   navNext: null,
@@ -251,6 +253,7 @@ export default class DayPickerRangeController extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      scrollable,
     } = this.props;
 
     const modifiers = {
@@ -295,6 +298,7 @@ export default class DayPickerRangeController extends React.Component {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
+        scrollable={scrollable}
       />
     );
   }

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -40,6 +40,18 @@ storiesOf('DayPicker', module)
       orientation={VERTICAL_ORIENTATION}
     />
   ))
+  .addWithInfo('vertically scrollable with 12 months', () => (
+    <div style={{
+      height: '568px',
+      width: '320px',
+    }}>
+      <DayPicker
+        numberOfMonths={12}
+        scrollable
+        orientation={VERTICAL_ORIENTATION}
+      />
+    </div>
+  ))
   .addWithInfo('with custom arrows', () => (
     <DayPicker
       navPrev={<TestPrevIcon />}


### PR DESCRIPTION
to: @majapw @ljharb 

For vertical DayPickers, calculate the height with `numberOfMonths` instead of using a fixed value, which currently truncate halfway into the second month. This allows vertically scrollable DayPickers on mobile by increasing the month count.