### PR TITLE
Adding text-align:left to container to override possible global styles.

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -3,6 +3,7 @@
 .DayPicker {
   background: $react-dates-color-white;
   position: relative;
+  text-align: left;
 }
 
 .DayPicker--horizontal {


### PR DESCRIPTION
Fixes #256, overriding global text-align style that causes the calendar grids to be positioned outside the grid container.