### PR TITLE
Fix issue when parent element of component has 'text-align:center',…

### DIFF
--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -3,6 +3,7 @@ $react-dates-width-day-picker: 300px;
 .CalendarMonthGrid {
   background: #fff;
   z-index: 0;
+  text-align: left;
 }
 
 .CalendarMonthGrid--animating {


### PR DESCRIPTION
The calendar layout breaks when the DatePicker's parent element is 'text-align:center'. I fixed the problem.