### PR TITLE
Remove mouse{down,up} and touch{start,end,tap}

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,18 +457,13 @@ Then, every Friday in the visible calendar would have the class `CalendarMonth__
 
 **Day interaction callbacks:**
 
-These callbacks get triggered when the relevant event ('click', 'mousedown', etc.) occurs on any visible `CalendarDay` component. The callback gets back 3 arguments, the day represented as a moment object, an array of strings representing the modifiers that are applicable to that day, and the event object itself.
+These callbacks get triggered when the relevant event ('click', 'mouseenter', etc.) occurs on any visible `CalendarDay` component. The callback gets back 3 arguments, the day represented as a moment object, an array of strings representing the modifiers that are applicable to that day, and the event object itself.
 
 `onDayTouchTap` has been implemented in-house and has not yet been thoroughly tested. We recommend using `onDayClick` whenever possible.
 ```
   onDayClick: PropTypes.func,
-  onDayMouseDown: PropTypes.func,
-  onDayMouseUp: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onDayTouchStart: PropTypes.func,
-  onDayTouchEnd: PropTypes.func,
-  onDayTouchTap: PropTypes.func,
 ```
 
 **Some other useful callbacks:**

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -3,38 +3,21 @@ import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 
-export const TOUCHSTART_TIMEOUT = 200;
-
 const propTypes = {
   day: momentPropTypes.momentObj,
   onDayClick: PropTypes.func,
-  onDayMouseDown: PropTypes.func,
-  onDayMouseUp: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onDayTouchStart: PropTypes.func,
-  onDayTouchEnd: PropTypes.func,
-  onDayTouchTap: PropTypes.func,
 };
 
 const defaultProps = {
   day: moment(),
   onDayClick() {},
-  onDayMouseDown() {},
-  onDayMouseUp() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  onDayTouchStart() {},
-  onDayTouchEnd() {},
-  onDayTouchTap() {},
 };
 
 export default class CalendarDay extends React.Component {
-  constructor(props) {
-    super(props);
-    this.hasActiveTouchStart = false;
-  }
-
   shouldComponentUpdate(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   }
@@ -42,16 +25,6 @@ export default class CalendarDay extends React.Component {
   onDayClick(day, e) {
     const { onDayClick } = this.props;
     onDayClick(day, e);
-  }
-
-  onDayMouseDown(day, e) {
-    const { onDayMouseDown } = this.props;
-    onDayMouseDown(day, e);
-  }
-
-  onDayMouseUp(day, e) {
-    const { onDayMouseUp } = this.props;
-    onDayMouseUp(day, e);
   }
 
   onDayMouseEnter(day, e) {
@@ -64,31 +37,6 @@ export default class CalendarDay extends React.Component {
     onDayMouseLeave(day, e);
   }
 
-  onDayTouchStart(day, e) {
-    const { onDayTouchStart } = this.props;
-    this.hasActiveTouchStart = true;
-    setTimeout(() => {
-      this.hasActiveTouchStart = false;
-    }, TOUCHSTART_TIMEOUT);
-
-    onDayTouchStart(day, e);
-  }
-
-  onDayTouchEnd(day, e) {
-    const { onDayTouchEnd } = this.props;
-    if (this.hasActiveTouchStart) {
-      this.hasActiveTouchStart = false;
-      this.onDayTouchTap(day, e);
-    }
-
-    onDayTouchEnd(day, e);
-  }
-
-  onDayTouchTap(day, e) {
-    const { onDayTouchTap } = this.props;
-    onDayTouchTap(day, e);
-  }
-
   render() {
     const { day } = this.props;
 
@@ -97,11 +45,7 @@ export default class CalendarDay extends React.Component {
         className="CalendarDay"
         onMouseEnter={e => this.onDayMouseEnter(day, e)}
         onMouseLeave={e => this.onDayMouseLeave(day, e)}
-        onMouseDown={e => this.onDayMouseDown(day, e)}
-        onMouseUp={e => this.onDayMouseUp(day, e)}
         onClick={e => this.onDayClick(day, e)}
-        onTouchStart={e => this.onDayTouchStart(day, e)}
-        onTouchEnd={e => this.onDayTouchEnd(day, e)}
       >
         <span className="CalendarDay__day">{day.format('D')}</span>
       </div>

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -25,13 +25,8 @@ const propTypes = {
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
   onDayClick: PropTypes.func,
-  onDayMouseDown: PropTypes.func,
-  onDayMouseUp: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onDayTouchStart: PropTypes.func,
-  onDayTouchEnd: PropTypes.func,
-  onDayTouchTap: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -44,13 +39,8 @@ const defaultProps = {
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   onDayClick() {},
-  onDayMouseDown() {},
-  onDayMouseUp() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  onDayTouchStart() {},
-  onDayTouchEnd() {},
-  onDayTouchTap() {},
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -89,13 +79,8 @@ export default class CalendarMonth extends React.Component {
       isVisible,
       modifiers,
       onDayClick,
-      onDayMouseDown,
-      onDayMouseUp,
       onDayMouseEnter,
       onDayMouseLeave,
-      onDayTouchStart,
-      onDayTouchEnd,
-      onDayTouchTap,
     } = this.props;
 
     const { weeks } = this.state;
@@ -130,12 +115,7 @@ export default class CalendarMonth extends React.Component {
                           day={day}
                           onDayMouseEnter={onDayMouseEnter}
                           onDayMouseLeave={onDayMouseLeave}
-                          onDayMouseDown={onDayMouseDown}
-                          onDayMouseUp={onDayMouseUp}
                           onDayClick={onDayClick}
-                          onDayTouchStart={onDayTouchStart}
-                          onDayTouchEnd={onDayTouchEnd}
-                          onDayTouchTap={onDayTouchTap}
                         />
                       }
                     </td>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -27,13 +27,8 @@ const propTypes = {
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
   onDayClick: PropTypes.func,
-  onDayMouseDown: PropTypes.func,
-  onDayMouseUp: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onDayTouchStart: PropTypes.func,
-  onDayTouchEnd: PropTypes.func,
-  onDayTouchTap: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
   transformValue: PropTypes.string,
 
@@ -50,13 +45,8 @@ const defaultProps = {
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   onDayClick() {},
-  onDayMouseDown() {},
-  onDayMouseUp() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  onDayTouchStart() {},
-  onDayTouchEnd() {},
-  onDayTouchTap() {},
   onMonthTransitionEnd() {},
   transformValue: 'none',
 
@@ -160,12 +150,7 @@ export default class CalendarMonthGrid extends React.Component {
       transformValue,
       onDayMouseEnter,
       onDayMouseLeave,
-      onDayMouseDown,
-      onDayMouseUp,
       onDayClick,
-      onDayTouchStart,
-      onDayTouchEnd,
-      onDayTouchTap,
       onMonthTransitionEnd,
     } = this.props;
 
@@ -200,12 +185,7 @@ export default class CalendarMonthGrid extends React.Component {
               orientation={orientation}
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
-              onDayMouseDown={onDayMouseDown}
-              onDayMouseUp={onDayMouseUp}
               onDayClick={onDayClick}
-              onDayTouchStart={onDayTouchStart}
-              onDayTouchEnd={onDayTouchEnd}
-              onDayTouchTap={onDayTouchTap}
             />
           );
         })}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -6,7 +6,6 @@ import cx from 'classnames';
 import Portal from 'react-portal';
 
 import OutsideClickHandler from './OutsideClickHandler';
-import isTouchDevice from '../utils/isTouchDevice';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
@@ -76,8 +75,6 @@ export default class DateRangePicker extends React.Component {
     this.state = {
       dayPickerContainerStyles: {},
     };
-
-    this.isTouchDevice = isTouchDevice();
 
     this.onOutsideClick = this.onOutsideClick.bind(this);
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -37,13 +37,8 @@ const propTypes = {
   navNext: PropTypes.node,
 
   onDayClick: PropTypes.func,
-  onDayMouseDown: PropTypes.func,
-  onDayMouseUp: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onDayTouchStart: PropTypes.func,
-  onDayTouchEnd: PropTypes.func,
-  onDayTouchTap: PropTypes.func,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
@@ -66,13 +61,8 @@ const defaultProps = {
   navNext: null,
 
   onDayClick() {},
-  onDayMouseDown() {},
-  onDayMouseUp() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  onDayTouchStart() {},
-  onDayTouchTap() {},
-  onDayTouchEnd() {},
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onOutsideClick() {},
@@ -380,11 +370,6 @@ export default class DayPicker extends React.Component {
       modifiers,
       withPortal,
       onDayClick,
-      onDayMouseDown,
-      onDayMouseUp,
-      onDayTouchStart,
-      onDayTouchEnd,
-      onDayTouchTap,
       onDayMouseEnter,
       onDayMouseLeave,
       onOutsideClick,
@@ -467,11 +452,6 @@ export default class DayPicker extends React.Component {
               withPortal={withPortal}
               numberOfMonths={numberOfMonths * scrollableMonthMultiple}
               onDayClick={onDayClick}
-              onDayMouseDown={onDayMouseDown}
-              onDayMouseUp={onDayMouseUp}
-              onDayTouchStart={onDayTouchStart}
-              onDayTouchEnd={onDayTouchEnd}
-              onDayTouchTap={onDayTouchTap}
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onMonthTransitionEnd={this.updateStateAfterMonthTransition}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -267,10 +267,9 @@ export default class DayPickerRangeController extends React.Component {
         enableOutsideDays={enableOutsideDays}
         modifiers={modifiers}
         numberOfMonths={numberOfMonths}
+        onDayClick={this.onDayClick}
         onDayMouseEnter={this.onDayMouseEnter}
         onDayMouseLeave={this.onDayMouseLeave}
-        onDayMouseDown={this.onDayClick}
-        onDayTouchTap={this.onDayClick}
         onPrevMonthClick={onPrevMonthClick}
         onNextMonthClick={onNextMonthClick}
         monthFormat={monthFormat}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -290,10 +290,9 @@ export default class SingleDatePicker extends React.Component {
           enableOutsideDays={enableOutsideDays}
           modifiers={modifiers}
           numberOfMonths={numberOfMonths}
+          onDayClick={this.onDayClick}
           onDayMouseEnter={this.onDayMouseEnter}
           onDayMouseLeave={this.onDayMouseLeave}
-          onDayMouseDown={this.onDayClick}
-          onDayTouchTap={this.onDayClick}
           onPrevMonthClick={onPrevMonthClick}
           onNextMonthClick={onNextMonthClick}
           monthFormat={monthFormat}

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -4,16 +4,9 @@ import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import CalendarDay, { TOUCHSTART_TIMEOUT } from '../../src/components/CalendarDay';
+import CalendarDay from '../../src/components/CalendarDay';
 
 describe('CalendarDay', () => {
-  describe('#constructor', () => {
-    it('sets this.hasActiveTouchStart to false initially', () => {
-      const wrapperInstance = shallow(<CalendarDay isOutsideDay />).instance();
-      expect(wrapperInstance.hasActiveTouchStart).to.equal(false);
-    });
-  });
-
   describe('#render', () => {
     it('is .CalendarDay class', () => {
       const wrapper = shallow(<CalendarDay />);
@@ -62,54 +55,6 @@ describe('CalendarDay', () => {
     });
   });
 
-  describe('#onDayMouseDown', () => {
-    let onDayMouseDownSpy;
-    beforeEach(() => {
-      onDayMouseDownSpy = sinon.spy(CalendarDay.prototype, 'onDayMouseDown');
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('gets triggered by mousedown', () => {
-      const wrapper = shallow(<CalendarDay />);
-      wrapper.simulate('mousedown');
-      expect(onDayMouseDownSpy).to.have.property('callCount', 1);
-    });
-
-    it('calls props.onDayMouseDown', () => {
-      const onMouseDownStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayMouseDown={onMouseDownStub} />);
-      wrapper.instance().onDayMouseDown();
-      expect(onMouseDownStub).to.have.property('callCount', 1);
-    });
-  });
-
-  describe('#onDayMouseUp', () => {
-    let onDayMouseUpSpy;
-    beforeEach(() => {
-      onDayMouseUpSpy = sinon.spy(CalendarDay.prototype, 'onDayMouseUp');
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('gets triggered by mouseup', () => {
-      const wrapper = shallow(<CalendarDay />);
-      wrapper.simulate('mouseup');
-      expect(onDayMouseUpSpy).to.have.property('callCount', 1);
-    });
-
-    it('calls props.onDayMouseUp', () => {
-      const onMouseUpStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayMouseUp={onMouseUpStub} />);
-      wrapper.instance().onDayMouseUp();
-      expect(onMouseUpStub).to.have.property('callCount', 1);
-    });
-  });
-
   describe('#onDayMouseEnter', () => {
     let onDayMouseEnterSpy;
     beforeEach(() => {
@@ -155,103 +100,6 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay onDayMouseLeave={onMouseLeaveStub} />);
       wrapper.instance().onDayMouseLeave();
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
-    });
-  });
-
-  describe('#onDayTouchStart', () => {
-    let onDayTouchStartSpy;
-    let useFakeTimers;
-    beforeEach(() => {
-      onDayTouchStartSpy = sinon.spy(CalendarDay.prototype, 'onDayTouchStart');
-      useFakeTimers = sinon.useFakeTimers();
-    });
-
-    it('gets triggered by touchstart', () => {
-      const wrapper = shallow(<CalendarDay />);
-      wrapper.simulate('touchstart');
-      expect(onDayTouchStartSpy).to.have.property('callCount', 1);
-    });
-
-    it('sets this.hasActiveTouchStart to true', () => {
-      const wrapperInstance = shallow(<CalendarDay />).instance();
-      wrapperInstance.onDayTouchStart();
-      expect(wrapperInstance.hasActiveTouchStart).to.equal(true);
-    });
-
-    it('sets this.hasActiveTouchStart to false after TOUCHSTART_TIMEOUT ms have passed', () => {
-      const wrapperInstance = shallow(<CalendarDay />).instance();
-      wrapperInstance.onDayTouchStart();
-      expect(wrapperInstance.hasActiveTouchStart).to.equal(true);
-      useFakeTimers.tick(TOUCHSTART_TIMEOUT);
-      expect(wrapperInstance.hasActiveTouchStart).to.equal(false);
-    });
-
-    it('calls props.onDayTouchStart', () => {
-      const onDayTouchStartStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayTouchStart={onDayTouchStartStub} />);
-      wrapper.instance().onDayTouchStart();
-      expect(onDayTouchStartStub).to.have.property('callCount', 1);
-    });
-
-    afterEach(() => {
-      sinon.restore();
-      useFakeTimers.restore();
-    });
-  });
-
-  describe('#onDayTouchEnd', () => {
-    let onDayTouchEndSpy;
-    let onDayTouchTapSpy;
-    beforeEach(() => {
-      onDayTouchEndSpy = sinon.spy(CalendarDay.prototype, 'onDayTouchEnd');
-      onDayTouchTapSpy = sinon.spy(CalendarDay.prototype, 'onDayTouchTap');
-    });
-
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('gets triggered by touchend', () => {
-      const wrapper = shallow(<CalendarDay />);
-      wrapper.simulate('touchend');
-      expect(onDayTouchEndSpy).to.have.property('callCount', 1);
-    });
-
-    it('calls onDayTouchTap if this.hasActiveTouchStart', () => {
-      const wrapperInstance = shallow(<CalendarDay />).instance();
-      wrapperInstance.hasActiveTouchStart = true;
-      wrapperInstance.onDayTouchEnd();
-      expect(onDayTouchTapSpy).to.have.property('callCount', 1);
-    });
-
-    it('sets this.hasActiveTouchStart to false if this.hasActiveTouchStart', () => {
-      const wrapperInstance = shallow(<CalendarDay />).instance();
-      wrapperInstance.hasActiveTouchStart = true;
-      wrapperInstance.onDayTouchEnd();
-      expect(wrapperInstance.hasActiveTouchStart).to.equal(false);
-    });
-
-    it('does not call onDayTouchTap if !this.hasActiveTouchStart', () => {
-      const wrapperInstance = shallow(<CalendarDay />).instance();
-      wrapperInstance.hasActiveTouchStart = false;
-      wrapperInstance.onDayTouchEnd();
-      expect(onDayTouchTapSpy.called).to.equal(false);
-    });
-
-    it('calls props.onDayTouchEnd', () => {
-      const onDayTouchEndStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayTouchEnd={onDayTouchEndStub} />);
-      wrapper.instance().onDayTouchEnd();
-      expect(onDayTouchEndStub).to.have.property('callCount', 1);
-    });
-  });
-
-  describe('#onDayTouchTap', () => {
-    it('calls props.onDayTouchTap', () => {
-      const onDayTouchTapStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayTouchTap={onDayTouchTapStub} />);
-      wrapper.instance().onDayTouchTap();
-      expect(onDayTouchTapStub).to.have.property('callCount', 1);
     });
   });
 });


### PR DESCRIPTION
to: @majapw 

Replaces mouse and touch handlers in favor of `onClick`/`onDayClick`. I think these mouse/touch handlers support functionality that's no longer used. This change should improve scroll performance on mobile because the browser doesn't need to interrupt scrolling to handle touchstart/end.