### PR TITLE
Use `aria-label` instead of visually hidden label

### DIFF
--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -42,17 +42,6 @@ $caret-top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-ar
   background: $react-dates-color-gray-lighter;
 }
 
-.DateInput__label {
-  border: 0;
-  clip: rect(0, 0, 0, 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
 .DateInput__input {
   opacity: 0;
   position: absolute;

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -109,11 +109,8 @@ export default class DateInput extends React.Component {
           'DateInput--disabled': disabled,
         })}
       >
-        <label className="DateInput__label" htmlFor={id}>
-          {placeholder}
-        </label>
-
         <input
+          aria-label={placeholder}
           className="DateInput__input"
           type="text"
           id={id}

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -26,20 +26,13 @@ describe('DateInput', () => {
       });
     });
 
-    describe('label', () => {
-      it('has .DateInput__label class', () => {
-        const wrapper = shallow(<DateInput id="date" />);
-        expect(wrapper.find('label').is('.DateInput__label')).to.equal(true);
-      });
-
-      it('has props.placeholder as content', () => {
+    describe('input', () => {
+      it('has props.placeholder as an aria-label if prop is passed in', () => {
         const placeholder = 'placeholder_foo';
         const wrapper = shallow(<DateInput id="date" placeholder={placeholder} />);
-        expect(wrapper.find('label').text()).to.equal(placeholder);
+        expect(wrapper.find('input').props()['aria-label']).to.equal(placeholder);
       });
-    });
 
-    describe('input', () => {
       it('has .DateInput__input class', () => {
         const wrapper = shallow(<DateInput id="date" />);
         expect(wrapper.find('input').is('.DateInput__input')).to.equal(true);


### PR DESCRIPTION
Instead of using a `label` element with CSS to visually hide it, use the
`aria-label` property on the `input` element itself. Having hidden text for
screen readers could cause the label value to be read aloud twice by the screen
reader: first when navigating nodes in the form, and then again when focusing
the input.