### PR TITLE
Fixes regression where user was unable to type into the input field

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -100,7 +100,7 @@ export default class DateInput extends React.Component {
     } = this.props;
 
     const displayText = displayValue || inputValue || dateString || placeholder || '';
-    const value = inputValue || displayValue || '';
+    const value = inputValue || displayValue || dateString || '';
 
     return (
       <div

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -56,6 +56,17 @@ describe('DateInput', () => {
         const wrapper = shallow(<DateInput id="date" displayValue={DISPLAY_VALUE} />);
         expect(wrapper.find('input').props().value).to.equal(DISPLAY_VALUE);
       });
+
+      it('has value === state.dateString if neither inputValue or displayValue are passed in',
+        () => {
+          const DATE_STRING = 'foobar';
+          const wrapper = shallow(<DateInput id="date" />);
+          wrapper.setState({
+            dateString: DATE_STRING,
+          });
+          expect(wrapper.find('input').props().value).to.equal(DATE_STRING);
+        },
+      );
     });
 
     describe('display text', () => {


### PR DESCRIPTION
Fix for a regression created in https://github.com/airbnb/react-dates/pull/229.

Thanks @timhwang21 for bringing it up here - https://github.com/airbnb/react-dates/issues/79#issuecomment-275445176

I even added a test @ljharb!

PTAL @airbnb/webinfra 