### PR TITLE
Add vertical scrollable orientation

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -7,6 +7,7 @@ module.exports = {
 
   HORIZONTAL_ORIENTATION: 'horizontal',
   VERTICAL_ORIENTATION: 'vertical',
+  VERTICAL_SCROLLABLE: 'verticalScrollable',
 
   ANCHOR_LEFT: 'left',
   ANCHOR_RIGHT: 'right',

--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -31,10 +31,18 @@
   color: $react-dates-color-gray-dark;
   margin-top: 7px;
   font-size: 18px;
-  padding: 15px 0 35px;
   text-align: center;
   // necessary to not hide borders in FF
   margin-bottom: 2px;
+}
+
+.CalendarMonth--horizontal .CalendarMonth__caption,
+.CalendarMonth--vertical .CalendarMonth__caption {
+  padding: 15px 0 35px;
+}
+
+.CalendarMonth--vertical-scrollable .CalendarMonth__caption {
+  padding: 5px 0;
 }
 
 // This order is important.

--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -23,3 +23,9 @@ $react-dates-width-day-picker: 300px;
   width: $react-dates-width-day-picker;
   margin: 0 auto;
 }
+
+.CalendarMonthGrid--vertical-scrollable {
+  width: $react-dates-width-day-picker;
+  margin: 0 auto;
+  overflow-y: scroll;
+}

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -58,6 +58,35 @@
   left: 50%;
 }
 
+.DayPicker--vertical-scrollable {
+  height: 100%;
+
+  .DayPicker__week-header {
+    top: 0;
+    display: table-row;
+    border-bottom: 1px solid $react-dates-color-border;
+    background: white;
+  }
+
+  .transition-container--vertical {
+    padding-top: 20px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    overflow-y: scroll;
+  }
+
+  .DayPicker__week-header {
+    margin-left: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+  }
+}
+
 .transition-container {
   position: relative;
   overflow: hidden;

--- a/css/DayPickerNavigation.scss
+++ b/css/DayPickerNavigation.scss
@@ -91,3 +91,11 @@
     }
   }
 }
+
+.DayPickerNavigation--vertical-scrollable {
+  position: relative;
+
+  .DayPickerNavigation__next {
+    width: 100%;
+  }
+}

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -10,16 +10,20 @@ import CalendarDay from './CalendarDay';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 
-import OrientationShape from '../shapes/OrientationShape';
+import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
 
 const propTypes = {
   month: momentPropTypes.momentObj,
   isVisible: PropTypes.bool,
   enableOutsideDays: PropTypes.bool,
   modifiers: PropTypes.object,
-  orientation: OrientationShape,
+  orientation: ScrollableOrientationShape,
   onDayClick: PropTypes.func,
   onDayMouseDown: PropTypes.func,
   onDayMouseUp: PropTypes.func,
@@ -100,6 +104,7 @@ export default class CalendarMonth extends React.Component {
     const calendarMonthClasses = cx('CalendarMonth', {
       'CalendarMonth--horizontal': orientation === HORIZONTAL_ORIENTATION,
       'CalendarMonth--vertical': orientation === VERTICAL_ORIENTATION,
+      'CalendarMonth--vertical-scrollable': orientation === VERTICAL_SCROLLABLE,
     });
 
     return (

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -10,9 +10,13 @@ import CalendarMonth from './CalendarMonth';
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 
-import OrientationShape from '../shapes/OrientationShape';
+import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
 
 const propTypes = {
   enableOutsideDays: PropTypes.bool,
@@ -21,7 +25,7 @@ const propTypes = {
   isAnimating: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   modifiers: PropTypes.object,
-  orientation: OrientationShape,
+  orientation: ScrollableOrientationShape,
   onDayClick: PropTypes.func,
   onDayMouseDown: PropTypes.func,
   onDayMouseUp: PropTypes.func,
@@ -171,6 +175,7 @@ export default class CalendarMonthGrid extends React.Component {
     const className = cx('CalendarMonthGrid', {
       'CalendarMonthGrid--horizontal': orientation === HORIZONTAL_ORIENTATION,
       'CalendarMonthGrid--vertical': orientation === VERTICAL_ORIENTATION,
+      'CalendarMonthGrid--vertical-scrollable': orientation === VERTICAL_SCROLLABLE,
       'CalendarMonthGrid--animating': isAnimating,
     });
 

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -5,11 +5,17 @@ import LeftArrow from '../svg/arrow-left.svg';
 import RightArrow from '../svg/arrow-right.svg';
 import ChevronUp from '../svg/chevron-up.svg';
 import ChevronDown from '../svg/chevron-down.svg';
+import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
+
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
 
 const propTypes = {
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
-  isVertical: PropTypes.bool,
+  orientation: ScrollableOrientationShape,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
@@ -17,7 +23,7 @@ const propTypes = {
 const defaultProps = {
   navPrev: null,
   navNext: null,
-  isVertical: false,
+  orientation: HORIZONTAL_ORIENTATION,
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -27,10 +33,13 @@ export default function DayPickerNavigation(props) {
   const {
     navPrev,
     navNext,
-    isVertical,
     onPrevMonthClick,
     onNextMonthClick,
+    orientation,
   } = props;
+
+  const isVertical = orientation !== HORIZONTAL_ORIENTATION;
+  const isVerticalScrollable = orientation === VERTICAL_SCROLLABLE;
 
   let navPrevIcon = navPrev;
   let navNextIcon = navNext;
@@ -48,6 +57,7 @@ export default function DayPickerNavigation(props) {
   const navClassNames = cx('DayPickerNavigation', {
     'DayPickerNavigation--horizontal': !isVertical,
     'DayPickerNavigation--vertical': isVertical,
+    'DayPickerNavigation--vertical-scrollable': isVerticalScrollable,
   });
   const prevClassNames = cx('DayPickerNavigation__prev', {
     'DayPickerNavigation__prev--default': isDefaultNavPrev,
@@ -58,12 +68,14 @@ export default function DayPickerNavigation(props) {
 
   return (
     <div className={navClassNames}>
-      <span
-        className={prevClassNames}
-        onClick={onPrevMonthClick}
-      >
-        {navPrevIcon}
-      </span>
+      {!isVerticalScrollable &&
+        <span
+          className={prevClassNames}
+          onClick={onPrevMonthClick}
+        >
+          {navPrevIcon}
+        </span>
+      }
 
       <span
         className={nextClassNames}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -9,7 +9,7 @@ import isNextDay from '../utils/isNextDay';
 import isSameDay from '../utils/isSameDay';
 
 import FocusedInputShape from '../shapes/FocusedInputShape';
-import OrientationShape from '../shapes/OrientationShape';
+import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
 import {
   START_DATE,
@@ -36,7 +36,7 @@ const propTypes = {
   // DayPicker props
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
-  orientation: OrientationShape,
+  orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,

--- a/src/shapes/ScrollableOrientationShape.js
+++ b/src/shapes/ScrollableOrientationShape.js
@@ -1,0 +1,13 @@
+import { PropTypes } from 'react';
+
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
+
+export default PropTypes.oneOf([
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+]);

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -2,7 +2,10 @@ import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import DayPicker from '../src/components/DayPicker';
 
-import { VERTICAL_ORIENTATION } from '../constants';
+import {
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../constants';
 
 const TestPrevIcon = props => (
   <span style={{
@@ -39,6 +42,17 @@ storiesOf('DayPicker', module)
       numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
     />
+  ))
+  .addWithInfo('vertically scrollable with 12 months', () => (
+    <div style={{
+      height: '568px',
+      width: '320px',
+    }}>
+      <DayPicker
+        numberOfMonths={12}
+        orientation={VERTICAL_SCROLLABLE}
+      />
+    </div>
   ))
   .addWithInfo('with custom arrows', () => (
     <DayPicker

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -4,6 +4,11 @@ import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 
 import DayPickerNavigation from '../../src/components/DayPickerNavigation';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
 
 describe('DayPickerNavigation', () => {
   describe('#render', () => {
@@ -13,12 +18,12 @@ describe('DayPickerNavigation', () => {
     });
 
     it('has .DayPickerNavigation--horizontal when not vertical', () => {
-      const wrapper = shallow(<DayPickerNavigation isVertical={false} />);
+      const wrapper = shallow(<DayPickerNavigation orientation={HORIZONTAL_ORIENTATION} />);
       expect(wrapper.find('.DayPickerNavigation--horizontal')).to.have.lengthOf(1);
     });
 
     it('has .DayPickerNavigation--vertical when vertical', () => {
-      const wrapper = shallow(<DayPickerNavigation isVertical />);
+      const wrapper = shallow(<DayPickerNavigation orientation={VERTICAL_ORIENTATION} />);
       expect(wrapper.find('.DayPickerNavigation--vertical')).to.have.lengthOf(1);
     });
 
@@ -41,6 +46,11 @@ describe('DayPickerNavigation', () => {
       it('has no .DayPickerNavigation__prev--default if custom prev icon', () => {
         const wrapper = shallow(<DayPickerNavigation navPrev={<span>Prev</span>} />);
         expect(wrapper.find('.DayPickerNavigation__prev--default')).to.have.lengthOf(0);
+      });
+
+      it('hidden when vertically scrollable', () => {
+        const wrapper = shallow(<DayPickerNavigation orientation={VERTICAL_SCROLLABLE} />);
+        expect(wrapper.find('.DayPickerNavigation__prev')).to.have.lengthOf(0);
       });
     });
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -7,7 +7,12 @@ import wrap from 'mocha-wrap';
 
 import DayPicker, { calculateDimension } from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import DayPickerNavigation from '../../src/components/DayPickerNavigation';
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
+} from '../../constants';
 
 describe('DayPicker', () => {
   describe('#render', () => {
@@ -116,6 +121,14 @@ describe('DayPicker', () => {
     });
   });
 
+  describe('props.orientation === VERTICAL_SCROLLABLE', () => {
+    it('uses multiplyScrollableMonths instead of onNextMonthClick', () => {
+      const wrapper = shallow(<DayPicker orientation={VERTICAL_SCROLLABLE} />);
+      const nav = wrapper.find(DayPickerNavigation);
+      expect(nav.prop('onNextMonthClick')).to.equal(wrapper.instance().multiplyScrollableMonths);
+    });
+  });
+
   describe('#onPrevMonthClick', () => {
     let translateFirstDayPickerForAnimationSpy;
     beforeEach(() => {
@@ -170,6 +183,14 @@ describe('DayPicker', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().onNextMonthClick();
       expect(wrapper.state().monthTransition).to.equal('next');
+    });
+  });
+
+  describe('#multiplyScrollableMonths', () => {
+    it('increments scrollableMonthMultiple', () => {
+      const wrapper = shallow(<DayPicker />);
+      wrapper.instance().multiplyScrollableMonths();
+      expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
     });
   });
 


### PR DESCRIPTION
to: @majapw 

Adds a new orientation that makes `DayPicker` vertically scrollable instead of using pagination. This scrollable `DayPicker` will fill the height of its parent and show `numberOfMonths`.

Replaces this [previous PR](https://github.com/airbnb/react-dates/pull/244). I've separated css by component and threaded the new orientation property throughout.
