### PR TITLE
Fix duplicate months

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -111,14 +111,7 @@ export default class CalendarMonthGrid extends React.Component {
     }
 
     if (hasNumberOfMonthsChanged) {
-      if (this.props.numberOfMonths < numberOfMonths) {
-        newMonths = months.slice();
-        for (let i = 0; i < numberOfMonths - this.props.numberOfMonths; i += 1) {
-          newMonths.push(months[months.length - 1].clone().add(i, 'month'));
-        }
-      } else {
-        newMonths = months.slice(0, numberOfMonths + 3);
-      }
+      newMonths = getMonths(initialMonth, numberOfMonths);
     }
 
     this.setState({
@@ -191,7 +184,7 @@ export default class CalendarMonthGrid extends React.Component {
             (i >= firstVisibleMonthIndex) && (i < firstVisibleMonthIndex + numberOfMonths);
           return (
             <CalendarMonth
-              key={month.month()}
+              key={month.format('YYYY-MM')}
               month={month}
               isVisible={isVisible}
               enableOutsideDays={enableOutsideDays}

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import moment from 'moment';
 
 import CalendarMonth from '../../src/components/CalendarMonth';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
@@ -50,5 +51,27 @@ describe('CalendarMonthGrid', () => {
     Object.keys(transformStyles).forEach((key) => {
       expect(wrapper.prop('style')[key]).to.equal(transformStyles[key]);
     });
+  });
+
+  it('does not generate duplicate months', () => {
+    const initialMonth = moment();
+    const wrapper = shallow(<CalendarMonthGrid numberOfMonths={12} initialMonth={initialMonth} />);
+
+    wrapper.instance().componentWillReceiveProps({
+      initialMonth,
+      numberOfMonths: 24,
+    });
+
+    const months = wrapper.state().months;
+
+    const collisions = months
+      .map(m => m.format('YYYY-MM'))
+      .reduce((acc, m) => Object.assign(
+        {},
+        acc,
+        { [m]: true },
+      ), {});
+
+    expect(Object.keys(collisions).length).to.equal(months.length);
   });
 });


### PR DESCRIPTION
to: @majapw @ljharb 

This PR fixes two issues related to duplicate months in `CalendarMonthGrid`:

* When increasing `numberOfMonths`, the last month was [duplicated in the first iteration of this loop](https://github.com/airbnb/react-dates/compare/master...moonboots:fix-month-conflict?expand=1#diff-ed0d63b6cfc2e8bdb08f69f4867c47a8L117). I simplified to reuse the `getMonths` logic instead of updating piecemeal. This should only be called when `numberOfMonths` changes, and it shouldn't affect the original perf improvements.
* Include year in `CalendarMonth` key to allow more than 12 months. Otherwise, React will only render the first occurrence and print `Warning: flattenChildren(...): Encountered two children with the same key`.
