### PR TITLE
[Issue 127] Render arbitrary content in CalendarDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ The `navPrev` and `navNext` props are used to assign custom icons to the "Next",
   navNext: PropTypes.node,
 ```
 
+**Custom content in calendar days:**
+
+If you want to add content to a specific day on the calendar, you can specify a `renderDetails` function which receives the `day` moment object as its only argument. Return either a valid JSX node to render (`element|string`) or something falsy (`false|null|undefined`).
+```
+  renderDetails: PropTypes.func,
+```
+
 **Some useful callbacks:**
 
 If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -8,6 +8,7 @@ const propTypes = {
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  renderDetails: PropTypes.func,
 };
 
 const defaultProps = {
@@ -15,6 +16,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  renderDetails: null,
 };
 
 export default class CalendarDay extends React.Component {
@@ -38,7 +40,7 @@ export default class CalendarDay extends React.Component {
   }
 
   render() {
-    const { day } = this.props;
+    const { day, renderDetails } = this.props;
 
     return (
       <div
@@ -48,6 +50,9 @@ export default class CalendarDay extends React.Component {
         onClick={e => this.onDayClick(day, e)}
       >
         <span className="CalendarDay__day">{day.format('D')}</span>
+        {renderDetails && (
+          <span className="CalendarDay__details">{renderDetails(day)}</span>
+        )}
       </div>
     );
   }

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -39,14 +39,9 @@ export default class CalendarDay extends React.Component {
     onDayMouseLeave(day, e);
   }
 
-  maybeRenderDetails(day) {
-    const { renderDetails } = this.props;
-    return renderDetails(day);
-  }
-
   render() {
-    const { day } = this.props;
-    const details = this.maybeRenderDetails(day);
+    const { day, renderDetails } = this.props;
+    const details = renderDetails(day);
     return (
       <div
         className="CalendarDay"

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -16,7 +16,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  renderDetails: null,
+  renderDetails() {},
 };
 
 export default class CalendarDay extends React.Component {
@@ -39,9 +39,14 @@ export default class CalendarDay extends React.Component {
     onDayMouseLeave(day, e);
   }
 
-  render() {
-    const { day, renderDetails } = this.props;
+  maybeRenderDetails(day) {
+    const { renderDetails } = this.props;
+    return renderDetails(day);
+  }
 
+  render() {
+    const { day } = this.props;
+    const details = this.maybeRenderDetails(day);
     return (
       <div
         className="CalendarDay"
@@ -50,8 +55,8 @@ export default class CalendarDay extends React.Component {
         onClick={e => this.onDayClick(day, e)}
       >
         <span className="CalendarDay__day">{day.format('D')}</span>
-        {renderDetails && (
-          <span className="CalendarDay__details">{renderDetails(day)}</span>
+        {details && (
+          <span className="CalendarDay__details">{details}</span>
         )}
       </div>
     );

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -27,6 +27,7 @@ const propTypes = {
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  renderDetails: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -41,6 +42,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  renderDetails: null,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -81,6 +83,7 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderDetails,
     } = this.props;
 
     const { weeks } = this.state;
@@ -116,6 +119,7 @@ export default class CalendarMonth extends React.Component {
                           onDayMouseEnter={onDayMouseEnter}
                           onDayMouseLeave={onDayMouseLeave}
                           onDayClick={onDayClick}
+                          renderDetails={renderDetails}
                         />
                       }
                     </td>

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -42,7 +42,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  renderDetails: null,
+  renderDetails() {},
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -30,6 +30,7 @@ const propTypes = {
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
+  renderDetails: PropTypes.func,
   transformValue: PropTypes.string,
 
   // i18n
@@ -48,6 +49,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
+  renderDetails: null,
   transformValue: 'none',
 
   // i18n
@@ -144,6 +146,7 @@ export default class CalendarMonthGrid extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
+      renderDetails,
       onMonthTransitionEnd,
     } = this.props;
 
@@ -179,6 +182,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
+              renderDetails={renderDetails}
             />
           );
         })}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -49,7 +49,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
-  renderDetails: null,
+  renderDetails() {},
   transformValue: 'none',
 
   // i18n

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -62,6 +62,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  renderDetails: null,
+
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
@@ -190,6 +192,7 @@ export default class DateRangePicker extends React.Component {
       endDate,
       minimumNights,
       keepOpenOnDateSelect,
+      renderDetails,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -225,6 +228,7 @@ export default class DateRangePicker extends React.Component {
           isDayHighlighted={isDayHighlighted}
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
+          renderDetails={renderDetails}
         />
 
         {withFullScreenPortal &&
@@ -268,6 +272,7 @@ export default class DateRangePicker extends React.Component {
       keepOpenOnDateSelect,
       onDatesChange,
       onFocusChange,
+      renderDetails,
     } = this.props;
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
@@ -298,6 +303,7 @@ export default class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={onFocusChange}
+            renderDetails={renderDetails}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
           />

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -62,7 +62,7 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
-  renderDetails: null,
+  renderDetails() {},
 
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -69,7 +69,7 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick() {},
 
-  renderDetails: null,
+  renderDetails() {},
   // i18n
   monthFormat: 'MMMM YYYY',
 };

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -43,6 +43,8 @@ const propTypes = {
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
 
+  renderDetails: PropTypes.func,
+
   // i18n
   monthFormat: PropTypes.string,
 };
@@ -67,6 +69,7 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick() {},
 
+  renderDetails: null,
   // i18n
   monthFormat: 'MMMM YYYY',
 };
@@ -372,6 +375,7 @@ export default class DayPicker extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderDetails,
       onOutsideClick,
       monthFormat,
     } = this.props;
@@ -454,6 +458,7 @@ export default class DayPicker extends React.Component {
               onDayClick={onDayClick}
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
+              renderDetails={renderDetails}
               onMonthTransitionEnd={this.updateStateAfterMonthTransition}
               monthFormat={monthFormat}
             />

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
+  renderDetails: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -81,6 +82,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onOutsideClick() {},
+
+  renderDetails: null,
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -236,6 +239,7 @@ export default class DayPickerRangeController extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      renderDetails,
     } = this.props;
 
     const modifiers = {
@@ -279,6 +283,7 @@ export default class DayPickerRangeController extends React.Component {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
+        renderDetails={renderDetails}
       />
     );
   }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -83,7 +83,7 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick() {},
 
-  renderDetails: null,
+  renderDetails() {},
 
   // i18n
   monthFormat: 'MMMM YYYY',

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -60,6 +60,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  renderDetails: null,
+
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
@@ -264,6 +266,7 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
+      renderDetails,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -303,6 +306,7 @@ export default class SingleDatePicker extends React.Component {
           onOutsideClick={onOutsideClick}
           navPrev={navPrev}
           navNext={navNext}
+          renderDetails={renderDetails}
         />
 
         {withFullScreenPortal &&

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -60,7 +60,7 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
-  renderDetails: null,
+  renderDetails() {},
 
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -40,6 +40,8 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  renderDetails: PropTypes.func,
+
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -38,6 +38,8 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  renderDetails: PropTypes.func,
+
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -277,8 +277,14 @@ storiesOf('DateRangePicker', module)
       customArrowIcon={<TestCustomArrowIcon />}
     />
   ))
+  .addWithInfo('with custom daily details', () => (
+    <DateRangePickerWrapper
+      renderDetails={day => day.format('ddd')}
+    />
+  ))
   .addWithInfo('with screen reader message', () => (
     <DateRangePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
   ));
+

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -60,6 +60,11 @@ storiesOf('DayPicker', module)
       navNext={<TestNextIcon />}
     />
   ))
+  .addWithInfo('with custom details', () => (
+    <DayPicker
+      renderDetails={day => day.day() % 6 === 5 && '😻'}
+    />
+  ))
   .addWithInfo('vertical with fixed-width container', () => (
     <div style={{ width: '400px' }}>
       <DayPicker

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -141,4 +141,10 @@ storiesOf('SingleDatePicker', module)
     <SingleDatePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
+  ))
+  .addWithInfo('with custom daily details', () => (
+    <SingleDatePickerWrapper
+      numberOfMonths={1}
+      renderDetails={day => day.format('ddd')}
+    />
   ));

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -108,4 +108,18 @@ describe('CalendarDay', () => {
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
     });
   });
+
+  describe('#maybeRenderDetails', () => {
+    it('returns nothing if props.renderDetails is not provided', () => {
+      const wrapper = shallow(<CalendarDay />);
+      const detail = wrapper.instance().maybeRenderDetails();
+      expect(detail).to.equal(undefined);
+    });
+
+    it('calls props.renderDetails from #render', () => {
+      const renderSpy = sinon.stub();
+      shallow(<CalendarDay renderDetails={renderSpy} />);
+      expect(renderSpy).to.have.property('callCount', 1);
+    });
+  });
 });

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -29,6 +29,12 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay day={lastOfMonth} />);
       expect(wrapper.text()).to.equal(lastOfMonth.format('D'));
     });
+
+    it('can render custom day output', () => {
+      const output = <div className="test">Stuff</div>;
+      const wrapper = shallow(<CalendarDay renderDetails={() => output} />);
+      expect(wrapper.find('.CalendarDay__details').contains(output)).to.equal(true);
+    });
   });
 
   describe('#onDayClick', () => {

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -108,18 +108,4 @@ describe('CalendarDay', () => {
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
     });
   });
-
-  describe('#maybeRenderDetails', () => {
-    it('returns nothing if props.renderDetails is not provided', () => {
-      const wrapper = shallow(<CalendarDay />);
-      const detail = wrapper.instance().maybeRenderDetails();
-      expect(detail).to.equal(undefined);
-    });
-
-    it('calls props.renderDetails from #render', () => {
-      const renderSpy = sinon.stub();
-      shallow(<CalendarDay renderDetails={renderSpy} />);
-      expect(renderSpy).to.have.property('callCount', 1);
-    });
-  });
 });


### PR DESCRIPTION
Re: #127

This PR adds a `renderDetails` method which, if provided, inserts a `<span className="CalendarDay__details"/>` into the `CalendarDay` square. 

I'm not married to the naming or the implementation; any/all criticism is welcome.

```js
/**
 * @param day - the Moment object representing the day
 * @returns {string|element} - returns anything that is valid in a JSX node: string, React element, null
 */
 // example
 // print a happy cat on Fridays
 <CalendarDay
   renderDetails={day => day.day() % 6 === 5 && '😻'} />
```

<img width="326" alt="screenshot 2017-02-01 17 36 44" src="https://cloud.githubusercontent.com/assets/971616/22529391/436007fc-e8a5-11e6-8f38-739a3faffe8f.png">