### PR TITLE
Adds daySize prop to the DRP/SDP/DP that scales everything accordingly

### DIFF
--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -1,5 +1,3 @@
-$react-dates-width-day-picker: 300px;
-
 .CalendarMonthGrid {
   background: #fff;
   z-index: 0;
@@ -16,16 +14,13 @@ $react-dates-width-day-picker: 300px;
 .CalendarMonthGrid--horizontal {
   position: absolute;
   left: 9px;
-  width: 4 * $react-dates-width-day-picker;
 }
 
 .CalendarMonthGrid--vertical {
-  width: $react-dates-width-day-picker;
   margin: 0 auto;
 }
 
 .CalendarMonthGrid--vertical-scrollable {
-  width: $react-dates-width-day-picker;
   margin: 0 auto;
   overflow-y: scroll;
 }

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -34,7 +34,6 @@
 .DayPicker__week-header {
   color: $react-dates-color-placeholder-text;
   position: absolute;
-  width: $react-dates-width-day-picker;
   top: 62px;
   z-index: 2;
   padding: 0 13px;
@@ -48,13 +47,11 @@
 
   li {
     display: inline-block;
-    width: 39px;
     text-align: center;
   }
 }
 
 .DayPicker--vertical .DayPicker__week-header {
-  margin-left: -1 * $react-dates-width-day-picker / 2;
   left: 50%;
 }
 

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,7 +1,6 @@
 $react-dates-width-input: 130px !default;
 $react-dates-width-arrow: 24px !default;
 $react-dates-width-tooltip-arrow: 20px !default;
-$react-dates-width-day-picker: 300px !default;
 $react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -6,6 +6,7 @@ import cx from 'classnames';
 
 const propTypes = {
   day: momentPropTypes.momentObj,
+  daySize: PropTypes.number,
   isOutsideDay: PropTypes.bool,
   modifiers: PropTypes.object,
   onDayClick: PropTypes.func,
@@ -16,6 +17,7 @@ const propTypes = {
 
 const defaultProps = {
   day: moment(),
+  daySize: 39,
   isOutsideDay: false,
   modifiers: {},
   onDayClick() {},
@@ -51,6 +53,7 @@ export default class CalendarDay extends React.Component {
   render() {
     const {
       day,
+      daySize,
       isOutsideDay,
       modifiers,
       renderDay,
@@ -60,9 +63,15 @@ export default class CalendarDay extends React.Component {
       'CalendarDay--outside': !day || isOutsideDay,
     }, getModifiersForDay(modifiers, day).map(mod => `CalendarDay--${mod}`));
 
+    const daySizeStyles = {
+      width: daySize,
+      height: daySize - 1,
+    };
+
     return (day ?
       <td
         className={className}
+        style={daySizeStyles}
         onMouseEnter={e => this.onDayMouseEnter(day, e)}
         onMouseLeave={e => this.onDayMouseLeave(day, e)}
         onClick={e => this.onDayClick(day, e)}

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -24,6 +24,7 @@ const propTypes = {
   enableOutsideDays: PropTypes.bool,
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
+  daySize: PropTypes.number,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
@@ -39,6 +40,7 @@ const defaultProps = {
   enableOutsideDays: false,
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
+  daySize: 39,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
@@ -80,6 +82,7 @@ export default class CalendarMonth extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       renderDay,
+      daySize,
     } = this.props;
 
     const { weeks } = this.state;
@@ -104,6 +107,7 @@ export default class CalendarMonth extends React.Component {
                 {week.map((day, dayOfWeek) => (
                   <CalendarDay
                     day={day}
+                    daySize={daySize}
                     isOutsideDay={!day || day.month() !== month.month()}
                     modifiers={modifiers}
                     key={dayOfWeek}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -9,6 +9,7 @@ import CalendarMonth from './CalendarMonth';
 
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
+import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -32,6 +33,7 @@ const propTypes = {
   onMonthTransitionEnd: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
+  daySize: PropTypes.number,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -51,6 +53,7 @@ const defaultProps = {
   onMonthTransitionEnd() {},
   renderDay: null,
   transformValue: 'none',
+  daySize: 39,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -146,6 +149,7 @@ export default class CalendarMonthGrid extends React.Component {
       monthFormat,
       orientation,
       transformValue,
+      daySize,
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
@@ -153,21 +157,33 @@ export default class CalendarMonthGrid extends React.Component {
       onMonthTransitionEnd,
     } = this.props;
 
-
     const { months } = this.state;
+    const isVertical = orientation === VERTICAL_ORIENTATION;
+    const isVerticalScrollable = orientation === VERTICAL_SCROLLABLE;
 
     const className = cx('CalendarMonthGrid', {
       'CalendarMonthGrid--horizontal': orientation === HORIZONTAL_ORIENTATION,
-      'CalendarMonthGrid--vertical': orientation === VERTICAL_ORIENTATION,
-      'CalendarMonthGrid--vertical-scrollable': orientation === VERTICAL_SCROLLABLE,
+      'CalendarMonthGrid--vertical': isVertical,
+      'CalendarMonthGrid--vertical-scrollable': isVerticalScrollable,
       'CalendarMonthGrid--animating': isAnimating,
     });
+
+    const calendarMonthWidth = getCalendarMonthWidth(daySize);
+
+    const width = isVertical || isVerticalScrollable ?
+      calendarMonthWidth :
+      (numberOfMonths + 2) * calendarMonthWidth;
+
+    const style = {
+      ...getTransformStyles(transformValue),
+      width,
+    };
 
     return (
       <div
         ref={(ref) => { this.container = ref; }}
         className={className}
-        style={getTransformStyles(transformValue)}
+        style={style}
         onTransitionEnd={onMonthTransitionEnd}
       >
         {months.map((month, i) => {
@@ -186,6 +202,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
               renderDay={renderDay}
+              daySize={daySize}
             />
           );
         })}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -58,6 +58,8 @@ const defaultProps = {
   withPortal: false,
   withFullScreenPortal: false,
 
+  daySize: 39,
+
   onDatesChange() {},
   onFocusChange() {},
   onPrevMonthClick() {},
@@ -175,10 +177,12 @@ export default class DateRangePicker extends React.Component {
   maybeRenderDayPickerWithPortal() {
     const { withPortal, withFullScreenPortal } = this.props;
 
+    console.log('hello world')
     if (!this.isOpened()) {
       return null;
     }
 
+    console.log('hello')
     if (withPortal || withFullScreenPortal) {
       return (
         <Portal isOpened>
@@ -206,6 +210,7 @@ export default class DateRangePicker extends React.Component {
       onFocusChange,
       withPortal,
       withFullScreenPortal,
+      daySize,
       enableOutsideDays,
       focusedInput,
       startDate,
@@ -243,6 +248,7 @@ export default class DateRangePicker extends React.Component {
           endDate={endDate}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}
           onOutsideClick={onOutsideClick}
           navPrev={navPrev}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -39,6 +39,7 @@ const propTypes = {
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  daySize: PropTypes.number,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -73,6 +74,7 @@ const defaultProps = {
   withPortal: false,
 
   initialVisibleMonth: () => moment(),
+  daySize: 39,
 
   navPrev: null,
   navNext: null,
@@ -236,6 +238,7 @@ export default class DayPickerRangeController extends React.Component {
       withPortal,
       enableOutsideDays,
       initialVisibleMonth,
+      daySize,
       focusedInput,
       renderDay,
     } = this.props;
@@ -278,6 +281,7 @@ export default class DayPickerRangeController extends React.Component {
         withPortal={withPortal}
         hidden={!focusedInput}
         initialVisibleMonth={initialVisibleMonth}
+        daySize={daySize}
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -58,6 +58,8 @@ const defaultProps = {
   screenReaderInputMessage: '',
   initialVisibleMonth: null,
 
+  daySize: 39,
+
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
@@ -292,6 +294,7 @@ export default class SingleDatePicker extends React.Component {
       renderDay,
       date,
       initialVisibleMonth,
+      daySize,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -333,6 +336,7 @@ export default class SingleDatePicker extends React.Component {
           navPrev={navPrev}
           navNext={navNext}
           renderDay={renderDay}
+          daySize={daySize}
         />
 
         {withFullScreenPortal &&

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -29,6 +29,8 @@ export default {
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
 
+  daySize: PropTypes.number,
+
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
   endDateId: PropTypes.string,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -35,6 +35,8 @@ export default {
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
 
+  daySize: PropTypes.number,
+
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 

--- a/src/utils/getCalendarMonthWidth.js
+++ b/src/utils/getCalendarMonthWidth.js
@@ -1,0 +1,5 @@
+const CALENDAR_MONTH_PADDING = 9;
+
+export default function getCalendarMonthWidth(daySize) {
+  return (7 * (daySize + 1)) + (2 * (CALENDAR_MONTH_PADDING + 1));
+}

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -137,6 +137,11 @@ storiesOf('DateRangePicker', module)
   .addWithInfo('3 months', () => (
     <DateRangePickerWrapper numberOfMonths={3} />
   ))
+  .addWithInfo('with custom day size', () => (
+    <DateRangePickerWrapper
+      daySize={50}
+    />
+  ))
   .addWithInfo('anchored right', () => (
     <div style={{ float: 'right' }}>
       <DateRangePickerWrapper
@@ -147,6 +152,12 @@ storiesOf('DateRangePicker', module)
   .addWithInfo('vertical', () => (
     <DateRangePickerWrapper
       orientation={VERTICAL_ORIENTATION}
+    />
+  ))
+  .addWithInfo('vertical with custom day size', () => (
+    <DateRangePickerWrapper
+      orientation={VERTICAL_ORIENTATION}
+      daySize={50}
     />
   ))
   .addWithInfo('vertical anchored right', () => (

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -7,23 +7,26 @@ import {
   VERTICAL_SCROLLABLE,
 } from '../constants';
 
-const TestPrevIcon = props => (
-  <span style={{
+const TestPrevIcon = () => (
+  <span
+    style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
-      padding: '3px'
+      padding: '3px',
     }}
   >
     Prev
   </span>
 );
-const TestNextIcon = props => (
-  <span style={{
-    border: '1px solid #dce0e0',
-    backgroundColor: '#fff',
-    color: '#484848',
-    padding: '3px'
+
+const TestNextIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
     }}
   >
     Next
@@ -33,6 +36,9 @@ const TestNextIcon = props => (
 storiesOf('DayPicker', module)
   .addWithInfo('default', () => (
     <DayPicker />
+  ))
+  .addWithInfo('with custom day size', () => (
+    <DayPicker daySize={50} />
   ))
   .addWithInfo('more than one month', () => (
     <DayPicker numberOfMonths={2} />
@@ -44,15 +50,24 @@ storiesOf('DayPicker', module)
     />
   ))
   .addWithInfo('vertically scrollable with 12 months', () => (
-    <div style={{
-      height: '568px',
-      width: '320px',
-    }}>
+    <div
+      style={{
+        height: 568,
+        width: 320,
+      }}
+    >
       <DayPicker
         numberOfMonths={12}
         orientation={VERTICAL_SCROLLABLE}
       />
     </div>
+  ))
+  .addWithInfo('vertical with custom day size', () => (
+    <DayPicker
+      numberOfMonths={2}
+      orientation={VERTICAL_ORIENTATION}
+      daySize={50}
+    />
   ))
   .addWithInfo('with custom arrows', () => (
     <DayPicker

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -7,37 +7,41 @@ import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 import { VERTICAL_ORIENTATION, ANCHOR_RIGHT } from '../constants';
 
 const TestInput = props => (
-   <div style={{ marginTop: 16 }} >
-     <input
-       {...props}
-       type="text"
-       style={{
-         height: 48,
-         width: 284,
-         fontSize: 18,
-         fontWeight: 200,
-         padding: '12px 16px',
-       }}
-     />
+  <div style={{ marginTop: 16 }} >
+    <input
+      {...props}
+      type="text"
+      style={{
+        height: 48,
+        width: 284,
+        fontSize: 18,
+        fontWeight: 200,
+        padding: '12px 16px',
+      }}
+    />
   </div>
 );
-const TestPrevIcon = props => (
-  <span style={{
+
+const TestPrevIcon = () => (
+  <span
+    style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
-      padding: '3px'
+      padding: '3px',
     }}
   >
     Prev
   </span>
 );
-const TestNextIcon = props => (
-  <span style={{
-    border: '1px solid #dce0e0',
-    backgroundColor: '#fff',
-    color: '#484848',
-    padding: '3px'
+
+const TestNextIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
     }}
   >
     Next
@@ -54,13 +58,18 @@ storiesOf('SingleDatePicker', module)
     />
   ))
   .addWithInfo('as part of a form', () => (
-     <div>
-       <SingleDatePickerWrapper />
-       <TestInput placeholder="Input 1" />
-       <TestInput placeholder="Input 2" />
-       <TestInput placeholder="Input 3" />
-     </div>
-   ))
+    <div>
+      <SingleDatePickerWrapper />
+      <TestInput placeholder="Input 1" />
+      <TestInput placeholder="Input 2" />
+      <TestInput placeholder="Input 3" />
+    </div>
+  ))
+  .addWithInfo('with custom day size', () => (
+    <SingleDatePickerWrapper
+      daySize={50}
+    />
+  ))
   .addWithInfo('anchored right', () => (
     <div style={{ float: 'right' }}>
       <SingleDatePickerWrapper
@@ -71,6 +80,12 @@ storiesOf('SingleDatePicker', module)
   .addWithInfo('vertical', () => (
     <SingleDatePickerWrapper
       orientation={VERTICAL_ORIENTATION}
+    />
+  ))
+  .addWithInfo('vertical with custom day size', () => (
+    <SingleDatePickerWrapper
+      orientation={VERTICAL_ORIENTATION}
+      daySize={50}
     />
   ))
   .addWithInfo('horizontal with portal', () => (

--- a/test/utils/getCalendarMonthWidth_spec.js
+++ b/test/utils/getCalendarMonthWidth_spec.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+
+import getCalendarMonthWidth from '../../src/utils/getCalendarMonthWidth';
+
+describe('#getCalendarMonthWidth', () => {
+  it('correctly calculates width for default day size of 39', () => {
+    expect(getCalendarMonthWidth(39)).to.equal(300);
+  });
+});


### PR DESCRIPTION
Basically, this conflates all of the code associated with the width of the `DayPicker` into the JS side of things (which again, will be nice for using `react-with-styles`). The DRP/SDP now take a `daySize` prop (specifically a numerical pixel value) and then does all of its calculations based on that. 

This should be a fix for https://github.com/airbnb/react-dates/issues/203

~~I'm going to add one more commit that modifies the height calculations to use this number as well instead of reaching into the DOM. ~~
Just kidding! The fact that the month title size is still not available to me is a problem. We'll just have to wait til everything is in one place with `react-with-styles`

to: @airbnb/webinfra @moonboots @ljharb 
fyi: @cemremengu