### PR TITLE
Added prop and tests for custom arrow icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Optionally, you can display a React node using `props.customInputIcon`
   customInputIcon: PropTypes.node
 ```
 
+To replace the default arrow icon, you may pass a React node to `props.customArrowIcon`.
+```
+  customArrowIcon: PropTypes.node
+```
+
 If the `disabled` prop is set to true, onFocusChange is not called when onStartDateFocus or onEndDateFocus are invoked and disabled is assigned to the actual `<input>` DOM elements.
 ```
   disabled: PropTypes.bool,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -42,6 +42,7 @@ const defaultProps = {
   showClearDates: false,
   showDefaultInputIcon: false,
   customInputIcon: null,
+  customArrowIcon: null,
   disabled: false,
   required: false,
   reopenPickerOnClearDates: false,
@@ -256,6 +257,7 @@ export default class DateRangePicker extends React.Component {
       showClearDates,
       showDefaultInputIcon,
       customInputIcon,
+      customArrowIcon,
       disabled,
       required,
       phrases,
@@ -288,6 +290,7 @@ export default class DateRangePicker extends React.Component {
             showCaret={!withPortal && !withFullScreenPortal}
             showDefaultInputIcon={showDefaultInputIcon}
             customInputIcon={customInputIcon}
+            customArrowIcon={customArrowIcon}
             disabled={disabled}
             required={required}
             reopenPickerOnClearDates={reopenPickerOnClearDates}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -36,6 +36,7 @@ const propTypes = {
   showCaret: PropTypes.bool,
   showDefaultInputIcon: PropTypes.bool,
   customInputIcon: PropTypes.node,
+  customArrowIcon: PropTypes.node,
 
   // i18n
   phrases: PropTypes.shape({
@@ -69,6 +70,7 @@ const defaultProps = {
   showCaret: false,
   showDefaultInputIcon: false,
   customInputIcon: null,
+  customArrowIcon: null,
 
   // i18n
   phrases: {
@@ -125,10 +127,12 @@ export default class DateRangePickerInput extends React.Component {
       showCaret,
       showDefaultInputIcon,
       customInputIcon,
+      customArrowIcon,
       phrases,
     } = this.props;
 
     const inputIcon = customInputIcon || (<CalendarIcon />);
+    const arrowIcon = customArrowIcon || (<RightArrow />);
 
     return (
       <div
@@ -160,7 +164,7 @@ export default class DateRangePickerInput extends React.Component {
         />
 
         <div className="DateRangePickerInput__arrow">
-          <RightArrow />
+          {arrowIcon}
         </div>
 
         <DateInput

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -41,6 +41,7 @@ const propTypes = {
   onDatesChange: PropTypes.func,
 
   customInputIcon: PropTypes.node,
+  customArrowIcon: PropTypes.node,
 
   // i18n
   phrases: PropTypes.shape({
@@ -75,6 +76,7 @@ const defaultProps = {
   onDatesChange() {},
 
   customInputIcon: null,
+  customArrowIcon: null,
 
   // i18n
   phrases: {
@@ -197,6 +199,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
       showCaret,
       showDefaultInputIcon,
       customInputIcon,
+      customArrowIcon,
       disabled,
       required,
       phrases,
@@ -224,6 +227,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
         showCaret={showCaret}
         showDefaultInputIcon={showDefaultInputIcon}
         customInputIcon={customInputIcon}
+        customArrowIcon={customArrowIcon}
         phrases={phrases}
         onStartDateChange={this.onStartDateChange}
         onStartDateFocus={this.onStartDateFocus}

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -75,6 +75,19 @@ const TestCustomInputIcon = () => (
   </span>
 );
 
+const TestCustomArrowIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
+    }}
+  >
+    ->
+  </span>
+);
+
 class TestWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -257,5 +270,10 @@ storiesOf('DateRangePicker', module)
   .addWithInfo('with custom show calendar icon', () => (
     <DateRangePickerWrapper
       customInputIcon={<TestCustomInputIcon />}
+    />
+  ))
+  .addWithInfo('with custom arrow icon', () => (
+    <DateRangePickerWrapper
+      customArrowIcon={<TestCustomArrowIcon />}
     />
   ));

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -107,6 +107,16 @@ describe('DateRangePickerInput', () => {
     });
   });
 
+  describe('props.customArrowIcon is a React Element', () => {
+    it('has custom icon', () => {
+      const wrapper = shallow(
+        <DateRangePickerInput
+          customArrowIcon={<span className="custom-arrow-icon" />}
+        />);
+      expect(wrapper.find('.DateRangePickerInput__calendar-icon .custom-arrow-icon'));
+    });
+  });
+
   describe('#onClearDatesMouseEnter', () => {
     it('sets state.isClearDatesHovered to true', () => {
       const wrapper = shallow(<DateRangePickerInput />);


### PR DESCRIPTION
This PR adds functionality for customizing the arrow icon between two dates in the date range picker, following the exact same pattern as the other custom icon props.