### PR TITLE
Fixes bug where dates were automatically iso over anything else due to a prop error

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "webpack": "^1.14.0"
   },
   "dependencies": {
+    "airbnb-prop-types": "^2.1.0",
     "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "react-moment-proptypes": "^1.2.1",

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -336,8 +336,8 @@ export default class SingleDatePicker extends React.Component {
       screenReaderInputMessage,
     } = this.props;
 
-    const dateString = this.getDateString(date);
-    const dateValue = toISODateString(date);
+    const displayValue = this.getDateString(date);
+    const inputValue = toISODateString(date);
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
 
@@ -354,8 +354,8 @@ export default class SingleDatePicker extends React.Component {
             phrases={phrases}
             onClearDate={this.clearDate}
             showClearDate={showClearDate}
-            dateValue={dateString}
-            inputValue={dateValue}
+            displayValue={displayValue}
+            inputValue={inputValue}
             onChange={this.onChange}
             onFocus={this.onFocus}
             onKeyDownShiftTab={this.onClearFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import cx from 'classnames';
 
 import DateInput from './DateInput';
 import CloseButton from '../svg/close.svg';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
@@ -26,7 +27,7 @@ const propTypes = {
   phrases: PropTypes.shape({
     clearDate: PropTypes.node,
   }),
-};
+});
 
 const defaultProps = {
   placeholder: 'Select Date',


### PR DESCRIPTION
In https://github.com/airbnb/react-dates/pull/229, I apparently did not check the SDP (or if I did, my eyes glazes over when I saw an ISO format date in the input and called it a day). Either way, @vklein pointed out that this was likely due to an error in prop naming in https://github.com/airbnb/react-dates/issues/281. 

SO. This fixes that issue. :)

to: @airbnb/webinfra @vklein