### PR TITLE
Allow modifiers for SingleDatePicker, DateRangePicker

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -61,6 +61,7 @@ const defaultProps = {
   onFocusChange() {},
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  modifiers: {},
 
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),
@@ -190,6 +191,7 @@ export default class DateRangePicker extends React.Component {
       endDate,
       minimumNights,
       keepOpenOnDateSelect,
+      modifiers,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -225,6 +227,7 @@ export default class DateRangePicker extends React.Component {
           isDayHighlighted={isDayHighlighted}
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
+          modifiers={modifiers}
         />
 
         {withFullScreenPortal &&

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
+  modifiers: PropTypes.object,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -81,6 +82,7 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onOutsideClick() {},
+  modifiers: {},
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -236,9 +238,10 @@ export default class DayPickerRangeController extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      modifiers,
     } = this.props;
 
-    const modifiers = {
+    const defaultModifiers = {
       today: day => this.isToday(day),
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
@@ -260,12 +263,14 @@ export default class DayPickerRangeController extends React.Component {
       'selected-span': day => this.isInSelectedSpan(day),
     };
 
+    const finalModifiers = Object.assign({}, defaultModifiers, modifiers);
+
     return (
       <DayPicker
         ref={(ref) => { this.dayPicker = ref; }}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
-        modifiers={modifiers}
+        modifiers={finalModifiers}
         numberOfMonths={numberOfMonths}
         onDayClick={this.onDayClick}
         onDayMouseEnter={this.onDayMouseEnter}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -264,10 +264,11 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
+      modifiers,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
-    const modifiers = {
+    const defaultModifiers = {
       today: day => this.isToday(day),
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
@@ -277,6 +278,8 @@ export default class SingleDatePicker extends React.Component {
       hovered: day => this.isHovered(day),
       selected: day => this.isSelected(day),
     };
+
+    const finalModifiers = Object.assign({}, defaultModifiers, modifiers);
 
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
 
@@ -289,7 +292,7 @@ export default class SingleDatePicker extends React.Component {
         <DayPicker
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
-          modifiers={modifiers}
+          modifiers={finalModifiers}
           numberOfMonths={numberOfMonths}
           onDayClick={this.onDayClick}
           onDayMouseEnter={this.onDayMouseEnter}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -39,6 +39,7 @@ export default {
   onFocusChange: PropTypes.func,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  modifiers: PropTypes.object,
 
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -37,6 +37,7 @@ export default {
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  modifiers: PropTypes.object,
 
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -88,6 +88,25 @@ const TestCustomArrowIcon = () => (
   </span>
 );
 
+const ModifierStyle = ({ dayKey, background, color }) => {
+  const html = [
+    '<style>',
+    `.CalendarMonth__day--${dayKey} {`,
+    `background: ${background};`,
+    `color: ${color};`,
+    '}',
+    '</style>',
+  ].join('\n');
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: html,
+      }}
+    />
+  );
+};
+
+
 class TestWrapper extends React.Component {
   constructor(props) {
     super(props);
@@ -281,4 +300,18 @@ storiesOf('DateRangePicker', module)
     <DateRangePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
-  ));
+  ))
+  .addWithInfo('with modifier', () => (
+    <div>
+      <ModifierStyle
+        dayKey="sunday"
+        background="#ff5a5f"
+        color="#ffffff"
+      />
+      <DateRangePickerWrapper
+        modifiers={{
+          sunday: (day) => (moment.weekdays(day.weekday()) === 'Sunday'),
+        }}
+      />
+    </div>
+  ))

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -44,6 +44,24 @@ const TestNextIcon = props => (
   </span>
 );
 
+const ModifierStyle = ({ dayKey, background, color }) => {
+  const html = [
+    '<style>',
+    `.CalendarMonth__day--${dayKey} {`,
+    `background: ${background};`,
+    `color: ${color};`,
+    '}',
+    '</style>',
+  ].join('\n');
+  return (
+    <div
+      dangerouslySetInnerHTML={{
+        __html: html,
+      }}
+    />
+  );
+};
+
 storiesOf('SingleDatePicker', module)
   .addWithInfo('default', () => (
     <SingleDatePickerWrapper />
@@ -141,4 +159,18 @@ storiesOf('SingleDatePicker', module)
     <SingleDatePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
+  ))
+  .addWithInfo('with modifier', () => (
+    <div>
+      <ModifierStyle
+        dayKey="saturday"
+        background="#ff5a5f"
+        color="#ffffff"
+      />
+      <SingleDatePickerWrapper
+        modifiers={{
+          saturday: (day) => (moment.weekdays(day.weekday()) === 'Saturday'),
+        }}
+      />
+    </div>
   ));


### PR DESCRIPTION
Hi, 

At present a modifier prop is not accepted by SingleDatePicker and DateRangePicker components. These components instead rely on a hard coded modifier object. This is problematic if you prefer to use either component but also need to apply a modifier.

This pull request makes the following core changes:

1.  Adds a modifier prop to SingleDatePicker, DateRangePicker and DayPickerRangeController.
2. Preserves the current hard coded modifier values in SingleDatePicker & DayPickerRangeController as defaultModifiers. 
4. Merges defaultModifiers and the new modifier prop into a finalModifier object
5. Passes finalModifier object to DayPicker

I also added two stories to illustrate the changes to DateRangePicker & SingleDatePicker.

Thanks!
Brent