### PR TITLE
Add aria-describedby attribute to date input

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,11 @@ If the `required` prop is set to true, the input will have to be filled before t
   required: PropTypes.bool,
 ```
 
+The `screenReaderInputMessage` prop accepts a contextual message for screen readers. When an input is focused, the `screenReaderInputMessage` prop value is read. This can inform users about constraints, such as the date format, minimum nights, blocked out dates, etc.
+```
+  screenReaderInputMessage: PropTypes.string,
+```
+
 **Custom Navigation Icons:**
 
 The `navPrev` and `navNext` props are used to assign custom icons to the "Next", and "Previous" arrows for the top navigation. If you do specify a custom icon you'll have to do the styling of the button yourself (e.g. the color, border, and things of that nature). All that comes "out of the box" is your button being positioned correctly.

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -8,6 +8,7 @@ const propTypes = {
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
   inputValue: PropTypes.string,
+  screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -23,6 +24,7 @@ const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
   inputValue: '',
+  screenReaderMessage: '',
   focused: false,
   disabled: false,
   required: false,
@@ -92,6 +94,7 @@ export default class DateInput extends React.Component {
       placeholder,
       displayValue,
       inputValue,
+      screenReaderMessage,
       focused,
       showCaret,
       onFocus,
@@ -101,6 +104,7 @@ export default class DateInput extends React.Component {
 
     const displayText = displayValue || inputValue || dateString || placeholder || '';
     const value = inputValue || displayValue || dateString || '';
+    const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     return (
       <div
@@ -125,7 +129,14 @@ export default class DateInput extends React.Component {
           disabled={disabled}
           readOnly={this.isTouchDevice}
           required={required}
+          aria-describedby={screenReaderMessage && screenReaderMessageId}
         />
+
+        {screenReaderMessage &&
+          <p id={screenReaderMessageId} className="screen-reader-only">
+            {screenReaderMessage}
+          </p>
+        }
 
         <div
           className={cx('DateInput__display-text', {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -32,6 +32,7 @@ const defaultProps = {
   startDateId: START_DATE,
   endDateId: END_DATE,
   focusedInput: null,
+  screenReaderInputMessage: '',
   minimumNights: 1,
   isDayBlocked: () => false,
   isDayHighlighted: () => false,
@@ -251,6 +252,7 @@ export default class DateRangePicker extends React.Component {
       endDateId,
       endDatePlaceholderText,
       focusedInput,
+      screenReaderInputMessage,
       showClearDates,
       showDefaultInputIcon,
       customInputIcon,
@@ -297,6 +299,7 @@ export default class DateRangePicker extends React.Component {
             onDatesChange={onDatesChange}
             onFocusChange={onFocusChange}
             phrases={phrases}
+            screenReaderMessage={screenReaderInputMessage}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -11,6 +11,7 @@ import { START_DATE, END_DATE } from '../../constants';
 const propTypes = {
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
+  screenReaderMessage: PropTypes.string,
 
   endDateId: PropTypes.string,
   endDatePlaceholderText: PropTypes.string,
@@ -49,6 +50,7 @@ const defaultProps = {
   endDateId: END_DATE,
   startDatePlaceholderText: 'Start Date',
   endDatePlaceholderText: 'End Date',
+  screenReaderMessage: '',
   onStartDateFocus() {},
   onEndDateFocus() {},
   onStartDateChange() {},
@@ -108,6 +110,7 @@ export default class DateRangePickerInput extends React.Component {
       startDateValue,
       startDateId,
       startDatePlaceholderText,
+      screenReaderMessage,
       isStartDateFocused,
       onStartDateChange,
       onStartDateFocus,
@@ -153,6 +156,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={startDatePlaceholderText}
           displayValue={startDate}
           inputValue={startDateValue}
+          screenReaderMessage={screenReaderMessage}
           focused={isStartDateFocused}
           disabled={disabled}
           required={required}
@@ -172,6 +176,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={endDatePlaceholderText}
           displayValue={endDate}
           inputValue={endDateValue}
+          screenReaderMessage={screenReaderMessage}
           focused={isEndDateFocused}
           disabled={disabled}
           required={required}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -25,6 +25,7 @@ const propTypes = {
   endDatePlaceholderText: PropTypes.string,
   isEndDateFocused: PropTypes.bool,
 
+  screenReaderMessage: PropTypes.string,
   showClearDates: PropTypes.bool,
   showCaret: PropTypes.bool,
   showDefaultInputIcon: PropTypes.bool,
@@ -60,6 +61,7 @@ const defaultProps = {
   endDatePlaceholderText: 'End Date',
   isEndDateFocused: false,
 
+  screenReaderMessage: '',
   showClearDates: false,
   showCaret: false,
   showDefaultInputIcon: false,
@@ -195,6 +197,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
       endDateId,
       endDatePlaceholderText,
       isEndDateFocused,
+      screenReaderMessage,
       showClearDates,
       showCaret,
       showDefaultInputIcon,
@@ -237,6 +240,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
         onEndDateTab={this.onClearFocus}
         showClearDates={showClearDates}
         onClearDates={this.clearDates}
+        screenReaderMessage={screenReaderMessage}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -54,6 +54,7 @@ const defaultProps = {
   horizontalMargin: 0,
   withPortal: false,
   withFullScreenPortal: false,
+  screenReaderInputMessage: '',
   initialVisibleMonth: () => moment(),
 
   onPrevMonthClick() {},
@@ -332,6 +333,7 @@ export default class SingleDatePicker extends React.Component {
       phrases,
       withPortal,
       withFullScreenPortal,
+      screenReaderInputMessage,
     } = this.props;
 
     const dateString = this.getDateString(date);
@@ -358,6 +360,7 @@ export default class SingleDatePicker extends React.Component {
             onFocus={this.onFocus}
             onKeyDownShiftTab={this.onClearFocus}
             onKeyDownTab={this.onClearFocus}
+            screenReaderMessage={screenReaderInputMessage}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -9,6 +9,7 @@ const propTypes = {
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
   inputValue: PropTypes.string,
+  screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
@@ -31,6 +32,7 @@ const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
   inputValue: '',
+  screenReaderMessage: '',
   focused: false,
   disabled: false,
   required: false,
@@ -90,6 +92,7 @@ export default class SingleDatePickerInput extends React.Component {
       onFocus,
       onKeyDownShiftTab,
       onKeyDownTab,
+      screenReaderMessage,
     } = this.props;
 
     return (
@@ -99,6 +102,7 @@ export default class SingleDatePickerInput extends React.Component {
           placeholder={placeholder} // also used as label
           displayValue={displayValue}
           inputValue={inputValue}
+          screenReaderMessage={screenReaderMessage}
           focused={focused}
           disabled={disabled}
           required={required}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -9,6 +9,7 @@ export default {
   startDate: momentPropTypes.momentObj,
   endDate: momentPropTypes.momentObj,
   focusedInput: FocusedInputShape,
+  screenReaderInputMessage: PropTypes.string,
   minimumNights: PropTypes.number,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -14,6 +14,7 @@ export default {
   keepOpenOnDateSelect: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  screenReaderInputMessage: PropTypes.string,
 
   onDateChange: PropTypes.func,
   onFocusChange: PropTypes.func,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -276,4 +276,9 @@ storiesOf('DateRangePicker', module)
     <DateRangePickerWrapper
       customArrowIcon={<TestCustomArrowIcon />}
     />
+  ))
+  .addWithInfo('with screen reader message', () => (
+    <DateRangePickerWrapper
+      screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
+    />
   ));

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -136,4 +136,9 @@ storiesOf('SingleDatePicker', module)
       numberOfMonths={1}
       enableOutsideDays
     />
+  ))
+  .addWithInfo('with screen reader message', () => (
+    <SingleDatePickerWrapper
+      screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
+    />
   ));

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -62,6 +62,50 @@ describe('DateInput', () => {
       );
     });
 
+    describe('screen reader message', () => {
+      let wrapper;
+      const inputId = 'date';
+      const screenReaderMessage = 'My screen reader message';
+      const screenReaderMessageId = `DateInput__screen-reader-message-${inputId}`;
+      const screenReaderMessageSelector = `#${screenReaderMessageId}`;
+
+      describe('props.screenReaderMessage is truthy', () => {
+        beforeEach(() => {
+          wrapper = shallow(<DateInput id={inputId} screenReaderMessage={screenReaderMessage} />);
+        });
+
+        it('has #DateInput__screen-reader-message id', () => {
+          expect(wrapper.find(screenReaderMessageSelector)).to.have.lengthOf(1);
+        });
+
+        it('has props.screenReaderMessage as content', () => {
+          expect(wrapper.find(screenReaderMessageSelector).text()).to.equal(screenReaderMessage);
+        });
+
+        it('has .screen-reader-only class', () => {
+          expect(wrapper.find(screenReaderMessageSelector).is('.screen-reader-only')).to.equal(true);
+        });
+
+        it('has aria-describedby attribute === screen reader message id', () => {
+          expect(wrapper.find(`input[aria-describedby="${screenReaderMessageId}"]`)).to.have.lengthOf(1);
+        });
+      });
+
+      describe('props.screenReaderMessage is falsey', () => {
+        beforeEach(() => {
+          wrapper = shallow(<DateInput id={inputId} />);
+        });
+
+        it('does not have #DateInput__screen-reader-message id', () => {
+          expect(wrapper.find(screenReaderMessageSelector)).to.have.lengthOf(0);
+        });
+
+        it('does not have aria-describedby attribute value', () => {
+          expect(wrapper.find(`input[aria-describedby="${screenReaderMessageId}"]`)).to.have.lengthOf(0);
+        });
+      });
+    });
+
     describe('display text', () => {
       it('has .DateInput__display-text class', () => {
         const wrapper = shallow(<DateInput id="date" />);


### PR DESCRIPTION
When using a screen reader you are able to type in a date but you don't know about any restrictions the date component might have.

This pull request adds the ability to inform screen reader users about the constraints of the component they are using via the `aria-describedby` attribute.

Any text passed into the new `screenReaderInputMessage` prop will be read out when a screen reader user interacts with the input.

Closes #261 