### PR TITLE
Keyboard Accessibility

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -13,4 +13,5 @@ module.exports = {
   ANCHOR_RIGHT: 'right',
 
   DAY_SIZE: 39,
+  BLOCKED_MODIFIER: 'blocked',
 };

--- a/css/CalendarDay.scss
+++ b/css/CalendarDay.scss
@@ -6,8 +6,6 @@
   box-sizing: border-box;
   color: $react-dates-color-gray;
   cursor: pointer;
-  width: 39px;
-  height: 38px;
 }
 
 .CalendarDay__button {

--- a/css/CalendarDay.scss
+++ b/css/CalendarDay.scss
@@ -1,6 +1,5 @@
 @import "variables";
 
-// This order is important.
 .CalendarDay {
   border: 1px solid lighten($react-dates-color-border-light, 3);
   padding: 0;
@@ -9,12 +8,31 @@
   cursor: pointer;
   width: 39px;
   height: 38px;
+}
+
+.CalendarDay__button {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  cursor: pointer;
+  box-sizing: border-box;
 
   &:active {
     background: darken($react-dates-color-white, 5%);
+    outline: 0;
   }
 }
 
+// This order is important.
 .CalendarDay--highlighted-calendar {
   background: $react-dates-color-highlighted;
   color: $react-dates-color-gray;

--- a/css/DateRangePicker.scss
+++ b/css/DateRangePicker.scss
@@ -24,11 +24,11 @@
 }
 
 .DateRangePicker__picker--direction-left {
-    left: 0;
+  left: 0;
 }
 
 .DateRangePicker__picker--direction-right {
-    right: 0;
+  right: 0;
 }
 
 .DateRangePicker__picker--portal {

--- a/css/DayPickerKeyboardShortcuts.scss
+++ b/css/DayPickerKeyboardShortcuts.scss
@@ -1,0 +1,161 @@
+.DayPickerKeyboardShortcuts__show,
+.DayPickerKeyboardShortcuts__close {
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  overflow: visible;
+  padding: 0;
+  cursor: pointer;
+
+  &:active {
+    outline: none;
+  }
+}
+
+.DayPickerKeyboardShortcuts__show {
+  width: 22px;
+  position: absolute;
+}
+
+.DayPickerKeyboardShortcuts__show--bottom-right {
+  border-top: 26px solid $react-dates-color-white;
+  border-right: 33px solid $react-dates-color-primary;
+  bottom: 0;
+  right: 0;
+
+  &:hover {
+    border-right: 33px solid #008489;
+  }
+
+  .DayPickerKeyboardShortcuts__show_span {
+    bottom: 0;
+    right: -28px;
+  }
+}
+
+.DayPickerKeyboardShortcuts__show--top-right {
+  border-bottom: 26px solid $react-dates-color-white;
+  border-right: 33px solid $react-dates-color-primary;
+  top: 0;
+  right: 0;
+
+  &:hover {
+    border-right: 33px solid #008489;
+  }
+
+  .DayPickerKeyboardShortcuts__show_span {
+    top: 1px;
+    right: -28px;
+  }
+}
+
+.DayPickerKeyboardShortcuts__show--top-left {
+  border-bottom: 26px solid $react-dates-color-white;
+  border-left: 33px solid $react-dates-color-primary;
+  top: 0;
+  left: 0;
+
+  &:hover {
+    border-left: 33px solid #008489;
+  }
+
+  .DayPickerKeyboardShortcuts__show_span {
+    top: 1px;
+    left: -28px;
+  }
+}
+
+.DayPickerKeyboardShortcuts__show_span {
+  color: $react-dates-color-white;
+  position: absolute;
+}
+
+.DayPickerKeyboardShortcuts__panel {
+  background: $react-dates-color-white;
+  border: 1px solid $react-dates-color-border;
+  border-radius: 2px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 2;
+  padding: 22px;
+  margin: 33px;
+}
+
+.DayPickerKeyboardShortcuts__title {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.DayPickerKeyboardShortcuts__list {
+  list-style: none;
+  padding: 0;
+
+}
+
+.DayPickerKeyboardShortcuts__close {
+  position: absolute;
+  right: 22px;
+  top: 22px;
+  z-index: 2;
+
+  svg {
+    height: 15px;
+    width: 15px;
+    fill: $react-dates-color-gray-lighter;
+
+    &:hover,
+    &:focus {
+      fill: $react-dates-color-gray-light;
+    }
+  }
+
+  &:active {
+    outline: none;
+  }
+}
+
+.KeyboardShortcutRow {
+  margin: 6px 0;
+}
+
+.KeyboardShortcutRow__key-container {
+  display: inline-block;
+  width: 15%;
+  white-space: nowrap;
+  text-align: right;
+  margin-right: 6px;
+}
+
+.KeyboardShortcutRow__key {
+  font-family: monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  background: $react-dates-color-gray-lightest;
+  padding: 2px 6px;
+}
+
+.KeyboardShortcutRow__action {
+  display: inline-block;
+}
+
+.DayPickerKeyboardShortcuts__panel--block {
+  .KeyboardShortcutRow {
+    margin-bottom: 16px;
+  }
+
+  .KeyboardShortcutRow__key-container {
+    width: auto;
+    text-align: left;
+    display: inline;
+  }
+
+  .KeyboardShortcutRow__action {
+    display: inline;
+  }
+}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -3,6 +3,7 @@
 @import 'CalendarMonthGrid';
 @import 'DayPicker';
 @import 'DayPickerNavigation';
+@import 'DayPickerKeyboardShortcuts';
 @import 'DateInput';
 @import 'DateRangePicker';
 @import 'DateRangePickerInput';

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -5,6 +5,7 @@ $react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;
 $react-dates-color-primary-dark: #00514a !default;
+$react-date-color-primary-dark-1: #008489 !default;
 $react-dates-color-primary-shade-1: #33dacd !default;
 $react-dates-color-primary-shade-2: #66e2da !default;
 $react-dates-color-primary-shade-3: #80e8e0 !default;
@@ -15,6 +16,7 @@ $react-dates-color-gray: #565a5c !default;
 $react-dates-color-gray-dark: darken($react-dates-color-gray, 10.5%) !default;
 $react-dates-color-gray-light: lighten($react-dates-color-gray, 17.8%) !default;   // #82888a
 $react-dates-color-gray-lighter: lighten($react-dates-color-gray, 45%) !default;     // #cacccd
+$react-dates-color-gray-lightest: lighten($react-dates-color-gray, 60%) !default;
 $react-dates-color-highlighted: #ffe8bc !default;
 
 $react-dates-color-border: #dbdbdb !default;

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -5,6 +5,7 @@ import omit from 'lodash.omit';
 
 import DateRangePicker from '../src/components/DateRangePicker';
 
+import { DateRangePickerPhrases } from '../src/defaultPhrases';
 import DateRangePickerShape from '../src/shapes/DateRangePickerShape';
 import { START_DATE, END_DATE, HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
@@ -74,10 +75,7 @@ const defaultProps = {
   // internationalization
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
-  phrases: {
-    closeDatePicker: 'Close',
-    clearDates: 'Clear Dates',
-  },
+  phrases: DateRangePickerPhrases,
 };
 
 class DateRangePickerWrapper extends React.Component {
@@ -112,6 +110,9 @@ class DateRangePickerWrapper extends React.Component {
   render() {
     const { focusedInput, startDate, endDate } = this.state;
 
+    // autoFocus, autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
+    // example wrapper but are not props on the SingleDatePicker itself and
+    // thus, have to be omitted.
     const props = omit(this.props, [
       'autoFocus',
       'autoFocusEndDate',

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -5,6 +5,7 @@ import omit from 'lodash.omit';
 
 import SingleDatePicker from '../src/components/SingleDatePicker';
 
+import { SingleDatePickerPhrases } from '../src/defaultPhrases';
 import SingleDatePickerShape from '../src/shapes/SingleDatePickerShape';
 import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
@@ -13,6 +14,7 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   initialDate: momentPropTypes.momentObj,
+
   ...omit(SingleDatePickerShape, [
     'date',
     'onDateChange',
@@ -61,10 +63,7 @@ const defaultProps = {
   // internationalization props
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
-  phrases: {
-    closeDatePicker: 'Close',
-    clearDate: 'Clear Date',
-  },
+  phrases: SingleDatePickerPhrases,
 };
 
 class SingleDatePickerWrapper extends React.Component {
@@ -90,9 +89,16 @@ class SingleDatePickerWrapper extends React.Component {
   render() {
     const { focused, date } = this.state;
 
+    // autoFocus and initialDate are helper props for the example wrapper but are not
+    // props on the SingleDatePicker itself and thus, have to be omitted.
+    const props = omit(this.props, [
+      'autoFocus',
+      'initialDate',
+    ]);
+
     return (
       <SingleDatePicker
-        {...this.props}
+        {...props}
         id="date_input"
         date={date}
         focused={focused}

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "consolidated-events": "^1.0.1",
+    "lodash.throttle": "^4.1.1",
     "react-moment-proptypes": "^1.3.0",
     "react-portal": "^3.0.0"
   },

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -5,17 +5,25 @@ import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
-import { DAY_SIZE } from '../../constants';
+import { CalendarDayPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
+import { BLOCKED_MODIFIER, DAY_SIZE } from '../../constants';
 
 const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
   daySize: nonNegativeInteger,
   isOutsideDay: PropTypes.bool,
   modifiers: PropTypes.object,
+  isFocused: PropTypes.bool,
+  tabIndex: PropTypes.oneOf([0, -1]),
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderDay: PropTypes.func,
+
+  // internationalization
+  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
 });
 
 const defaultProps = {
@@ -23,10 +31,15 @@ const defaultProps = {
   daySize: DAY_SIZE,
   isOutsideDay: false,
   modifiers: {},
+  isFocused: false,
+  tabIndex: -1,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   renderDay: null,
+
+  // internationalization
+  phrases: CalendarDayPhrases,
 };
 
 export function getModifiersForDay(modifiers, day) {
@@ -36,6 +49,15 @@ export function getModifiersForDay(modifiers, day) {
 export default class CalendarDay extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isFocused, tabIndex } = this.props;
+    if (tabIndex === 0) {
+      if (isFocused || tabIndex !== prevProps.tabIndex) {
+        this.buttonRef.focus();
+      }
+    }
   }
 
   onDayClick(day, e) {
@@ -60,29 +82,47 @@ export default class CalendarDay extends React.Component {
       isOutsideDay,
       modifiers,
       renderDay,
+      tabIndex,
+      phrases: { unavailable, available },
     } = this.props;
 
-    const className = cx('CalendarDay', {
-      'CalendarDay--outside': !day || isOutsideDay,
-    }, getModifiersForDay(modifiers, day).map(mod => `CalendarDay--${mod}`));
+    if (!day) return <td />;
 
+    const modifiersForDay = getModifiersForDay(modifiers, day);
+
+    const className = cx('CalendarDay', {
+      'CalendarDay--outside': isOutsideDay,
+    }, modifiersForDay.map(mod => `CalendarDay--${mod}`));
+
+
+    let availabilityText = '';
+    if (BLOCKED_MODIFIER in modifiers) {
+      availabilityText = modifiers[BLOCKED_MODIFIER](day) ? unavailable : available;
+    }
+
+    const ariaLabel = `${availabilityText} ${day.format('dddd')}. ${day.format('LL')}`;
     const daySizeStyles = {
       width: daySize,
       height: daySize - 1,
     };
 
-    return (day ?
-      <td
-        className={className}
-        style={daySizeStyles}
-        onMouseEnter={e => this.onDayMouseEnter(day, e)}
-        onMouseLeave={e => this.onDayMouseLeave(day, e)}
-        onClick={e => this.onDayClick(day, e)}
-      >
-        {renderDay ? renderDay(day) : day.format('D')}
+    return (
+      <td className={className}>
+        <button
+          type="button"
+          ref={(ref) => { this.buttonRef = ref; }}
+          className="CalendarDay__button"
+          aria-label={ariaLabel}
+          style={daySizeStyles}
+          onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}
+          onMouseLeave={(e) => { this.onDayMouseLeave(day, e); }}
+          onMouseUp={(e) => { e.currentTarget.blur(); }}
+          onClick={(e) => { this.onDayClick(day, e); }}
+          tabIndex={tabIndex}
+        >
+          {renderDay ? renderDay(day) : day.format('D')}
+        </button>
       </td>
-      :
-      <td />
     );
   }
 }

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -7,6 +7,7 @@ import cx from 'classnames';
 
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import getPhrase from '../utils/getPhrase';
 
 import { BLOCKED_MODIFIER, DAY_SIZE } from '../../constants';
 
@@ -83,7 +84,10 @@ export default class CalendarDay extends React.Component {
       modifiers,
       renderDay,
       tabIndex,
-      phrases: { unavailable, available },
+      phrases: {
+        chooseAvailableDate,
+        dateIsUnavailable,
+      },
     } = this.props;
 
     if (!day) return <td />;
@@ -95,25 +99,29 @@ export default class CalendarDay extends React.Component {
     }, modifiersForDay.map(mod => `CalendarDay--${mod}`));
 
 
-    let availabilityText = '';
-    if (BLOCKED_MODIFIER in modifiers) {
-      availabilityText = modifiers[BLOCKED_MODIFIER](day) ? unavailable : available;
+    const formattedDate = `${day.format('dddd')}, ${day.format('LL')}`;
+
+    let ariaLabel = getPhrase(chooseAvailableDate, {
+      checkin_date: formattedDate,
+      checkout_date: formattedDate,
+    });
+
+    if (BLOCKED_MODIFIER in modifiers && modifiers[BLOCKED_MODIFIER](day)) {
+      ariaLabel = getPhrase(dateIsUnavailable, { date: formattedDate });
     }
 
-    const ariaLabel = `${availabilityText} ${day.format('dddd')}. ${day.format('LL')}`;
     const daySizeStyles = {
       width: daySize,
       height: daySize - 1,
     };
 
     return (
-      <td className={className}>
+      <td className={className} style={daySizeStyles}>
         <button
           type="button"
           ref={(ref) => { this.buttonRef = ref; }}
           className="CalendarDay__button"
           aria-label={ariaLabel}
-          style={daySizeStyles}
           onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}
           onMouseLeave={(e) => { this.onDayMouseLeave(day, e); }}
           onMouseUp={(e) => { e.currentTarget.blur(); }}

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -7,9 +7,13 @@ import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
+import { CalendarDayPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
 import CalendarDay from './CalendarDay';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
+import isSameDay from '../utils/isSameDay';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -32,8 +36,12 @@ const propTypes = forbidExtraProps({
   onDayMouseLeave: PropTypes.func,
   renderDay: PropTypes.func,
 
+  focusedDate: momentPropTypes.momentObj, // indicates focusable day
+  isFocused: PropTypes.bool, // indicates whether or not to move focus to focusable day
+
   // i18n
   monthFormat: PropTypes.string,
+  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
 });
 
 const defaultProps = {
@@ -48,8 +56,12 @@ const defaultProps = {
   onDayMouseLeave() {},
   renderDay: null,
 
+  focusedDate: null,
+  isFocused: false,
+
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
+  phrases: CalendarDayPhrases,
 };
 
 export default class CalendarMonth extends React.Component {
@@ -85,6 +97,9 @@ export default class CalendarMonth extends React.Component {
       onDayMouseLeave,
       renderDay,
       daySize,
+      focusedDate,
+      isFocused,
+      phrases,
     } = this.props;
 
     const { weeks } = this.state;
@@ -111,12 +126,15 @@ export default class CalendarMonth extends React.Component {
                     day={day}
                     daySize={daySize}
                     isOutsideDay={!day || day.month() !== month.month()}
+                    tabIndex={isVisible && isSameDay(day, focusedDate) ? 0 : -1}
+                    isFocused={isFocused}
                     modifiers={modifiers}
                     key={dayOfWeek}
                     onDayMouseEnter={onDayMouseEnter}
                     onDayMouseLeave={onDayMouseLeave}
                     onDayClick={onDayClick}
                     renderDay={renderDay}
+                    phrases={phrases}
                   />
                 ))}
               </tr>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -6,6 +6,9 @@ import moment from 'moment';
 import cx from 'classnames';
 import { addEventListener, removeEventListener } from 'consolidated-events';
 
+import { CalendarDayPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
 import CalendarMonth from './CalendarMonth';
 
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
@@ -36,9 +39,12 @@ const propTypes = forbidExtraProps({
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
   daySize: nonNegativeInteger,
+  focusedDate: momentPropTypes.momentObj, // indicates focusable day
+  isFocused: PropTypes.bool, // indicates whether or not to move focus to focusable day
 
   // i18n
   monthFormat: PropTypes.string,
+  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
 });
 
 const defaultProps = {
@@ -56,9 +62,12 @@ const defaultProps = {
   renderDay: null,
   transformValue: 'none',
   daySize: DAY_SIZE,
+  focusedDate: null,
+  isFocused: false,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
+  phrases: CalendarDayPhrases,
 };
 
 function getMonths(initialMonth, numberOfMonths) {
@@ -157,14 +166,18 @@ export default class CalendarMonthGrid extends React.Component {
       onDayClick,
       renderDay,
       onMonthTransitionEnd,
+      focusedDate,
+      isFocused,
+      phrases,
     } = this.props;
 
     const { months } = this.state;
     const isVertical = orientation === VERTICAL_ORIENTATION;
     const isVerticalScrollable = orientation === VERTICAL_SCROLLABLE;
+    const isHorizontal = orientation === HORIZONTAL_ORIENTATION;
 
     const className = cx('CalendarMonthGrid', {
-      'CalendarMonthGrid--horizontal': orientation === HORIZONTAL_ORIENTATION,
+      'CalendarMonthGrid--horizontal': isHorizontal,
       'CalendarMonthGrid--vertical': isVertical,
       'CalendarMonthGrid--vertical-scrollable': isVerticalScrollable,
       'CalendarMonthGrid--animating': isAnimating,
@@ -205,6 +218,9 @@ export default class CalendarMonthGrid extends React.Component {
               onDayClick={onDayClick}
               renderDay={renderDay}
               daySize={daySize}
+              focusedDate={isVisible ? focusedDate : null}
+              isFocused={isFocused}
+              phrases={phrases}
             />
           );
         })}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -95,6 +95,7 @@ export default class DateRangePicker extends React.Component {
       dayPickerContainerStyles: {},
       isDateRangePickerInputFocused: false,
       isDayPickerFocused: false,
+      showKeyboardShortcuts: false,
     };
 
     this.isTouchDevice = false;
@@ -103,6 +104,7 @@ export default class DateRangePicker extends React.Component {
     this.onDateRangePickerInputFocus = this.onDateRangePickerInputFocus.bind(this);
     this.onDayPickerFocus = this.onDayPickerFocus.bind(this);
     this.onDayPickerBlur = this.onDayPickerBlur.bind(this);
+    this.showKeyboardShortcutsPanel = this.showKeyboardShortcutsPanel.bind(this);
 
     this.responsivizePickerPosition = this.responsivizePickerPosition.bind(this);
   }
@@ -137,7 +139,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   componentWillUnmount() {
-    removeEventListener(this.resizeHandle);
+    if (this.resizeHandle) removeEventListener(this.resizeHandle);
   }
 
   onOutsideClick() {
@@ -147,6 +149,7 @@ export default class DateRangePicker extends React.Component {
     this.setState({
       isDateRangePickerInputFocused: false,
       isDayPickerFocused: false,
+      showKeyboardShortcuts: false,
     });
 
     onFocusChange(null);
@@ -168,9 +171,13 @@ export default class DateRangePicker extends React.Component {
   }
 
   onDayPickerFocus() {
+    const { focusedInput, onFocusChange } = this.props;
+    if (!focusedInput) onFocusChange(START_DATE);
+
     this.setState({
       isDateRangePickerInputFocused: false,
       isDayPickerFocused: true,
+      showKeyboardShortcuts: false,
     });
   }
 
@@ -178,6 +185,7 @@ export default class DateRangePicker extends React.Component {
     this.setState({
       isDateRangePickerInputFocused: true,
       isDayPickerFocused: false,
+      showKeyboardShortcuts: false,
     });
   }
 
@@ -235,6 +243,14 @@ export default class DateRangePicker extends React.Component {
     }
   }
 
+  showKeyboardShortcutsPanel() {
+    this.setState({
+      isDateRangePickerInputFocused: false,
+      isDayPickerFocused: true,
+      showKeyboardShortcuts: true,
+    });
+  }
+
   maybeRenderDayPickerWithPortal() {
     const { withPortal, withFullScreenPortal } = this.props;
 
@@ -280,8 +296,9 @@ export default class DateRangePicker extends React.Component {
       renderCalendarInfo,
       initialVisibleMonth,
       customCloseIcon,
+      phrases,
     } = this.props;
-    const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
+    const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
     const onOutsideClick = (!withFullScreenPortal && withPortal)
       ? this.onOutsideClick
@@ -324,7 +341,9 @@ export default class DateRangePicker extends React.Component {
           renderDay={renderDay}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}
+          showKeyboardShortcuts={showKeyboardShortcuts}
           onBlur={this.onDayPickerBlur}
+          phrases={phrases}
         />
 
         {withFullScreenPortal && (
@@ -332,10 +351,8 @@ export default class DateRangePicker extends React.Component {
             className="DateRangePicker__close"
             type="button"
             onClick={this.onOutsideClick}
+            aria-label={phrases.closeDatePicker}
           >
-            <span className="screen-reader-only">
-              {this.props.phrases.closeDatePicker}
-            </span>
             <div className="DateRangePicker__close">
               {closeIcon}
             </div>
@@ -403,6 +420,8 @@ export default class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={this.onDateRangePickerInputFocus}
+            onArrowDown={this.onDayPickerFocus}
+            onQuestionMark={this.showKeyboardShortcutsPanel}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
             isFocused={isDateRangePickerInputFocused}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -27,6 +27,8 @@ const propTypes = forbidExtraProps({
   onStartDateShiftTab: PropTypes.func,
   onEndDateTab: PropTypes.func,
   onClearDates: PropTypes.func,
+  onArrowDown: PropTypes.func,
+  onQuestionMark: PropTypes.func,
 
   startDate: PropTypes.string,
   startDateValue: PropTypes.string,
@@ -44,6 +46,7 @@ const propTypes = forbidExtraProps({
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
 
+  // accessibility
   isFocused: PropTypes.bool, // describes actual DOM focus
 
   // i18n
@@ -63,6 +66,8 @@ const defaultProps = {
   onStartDateShiftTab() {},
   onEndDateTab() {},
   onClearDates() {},
+  onArrowDown() {},
+  onQuestionMark() {},
 
   startDate: '',
   startDateValue: '',
@@ -80,6 +85,7 @@ const defaultProps = {
   customArrowIcon: null,
   customCloseIcon: null,
 
+  // accessibility
   isFocused: false,
 
   // i18n
@@ -129,6 +135,8 @@ export default class DateRangePickerInput extends React.Component {
       onEndDateChange,
       onEndDateFocus,
       onEndDateTab,
+      onArrowDown,
+      onQuestionMark,
       onClearDates,
       showClearDates,
       disabled,
@@ -146,6 +154,8 @@ export default class DateRangePickerInput extends React.Component {
     const arrowIcon = customArrowIcon || (<RightArrow />);
     const closeIcon = customCloseIcon || (<CloseButton />);
 
+    const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
+
     return (
       <div
         className={cx('DateRangePickerInput', {
@@ -155,9 +165,9 @@ export default class DateRangePickerInput extends React.Component {
         {(showDefaultInputIcon || customInputIcon !== null) && (
           <button
             type="button"
-            aria-label={phrases.focusStartDate}
             className="DateRangePickerInput__calendar-icon"
-            onClick={onStartDateFocus}
+            aria-label={phrases.focusStartDate}
+            onClick={onArrowDown}
           >
             {inputIcon}
           </button>
@@ -168,7 +178,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={startDatePlaceholderText}
           displayValue={startDate}
           inputValue={startDateValue}
-          screenReaderMessage={screenReaderMessage}
+          screenReaderMessage={screenReaderText}
           focused={isStartDateFocused}
           isFocused={isFocused}
           disabled={disabled}
@@ -178,9 +188,15 @@ export default class DateRangePickerInput extends React.Component {
           onChange={onStartDateChange}
           onFocus={onStartDateFocus}
           onKeyDownShiftTab={onStartDateShiftTab}
+          onKeyDownArrowDown={onArrowDown}
+          onKeyDownQuestionMark={onQuestionMark}
         />
 
-        <div className="DateRangePickerInput__arrow">
+        <div
+          className="DateRangePickerInput__arrow"
+          aria-hidden="true"
+          role="presentation"
+        >
           {arrowIcon}
         </div>
 
@@ -189,7 +205,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={endDatePlaceholderText}
           displayValue={endDate}
           inputValue={endDateValue}
-          screenReaderMessage={screenReaderMessage}
+          screenReaderMessage={screenReaderText}
           focused={isEndDateFocused}
           isFocused={isFocused}
           disabled={disabled}
@@ -199,11 +215,14 @@ export default class DateRangePickerInput extends React.Component {
           onChange={onEndDateChange}
           onFocus={onEndDateFocus}
           onKeyDownTab={onEndDateTab}
+          onKeyDownArrowDown={onArrowDown}
+          onKeyDownQuestionMark={onQuestionMark}
         />
 
         {showClearDates && (
           <button
             type="button"
+            aria-label={phrases.clearDates}
             className={cx('DateRangePickerInput__clear-dates', {
               'DateRangePickerInput__clear-dates--hide': !(startDate || endDate),
               'DateRangePickerInput__clear-dates--hover': isClearDatesHovered,
@@ -212,9 +231,6 @@ export default class DateRangePickerInput extends React.Component {
             onMouseLeave={this.onClearDatesMouseLeave}
             onClick={onClearDates}
           >
-            <span className="screen-reader-only">
-              {phrases.clearDates}
-            </span>
             <div className="DateRangePickerInput__close-icon">
               {closeIcon}
             </div>

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -44,11 +44,14 @@ const propTypes = forbidExtraProps({
 
   onFocusChange: PropTypes.func,
   onDatesChange: PropTypes.func,
+  onArrowDown: PropTypes.func,
+  onQuestionMark: PropTypes.func,
 
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
 
+  // accessibility
   isFocused: PropTypes.bool,
 
   // i18n
@@ -81,11 +84,14 @@ const defaultProps = {
 
   onFocusChange() {},
   onDatesChange() {},
+  onArrowDown() {},
+  onQuestionMark() {},
 
   customInputIcon: null,
   customArrowIcon: null,
   customCloseIcon: null,
 
+  // accessibility
   isFocused: false,
 
   // i18n
@@ -214,6 +220,8 @@ export default class DateRangePickerInputController extends React.Component {
       required,
       isFocused,
       phrases,
+      onArrowDown,
+      onQuestionMark,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -251,6 +259,8 @@ export default class DateRangePickerInputController extends React.Component {
         showClearDates={showClearDates}
         onClearDates={this.clearDates}
         screenReaderMessage={screenReaderMessage}
+        onArrowDown={onArrowDown}
+        onQuestionMark={onQuestionMark}
       />
     );
   }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -272,7 +272,7 @@ export default class DayPicker extends React.Component {
   }
 
   onKeyDown(e) {
-    e.stopPropagation();
+    if (e) e.stopPropagation();
 
     const { onBlur } = this.props;
     const { focusedDate, showKeyboardShortcuts } = this.state;
@@ -291,10 +291,12 @@ export default class DayPicker extends React.Component {
 
     switch (e.key) {
       case 'ArrowUp':
+        if (e) e.preventDefault();
         newFocusedDate.subtract(1, 'week');
         didTransitionMonth = this.maybeTransitionPrevMonth(newFocusedDate);
         break;
       case 'ArrowLeft':
+        if (e) e.preventDefault();
         newFocusedDate.subtract(1, 'day');
         didTransitionMonth = this.maybeTransitionPrevMonth(newFocusedDate);
         break;
@@ -308,10 +310,12 @@ export default class DayPicker extends React.Component {
         break;
 
       case 'ArrowDown':
+        if (e) e.preventDefault();
         newFocusedDate.add(1, 'week');
         didTransitionMonth = this.maybeTransitionNextMonth(newFocusedDate);
         break;
       case 'ArrowRight':
+        if (e) e.preventDefault();
         newFocusedDate.add(1, 'day');
         didTransitionMonth = this.maybeTransitionNextMonth(newFocusedDate);
         break;
@@ -392,14 +396,11 @@ export default class DayPicker extends React.Component {
   }
 
   getFocusedDay(newMonth) {
-    // TODO(maja): figure out which month var I should be using
     const { getFirstFocusableDay } = this.props;
-    const { currentMonth } = this.state;
 
     let focusedDate;
     if (getFirstFocusableDay) {
-      const month = newMonth || currentMonth;
-      focusedDate = getFirstFocusableDay(month);
+      focusedDate = getFirstFocusableDay(newMonth);
     }
 
     if (newMonth && (!focusedDate || !this.isDayVisible(focusedDate, newMonth))) {

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -1,0 +1,176 @@
+import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
+import cx from 'classnames';
+
+import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
+import CloseButton from '../svg/close.svg';
+
+export const TOP_LEFT = 'top-left';
+export const TOP_RIGHT = 'top-right';
+export const BOTTOM_RIGHT = 'bottom-right';
+
+const propTypes = forbidExtraProps({
+  block: PropTypes.bool,
+  buttonLocation: PropTypes.oneOf([TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT]),
+  showKeyboardShortcutsPanel: PropTypes.bool,
+  openKeyboardShortcutsPanel: PropTypes.func,
+  closeKeyboardShortcutsPanel: PropTypes.func,
+  phrases: PropTypes.shape(getPhrasePropTypes(DayPickerKeyboardShortcutsPhrases)),
+});
+
+const defaultProps = {
+  block: false,
+  buttonLocation: BOTTOM_RIGHT,
+  showKeyboardShortcutsPanel: false,
+  openKeyboardShortcutsPanel() {},
+  closeKeyboardShortcutsPanel() {},
+  phrases: DayPickerKeyboardShortcutsPhrases,
+};
+
+export function KeyboardShortcutRow({ unicode, label, action }) {
+  return (
+    <li className="KeyboardShortcutRow">
+      <div
+        className="KeyboardShortcutRow__key-container"
+      >
+        <span
+          className="KeyboardShortcutRow__key"
+          role="img"
+          aria-label={label}
+        >
+          {unicode}
+        </span>
+      </div>
+
+      <div className="KeyboardShortcutRow__action">
+        {action}
+      </div>
+    </li>
+  );
+}
+
+KeyboardShortcutRow.propTypes = {
+  unicode: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  action: PropTypes.string.isRequired,
+};
+
+export default function DayPickerKeyboardShortcuts({
+  block,
+  buttonLocation,
+  showKeyboardShortcutsPanel,
+  openKeyboardShortcutsPanel,
+  closeKeyboardShortcutsPanel,
+  phrases,
+}) {
+  const keyboardShortcuts = [{
+    unicode: '↵',
+    label: phrases.enterKey,
+    action: phrases.selectFocusedDate,
+  },
+  {
+    unicode: '←/→',
+    label: phrases.leftArrowRightArrow,
+    action: phrases.moveFocusByOneDay,
+  },
+  {
+    unicode: '↑/↓',
+    label: phrases.upArrowDownArrow,
+    action: phrases.moveFocusByOneWeek,
+  },
+  {
+    unicode: 'PgUp/PgDn',
+    label: phrases.pageUpPageDown,
+    action: phrases.moveFocusByOneMonth,
+  },
+  {
+    unicode: 'Home/End',
+    label: phrases.homeEnd,
+    action: phrases.moveFocustoStartAndEndOfWeek,
+  },
+  {
+    unicode: 'Esc',
+    label: phrases.escape,
+    action: phrases.returnFocusToInput,
+  },
+  {
+    unicode: '?',
+    label: phrases.questionMark,
+    action: phrases.openThisPanel,
+  },
+  ];
+
+  const toggleButtonText =
+    showKeyboardShortcutsPanel
+    ? phrases.hideKeyboardShortcutsPanel
+    : phrases.showKeyboardShortcutsPanel;
+
+  return (
+    <div>
+      <button
+        ref={(ref) => { this.showKeyboardShortcutsButton = ref; }}
+        className={cx('DayPickerKeyboardShortcuts__show', {
+          'DayPickerKeyboardShortcuts__show--bottom-right': buttonLocation === BOTTOM_RIGHT,
+          'DayPickerKeyboardShortcuts__show--top-right': buttonLocation === TOP_RIGHT,
+          'DayPickerKeyboardShortcuts__show--top-left': buttonLocation === TOP_LEFT,
+        })}
+        type="button"
+        aria-label={toggleButtonText}
+        onClick={() => {
+          // we want to return focus to this button after closing the keyboard shortcuts panel
+          openKeyboardShortcutsPanel(() => { this.showKeyboardShortcutsButton.focus(); });
+        }}
+        onMouseUp={(e) => {
+          e.currentTarget.blur();
+        }}
+      >
+        <span className="DayPickerKeyboardShortcuts__show_span">?</span>
+      </button>
+
+      {showKeyboardShortcutsPanel &&
+        <div
+          className={cx('DayPickerKeyboardShortcuts__panel', {
+            'DayPickerKeyboardShortcuts__panel--block': block,
+          })}
+          role="dialog"
+          aria-labelledby="DayPickerKeyboardShortcuts__title"
+        >
+          <div
+            id="DayPickerKeyboardShortcuts__title"
+            className="DayPickerKeyboardShortcuts__title"
+          >
+            {phrases.keyboardShortcuts}
+          </div>
+
+          <button
+            className="DayPickerKeyboardShortcuts__close"
+            type="button"
+            aria-label={phrases.hideKeyboardShortcutsPanel}
+            onClick={closeKeyboardShortcutsPanel}
+            onKeyDown={(e) => {
+              // Because the close button is the only focusable element inside of the panel, this
+              // amount to a very basic focus trap. The user can exit the panel by "pressing" the
+              // close button or hitting escape
+              if (e.key === 'Tab') {
+                e.preventDefault();
+              }
+            }}
+          >
+            <CloseButton />
+          </button>
+
+          <ul className="DayPickerKeyboardShortcuts__list">
+            {keyboardShortcuts.map(({ unicode, label, action }) => (
+              <KeyboardShortcutRow key={label} unicode={unicode} label={label} action={action} />
+            ))}
+          </ul>
+        </div>
+      }
+    </div>
+  );
+}
+
+DayPickerKeyboardShortcuts.propTypes = propTypes;
+DayPickerKeyboardShortcuts.defaultProps = defaultProps;

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -80,23 +80,32 @@ export default function DayPickerNavigation(props) {
 
   return (
     <div className={navClassNames}>
+
       {!isVerticalScrollable && (
-        <span
+        <button
+          type="button"
           aria-label={phrases.jumpToPrevMonth}
           className={prevClassNames}
           onClick={onPrevMonthClick}
+          onMouseUp={(e) => {
+            e.currentTarget.blur();
+          }}
         >
           {navPrevIcon}
-        </span>
+        </button>
       )}
 
-      <span
+      <button
+        type="button"
         aria-label={phrases.jumpToNextMonth}
         className={nextClassNames}
         onClick={onNextMonthClick}
+        onMouseUp={(e) => {
+          e.currentTarget.blur();
+        }}
       >
         {navNextIcon}
-      </span>
+      </button>
     </div>
   );
 }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -330,6 +330,17 @@ export default class DayPickerRangeController extends React.Component {
       },
     };
 
+    // set the appropriate CalendarDay phrase based on focusedInput
+    const chooseAvailableDate =
+      focusedInput === START_DATE
+      ? phrases.chooseAvailableStartDate
+      : phrases.chooseAvailableEndDate;
+
+    const calendarDayPhrases = {
+      ...phrases,
+      chooseAvailableDate,
+    };
+
     return (
       <DayPicker
         ref={(ref) => { this.dayPicker = ref; }}
@@ -356,7 +367,7 @@ export default class DayPickerRangeController extends React.Component {
         getFirstFocusableDay={this.getFirstFocusableDay}
         onBlur={onBlur}
         showKeyboardShortcuts={showKeyboardShortcuts}
-        phrases={phrases}
+        phrases={calendarDayPhrases}
       />
     );
   }

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -30,7 +30,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   componentWillUnmount() {
-    removeEventListener(this.clickHandle);
+    if (this.clickHandle) removeEventListener(this.clickHandle);
   }
 
   onOutsideClick(e) {

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -27,6 +27,7 @@ const propTypes = forbidExtraProps({
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
+  onKeyDownArrowDown: PropTypes.func,
 
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerInputPhrases)),
@@ -50,6 +51,7 @@ const defaultProps = {
   onFocus() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
+  onKeyDownArrowDown() {},
 
   // i18n
   phrases: SingleDatePickerInputPhrases,
@@ -97,11 +99,13 @@ export default class SingleDatePickerInput extends React.Component {
       onFocus,
       onKeyDownShiftTab,
       onKeyDownTab,
+      onKeyDownArrowDown,
       screenReaderMessage,
       customCloseIcon,
     } = this.props;
 
     const closeIcon = customCloseIcon || (<CloseButton />);
+    const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
 
     return (
       <div className="SingleDatePickerInput">
@@ -110,17 +114,17 @@ export default class SingleDatePickerInput extends React.Component {
           placeholder={placeholder} // also used as label
           displayValue={displayValue}
           inputValue={inputValue}
-          screenReaderMessage={screenReaderMessage}
+          screenReaderMessage={screenReaderText}
           focused={focused}
           isFocused={isFocused}
           disabled={disabled}
           required={required}
           showCaret={showCaret}
-
           onChange={onChange}
           onFocus={onFocus}
           onKeyDownShiftTab={onKeyDownShiftTab}
           onKeyDownTab={onKeyDownTab}
+          onKeyDownArrowDown={onKeyDownArrowDown}
         />
 
         {showClearDate && (

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -2,8 +2,8 @@ const closeDatePicker = 'Close';
 const focusStartDate = 'Interact with the calendar and add the check-in date for your trip.';
 const clearDate = 'Clear Date';
 const clearDates = 'Clear Dates';
-const jumpToPrevMonth = 'Move forward to switch to the previous month';
-const jumpToNextMonth = 'Move backward to switch to the next month';
+const jumpToPrevMonth = 'Move backward to switch to the previous month';
+const jumpToNextMonth = 'Move forward to switch to the next month';
 const keyboardShortcuts = 'Keyboard Shortcuts';
 const showKeyboardShortcutsPanel = 'Open the keyboard shortcuts panel';
 const hideKeyboardShortcutsPanel = 'Close the shortcuts panel';
@@ -23,8 +23,14 @@ const moveFocustoStartAndEndOfWeek = 'Go to the first or last day of a week';
 const returnFocusToInput = 'Return to the date input field';
 const keyboardNavigationInstructions = `Press the down arrow key to interact with the calendar and
   select a date. Press the question mark key to get the keyboard shortcuts for changing dates.`;
-const available = 'Available.';
-const unavailable = 'Unavailable.';
+
+// eslint-disable-next-line camelcase
+const chooseAvailableStartDate = ({ checkin_date }) => `Choose ${checkin_date} as your check-in date. It's available.`;
+
+// eslint-disable-next-line camelcase
+const chooseAvailableEndDate = ({ checkout_date }) => `Choose ${checkout_date} as your check-out date. It's available.`;
+const dateIsUnavailable = ({ date }) => `Not available. ${date}`;
+
 
 export default {
   closeDatePicker,
@@ -51,8 +57,10 @@ export default {
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
   keyboardNavigationInstructions,
-  available,
-  unavailable,
+
+  chooseAvailableStartDate,
+  chooseAvailableEndDate,
+  dateIsUnavailable,
 };
 
 export const DateRangePickerPhrases = {
@@ -79,8 +87,9 @@ export const DateRangePickerPhrases = {
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
   keyboardNavigationInstructions,
-  available,
-  unavailable,
+  chooseAvailableStartDate,
+  chooseAvailableEndDate,
+  dateIsUnavailable,
 };
 
 export const DateRangePickerInputPhrases = {
@@ -112,8 +121,9 @@ export const SingleDatePickerPhrases = {
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
   keyboardNavigationInstructions,
-  available,
-  unavailable,
+  chooseAvailableStartDate,
+  chooseAvailableEndDate,
+  dateIsUnavailable,
 };
 
 export const SingleDatePickerInputPhrases = {
@@ -141,8 +151,8 @@ export const DayPickerPhrases = {
   moveFocusByOneMonth,
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
-  available,
-  unavailable,
+  chooseAvailableDate: chooseAvailableStartDate,
+  dateIsUnavailable,
 };
 
 export const DayPickerKeyboardShortcutsPhrases = {
@@ -171,6 +181,6 @@ export const DayPickerNavigationPhrases = {
 };
 
 export const CalendarDayPhrases = {
-  available,
-  unavailable,
+  chooseAvailableDate: chooseAvailableStartDate,
+  dateIsUnavailable,
 };

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -1,9 +1,30 @@
 const closeDatePicker = 'Close';
-const focusStartDate = 'Focus on start date';
+const focusStartDate = 'Interact with the calendar and add the check-in date for your trip.';
 const clearDate = 'Clear Date';
 const clearDates = 'Clear Dates';
-const jumpToPrevMonth = 'Jump to previous month';
-const jumpToNextMonth = 'Jump to next month';
+const jumpToPrevMonth = 'Move forward to switch to the previous month';
+const jumpToNextMonth = 'Move backward to switch to the next month';
+const keyboardShortcuts = 'Keyboard Shortcuts';
+const showKeyboardShortcutsPanel = 'Open the keyboard shortcuts panel';
+const hideKeyboardShortcutsPanel = 'Close the shortcuts panel';
+const openThisPanel = 'Open this panel';
+const enterKey = 'Enter key';
+const leftArrowRightArrow = 'Right and left arrow keys';
+const upArrowDownArrow = 'up and down arrow keys';
+const pageUpPageDown = 'page up and page down keys';
+const homeEnd = 'Home and end keys';
+const escape = 'Escape key';
+const questionMark = 'Question mark';
+const selectFocusedDate = 'Select the date in focus';
+const moveFocusByOneDay = 'Move backward (left) and forward (right) by one day';
+const moveFocusByOneWeek = 'Move backward (up) and forward (down) by one week';
+const moveFocusByOneMonth = 'Switch months';
+const moveFocustoStartAndEndOfWeek = 'Go to the first or last day of a week';
+const returnFocusToInput = 'Return to the date input field';
+const keyboardNavigationInstructions = `Press the down arrow key to interact with the calendar and
+  select a date. Press the question mark key to get the keyboard shortcuts for changing dates.`;
+const available = 'Available.';
+const unavailable = 'Unavailable.';
 
 export default {
   closeDatePicker,
@@ -12,6 +33,26 @@ export default {
   clearDates,
   jumpToPrevMonth,
   jumpToNextMonth,
+  keyboardShortcuts,
+  showKeyboardShortcutsPanel,
+  hideKeyboardShortcutsPanel,
+  openThisPanel,
+  enterKey,
+  leftArrowRightArrow,
+  upArrowDownArrow,
+  pageUpPageDown,
+  homeEnd,
+  escape,
+  questionMark,
+  selectFocusedDate,
+  moveFocusByOneDay,
+  moveFocusByOneWeek,
+  moveFocusByOneMonth,
+  moveFocustoStartAndEndOfWeek,
+  returnFocusToInput,
+  keyboardNavigationInstructions,
+  available,
+  unavailable,
 };
 
 export const DateRangePickerPhrases = {
@@ -20,11 +61,32 @@ export const DateRangePickerPhrases = {
   focusStartDate,
   jumpToPrevMonth,
   jumpToNextMonth,
+  keyboardShortcuts,
+  showKeyboardShortcutsPanel,
+  hideKeyboardShortcutsPanel,
+  openThisPanel,
+  enterKey,
+  leftArrowRightArrow,
+  upArrowDownArrow,
+  pageUpPageDown,
+  homeEnd,
+  escape,
+  questionMark,
+  selectFocusedDate,
+  moveFocusByOneDay,
+  moveFocusByOneWeek,
+  moveFocusByOneMonth,
+  moveFocustoStartAndEndOfWeek,
+  returnFocusToInput,
+  keyboardNavigationInstructions,
+  available,
+  unavailable,
 };
 
 export const DateRangePickerInputPhrases = {
   focusStartDate,
   clearDates,
+  keyboardNavigationInstructions,
 };
 
 export const SingleDatePickerPhrases = {
@@ -32,18 +94,83 @@ export const SingleDatePickerPhrases = {
   clearDate,
   jumpToPrevMonth,
   jumpToNextMonth,
+  keyboardShortcuts,
+  showKeyboardShortcutsPanel,
+  hideKeyboardShortcutsPanel,
+  openThisPanel,
+  enterKey,
+  leftArrowRightArrow,
+  upArrowDownArrow,
+  pageUpPageDown,
+  homeEnd,
+  escape,
+  questionMark,
+  selectFocusedDate,
+  moveFocusByOneDay,
+  moveFocusByOneWeek,
+  moveFocusByOneMonth,
+  moveFocustoStartAndEndOfWeek,
+  returnFocusToInput,
+  keyboardNavigationInstructions,
+  available,
+  unavailable,
 };
 
 export const SingleDatePickerInputPhrases = {
   clearDate,
+  keyboardNavigationInstructions,
 };
 
 export const DayPickerPhrases = {
   jumpToPrevMonth,
   jumpToNextMonth,
+  keyboardShortcuts,
+  showKeyboardShortcutsPanel,
+  hideKeyboardShortcutsPanel,
+  openThisPanel,
+  enterKey,
+  leftArrowRightArrow,
+  upArrowDownArrow,
+  pageUpPageDown,
+  homeEnd,
+  escape,
+  questionMark,
+  selectFocusedDate,
+  moveFocusByOneDay,
+  moveFocusByOneWeek,
+  moveFocusByOneMonth,
+  moveFocustoStartAndEndOfWeek,
+  returnFocusToInput,
+  available,
+  unavailable,
+};
+
+export const DayPickerKeyboardShortcutsPhrases = {
+  keyboardShortcuts,
+  showKeyboardShortcutsPanel,
+  hideKeyboardShortcutsPanel,
+  openThisPanel,
+  enterKey,
+  leftArrowRightArrow,
+  upArrowDownArrow,
+  pageUpPageDown,
+  homeEnd,
+  escape,
+  questionMark,
+  selectFocusedDate,
+  moveFocusByOneDay,
+  moveFocusByOneWeek,
+  moveFocusByOneMonth,
+  moveFocustoStartAndEndOfWeek,
+  returnFocusToInput,
 };
 
 export const DayPickerNavigationPhrases = {
   jumpToPrevMonth,
   jumpToNextMonth,
+};
+
+export const CalendarDayPhrases = {
+  available,
+  unavailable,
 };

--- a/src/utils/getPhrase.jsx
+++ b/src/utils/getPhrase.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function getPhrase(phrase, args) {
+  if (typeof phrase === 'string') return phrase;
+
+  if (typeof phrase === 'function') return phrase(args);
+
+  return <phrase {...args} />;
+}

--- a/src/utils/getPhrasePropTypes.js
+++ b/src/utils/getPhrasePropTypes.js
@@ -2,5 +2,8 @@ import { PropTypes } from 'react';
 
 export default function getPhrasePropTypes(defaultPhrases) {
   return Object.keys(defaultPhrases)
-    .reduce((phrases, key) => ({ ...phrases, [key]: PropTypes.node }), {});
+    .reduce((phrases, key) => ({
+      ...phrases,
+      [key]: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.node]),
+    }), {});
 }

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -36,6 +36,19 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay renderDay={renderDay} />);
       expect(wrapper.text()).to.equal(dayName);
     });
+
+    describe('button', () => {
+      it('contains a button', () => {
+        const wrapper = shallow(<CalendarDay />);
+        expect(wrapper.find('button')).to.have.lengthOf(1);
+      });
+
+      it('has tabIndex equal to props.tabIndex', () => {
+        const tabIndex = -1;
+        const wrapper = shallow(<CalendarDay tabIndex={tabIndex} />);
+        expect(wrapper.find('button').props().tabIndex).to.equal(tabIndex);
+      });
+    });
   });
 
   describe('#onDayClick', () => {
@@ -49,7 +62,7 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by click', () => {
-      const wrapper = shallow(<CalendarDay />);
+      const wrapper = shallow(<CalendarDay />).find('button');
       wrapper.simulate('click');
       expect(onDayClickSpy).to.have.property('callCount', 1);
     });
@@ -73,7 +86,7 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by mouseenter', () => {
-      const wrapper = shallow(<CalendarDay />);
+      const wrapper = shallow(<CalendarDay />).find('button');
       wrapper.simulate('mouseenter');
       expect(onDayMouseEnterSpy).to.have.property('callCount', 1);
     });
@@ -97,7 +110,7 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by mouseleave', () => {
-      const wrapper = shallow(<CalendarDay />);
+      const wrapper = shallow(<CalendarDay />).find('button');
       wrapper.simulate('mouseleave');
       expect(onDayMouseLeaveSpy).to.have.property('callCount', 1);
     });

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -5,6 +5,8 @@ import sinon from 'sinon-sandbox';
 
 import DateInput from '../../src/components/DateInput';
 
+const event = { preventDefault() {}, stopPropagation() {} };
+
 describe('DateInput', () => {
   describe('#render', () => {
     it('is .DateInput class', () => {
@@ -181,13 +183,25 @@ describe('DateInput', () => {
       wrapper.instance().onChange(evt);
       expect(onChangeStub.getCall(0).args[0]).to.equal(evt.target.value);
     });
+
+    it('calls props.onKeyDownQuestionMark if last typed character is ?', () => {
+      const onKeyDownQuestionMarkStub = sinon.stub();
+      const wrapper = shallow(
+        <DateInput
+          id="date"
+          onKeyDownQuestionMark={onKeyDownQuestionMarkStub}
+        />,
+      );
+      wrapper.instance().onChange({ target: { value: 'foobar?' } });
+      expect(onKeyDownQuestionMarkStub.callCount).to.equal(1);
+    });
   });
 
   describe('#onKeyDown', () => {
     it('calls props.onKeyDownTab if e.key === `Tab` and e.shiftKey === false', () => {
       const onKeyDownTabStub = sinon.stub();
       const wrapper = shallow(<DateInput id="date" onKeyDownTab={onKeyDownTabStub} />);
-      wrapper.instance().onKeyDown({ key: 'Tab', shiftKey: false });
+      wrapper.instance().onKeyDown({ ...event, key: 'Tab', shiftKey: false });
       expect(onKeyDownTabStub.callCount).to.equal(1);
     });
 
@@ -195,15 +209,47 @@ describe('DateInput', () => {
       const onKeyDownShiftTabStub = sinon.stub();
       const wrapper =
         shallow(<DateInput id="date" onKeyDownShiftTab={onKeyDownShiftTabStub} />);
-      wrapper.instance().onKeyDown({ key: 'Tab', shiftKey: true });
+      wrapper.instance().onKeyDown({ ...event, key: 'Tab', shiftKey: true });
       expect(onKeyDownShiftTabStub.callCount).to.equal(1);
     });
 
     it('does not call props.onKeyDownTab if e.key !== `Tab`', () => {
       const onKeyDownTabStub = sinon.stub();
       const wrapper = shallow(<DateInput id="date" onKeyDownTab={onKeyDownTabStub} />);
-      wrapper.instance().onKeyDown({ key: 'foo' });
+      wrapper.instance().onKeyDown({ ...event, key: 'foo' });
       expect(onKeyDownTabStub.callCount).to.equal(0);
+    });
+
+    it('calls props.onKeyDownArrowDown if e.key === `ArrowDown`', () => {
+      const onKeyDownArrowDownStub = sinon.stub();
+      const wrapper = shallow(<DateInput id="date" onKeyDownArrowDown={onKeyDownArrowDownStub} />);
+      wrapper.instance().onKeyDown({ ...event, key: 'ArrowDown' });
+      expect(onKeyDownArrowDownStub.callCount).to.equal(1);
+    });
+
+    it('does not call props.onKeyDownArrowDown if e.key !== `ArrowDown`', () => {
+      const onKeyDownArrowDownStub = sinon.stub();
+      const wrapper = shallow(<DateInput id="date" onKeyDownArrowDown={onKeyDownArrowDownStub} />);
+      wrapper.instance().onKeyDown({ ...event, key: 'foo' });
+      expect(onKeyDownArrowDownStub.callCount).to.equal(0);
+    });
+
+    it('calls props.onKeyDownQuestionMark if e.key === `?`', () => {
+      const onKeyDownQuestionMarkStub = sinon.stub();
+      const wrapper = shallow(
+        <DateInput id="date" onKeyDownQuestionMark={onKeyDownQuestionMarkStub} />,
+      );
+      wrapper.instance().onKeyDown({ ...event, key: '?' });
+      expect(onKeyDownQuestionMarkStub.callCount).to.equal(1);
+    });
+
+    it('does not call props.onKeyDownQuestionMark if e.key !== `?`', () => {
+      const onKeyDownQuestionMarkStub = sinon.stub();
+      const wrapper = shallow(
+        <DateInput id="date" onKeyDownQuestionMark={onKeyDownQuestionMarkStub} />,
+      );
+      wrapper.instance().onKeyDown({ ...event, key: 'foo' });
+      expect(onKeyDownQuestionMarkStub.callCount).to.equal(0);
     });
   });
 

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -12,7 +12,6 @@ import DateRangePickerInput from '../../src/components/DateRangePickerInput';
 import isSameDay from '../../src/utils/isSameDay';
 
 import {
-  VERTICAL_ORIENTATION,
   START_DATE,
   END_DATE,
 } from '../../constants';
@@ -579,13 +578,12 @@ describe('DateRangePickerInputController', () => {
       });
     });
 
-    describe('props.startDate = moment and props.orientation = VERTICAL_ORIENTATION', () => {
+    describe('props.startDate = moment', () => {
       it('calls props.onFocusChange once with arg END_DATE', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
           <DateRangePickerInputController
             startDate={moment(today)}
-            orientation={VERTICAL_ORIENTATION}
             onFocusChange={onFocusChangeStub}
           />,
         );

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -20,14 +20,14 @@ describe('DateRangePickerInput', () => {
 
     describe('props.disabled is falsey', () => {
       it('does not have .DateRangePickerInput--disabled class ', () => {
-        const wrapper = shallow(<DateRangePickerInput id="date" disabled={false} />);
+        const wrapper = shallow(<DateRangePickerInput disabled={false} />);
         expect(wrapper.find('.DateRangePickerInput--disabled')).to.have.lengthOf(0);
       });
     });
 
     describe('props.disabled is truthy', () => {
       it('has .DateRangePickerInput--disabled class', () => {
-        const wrapper = shallow(<DateRangePickerInput id="date" disabled />);
+        const wrapper = shallow(<DateRangePickerInput disabled />);
         expect(wrapper.find('.DateRangePickerInput--disabled')).to.have.lengthOf(1);
       });
     });
@@ -195,16 +195,16 @@ describe('DateRangePickerInput', () => {
 
   describe('calendar icon interaction', () => {
     describe('onClick', () => {
-      it('props.onStartDateFocus gets triggered', () => {
-        const onStartDateFocusSpy = sinon.spy();
+      it('props.onArrowDown gets triggered', () => {
+        const onArrowDownSpy = sinon.spy();
         const wrapper = shallow(
           <DateRangePickerInput
-            onStartDateFocus={onStartDateFocusSpy}
+            onArrowDown={onArrowDownSpy}
             showDefaultInputIcon
           />);
         const calendarIconWrapper = wrapper.find('.DateRangePickerInput__calendar-icon');
         calendarIconWrapper.simulate('click');
-        expect(onStartDateFocusSpy.called).to.equal(true);
+        expect(onArrowDownSpy.callCount).to.equal(1);
       });
     });
   });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -175,6 +175,51 @@ describe('DateRangePicker', () => {
       wrapper.instance().onOutsideClick();
       expect(onFocusChangeStub.callCount).to.equal(1);
     });
+
+    it('sets state.isDateRangePickerInputFocused to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          focusedInput={START_DATE}
+          onFocusChange={sinon.stub()}
+          onDatesChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDateRangePickerInputFocused: true,
+      });
+      wrapper.instance().onOutsideClick();
+      expect(wrapper.state().isDateRangePickerInputFocused).to.equal(false);
+    });
+
+    it('sets state.isDayPickerFocused to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          focusedInput={START_DATE}
+          onFocusChange={sinon.stub()}
+          onDatesChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: true,
+      });
+      wrapper.instance().onOutsideClick();
+      expect(wrapper.state().isDayPickerFocused).to.equal(false);
+    });
+
+    it('sets state.showKeyboardShortcuts to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          focusedInput={START_DATE}
+          onFocusChange={sinon.stub()}
+          onDatesChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        showKeyboardShortcuts: true,
+      });
+      wrapper.instance().onOutsideClick();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
+    });
   });
 
   describe('#onDateRangePickerInputFocus', () => {
@@ -279,6 +324,63 @@ describe('DateRangePicker', () => {
       wrapper.instance().onDayPickerFocus();
       expect(wrapper.state().isDayPickerFocused).to.equal(true);
     });
+
+    it('sets state.showKeyboardShortcuts to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        showKeyboardShortcuts: true,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
+    });
+
+    describe('focusedInput is truthy', () => {
+      it('does not call onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            focusedInput={START_DATE}
+            onDatesChange={sinon.stub()}
+            onFocusChange={onFocusChangeStub}
+          />,
+        );
+        wrapper.instance().onDayPickerFocus();
+        expect(onFocusChangeStub.callCount).to.equal(0);
+      });
+    });
+
+    describe('focusedInput is falsey', () => {
+      it('calls onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            focusedInput={null}
+            onDatesChange={sinon.stub()}
+            onFocusChange={onFocusChangeStub}
+          />,
+        );
+        wrapper.instance().onDayPickerFocus();
+        expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls onFocusChange with START_DATE as arg', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <DateRangePicker
+            focusedInput={null}
+            onDatesChange={sinon.stub()}
+            onFocusChange={onFocusChangeStub}
+          />,
+        );
+        wrapper.instance().onDayPickerFocus();
+        expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
+      });
+    });
   });
 
   describe('#onDayPickerBlur', () => {
@@ -308,6 +410,64 @@ describe('DateRangePicker', () => {
       });
       wrapper.instance().onDayPickerBlur();
       expect(wrapper.state().isDayPickerFocused).to.equal(false);
+    });
+
+    it('sets state.showKeyboardShortcuts to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        showKeyboardShortcuts: true,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
+    });
+  });
+
+  describe('#showKeyboardShortcutsPanel', () => {
+    it('sets state.isDateRangePickerInputFocused to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDateRangePickerInputFocused: true,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().isDateRangePickerInputFocused).to.equal(false);
+    });
+
+    it('sets state.isDayPickerFocused to true', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: false,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().isDayPickerFocused).to.equal(true);
+    });
+
+    it('sets state.showKeyboardShortcuts to true', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        showKeyboardShortcuts: false,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(true);
     });
   });
 

--- a/test/components/DayPickerKeyboardShortcuts_spec.jsx
+++ b/test/components/DayPickerKeyboardShortcuts_spec.jsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
+import { shallow } from 'enzyme';
+
+import { DayPickerKeyboardShortcutsPhrases } from '../../src/defaultPhrases';
+import CloseButton from '../../src/svg/close.svg';
+
+import DayPickerKeyboardShortcuts, { KeyboardShortcutRow } from '../../src/components/DayPickerKeyboardShortcuts';
+
+describe('KeyboardShortcutRow', () => {
+  it('is a .KeyboardShortcutRow', () => {
+    const wrapper = shallow(
+      <KeyboardShortcutRow
+        unicode="foo"
+        label="bar"
+        action="baz"
+      />,
+    );
+    expect(wrapper.is('.KeyboardShortcutRow')).to.equal(true);
+  });
+
+  it('is an li', () => {
+    const wrapper = shallow(
+      <KeyboardShortcutRow
+        unicode="foo"
+        label="bar"
+        action="baz"
+      />,
+    );
+    expect(wrapper.is('li')).to.equal(true);
+  });
+
+  describe('.KeyboardShortcutRow__key-container', () => {
+    it('is rendered', () => {
+      const wrapper = shallow(
+        <KeyboardShortcutRow
+          unicode="foo"
+          label="bar"
+          action="baz"
+        />,
+      );
+      expect(wrapper.find('.KeyboardShortcutRow__key-container')).to.have.lengthOf(1);
+    });
+
+    describe('.KeyboardShortcutRow__key', () => {
+      it('is rendered', () => {
+        const wrapper = shallow(
+          <KeyboardShortcutRow
+            unicode="foo"
+            label="bar"
+            action="baz"
+          />,
+        );
+        const keyContainer = wrapper.find('.KeyboardShortcutRow__key-container');
+        expect(keyContainer.find('.KeyboardShortcutRow__key')).to.have.lengthOf(1);
+      });
+
+      it('has role=`img`', () => {
+        const wrapper = shallow(
+          <KeyboardShortcutRow
+            unicode="foo"
+            label="bar"
+            action="baz"
+          />,
+        );
+        const keyContainer = wrapper.find('.KeyboardShortcutRow__key-container');
+        expect(keyContainer.find('.KeyboardShortcutRow__key').props().role).to.equal('img');
+      });
+
+      it('has props.unicode as child', () => {
+        const unicode = 'UNICODE';
+        const wrapper = shallow(
+          <KeyboardShortcutRow
+            unicode={unicode}
+            label="bar"
+            action="baz"
+          />,
+        );
+        const keyContainer = wrapper.find('.KeyboardShortcutRow__key-container');
+        expect(keyContainer.find('.KeyboardShortcutRow__key').text()).to.equal(unicode);
+      });
+    });
+  });
+
+  describe('.KeyboardShortcutRow__action', () => {
+    it('is rendered', () => {
+      const wrapper = shallow(
+        <KeyboardShortcutRow
+          unicode="foo"
+          label="bar"
+          action="baz"
+        />,
+      );
+      expect(wrapper.find('.KeyboardShortcutRow__action')).to.have.lengthOf(1);
+    });
+
+    it('contains props.action as child', () => {
+      const action = 'ACTION';
+      const wrapper = shallow(
+        <KeyboardShortcutRow
+          unicode="foo"
+          label="bar"
+          action={action}
+        />,
+      );
+      expect(wrapper.find('.KeyboardShortcutRow__action').text()).to.equal(action);
+    });
+  });
+});
+
+describe('DayPickerKeyboardShortcuts', () => {
+  describe('#render', () => {
+    describe('.DayPickerKeyboardShortcuts__show', () => {
+      it('is rendered', () => {
+        const wrapper = shallow(<DayPickerKeyboardShortcuts />);
+        expect(wrapper.find('.DayPickerKeyboardShortcuts__show')).to.have.lengthOf(1);
+      });
+
+      it('is a button', () => {
+        const wrapper = shallow(<DayPickerKeyboardShortcuts />);
+        expect(wrapper.find('.DayPickerKeyboardShortcuts__show').is('button')).to.equal(true);
+      });
+
+      it('contains .DayPickerKeyboardShortcuts__show_span', () => {
+        const wrapper = shallow(<DayPickerKeyboardShortcuts />);
+        const buttonWrapper = wrapper.find('.DayPickerKeyboardShortcuts__show');
+        expect(buttonWrapper.find('.DayPickerKeyboardShortcuts__show_span')).to.have.lengthOf(1);
+      });
+
+      it('click calls props.openKeyboardShortcutsPanel', () => {
+        const openKeyboardShortcutsPanelStub = sinon.stub();
+        const wrapper = shallow(
+          <DayPickerKeyboardShortcuts
+            openKeyboardShortcutsPanel={openKeyboardShortcutsPanelStub}
+          />,
+        );
+        const buttonWrapper = wrapper.find('.DayPickerKeyboardShortcuts__show');
+        buttonWrapper.simulate('click');
+        expect(openKeyboardShortcutsPanelStub.callCount).to.equal(1);
+      });
+    });
+
+    describe('.DayPickerKeyboardShortcuts__panel', () => {
+      it('is not rendered if props.showKeyboardShortcutsPanel is falsey', () => {
+        const wrapper = shallow(
+          <DayPickerKeyboardShortcuts
+            showKeyboardShortcutsPanel={false}
+          />,
+        );
+        expect(wrapper.find('.DayPickerKeyboardShortcuts__panel')).to.have.lengthOf(0);
+      });
+
+      it('is rendered if props.showKeyboardShortcutsPanel is truthy', () => {
+        const wrapper = shallow(
+          <DayPickerKeyboardShortcuts
+            showKeyboardShortcutsPanel
+          />,
+        );
+        expect(wrapper.find('.DayPickerKeyboardShortcuts__panel')).to.have.lengthOf(1);
+      });
+
+      it('has role of dialog', () => {
+        const wrapper = shallow(
+          <DayPickerKeyboardShortcuts
+            showKeyboardShortcutsPanel
+          />,
+        );
+        expect(wrapper.find('.DayPickerKeyboardShortcuts__panel').props().role).to.equal('dialog');
+      });
+
+      describe('.DayPickerKeyboardShortcuts__title', () => {
+        it('is rendered', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__title')).to.have.lengthOf(1);
+        });
+
+        it('has props.phrases.keyboardShortcuts as a child', () => {
+          const keyboardShortcuts = 'FOOBARBAZ';
+          const phrases = { ...DayPickerKeyboardShortcutsPhrases, keyboardShortcuts };
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+              phrases={phrases}
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__title').text()).to.equal(keyboardShortcuts);
+        });
+      });
+
+      describe('.DayPickerKeyboardShortcuts__close', () => {
+        it('is rendered', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__close')).to.have.lengthOf(1);
+        });
+
+        it('is a button', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__close').is('button')).to.equal(true);
+        });
+
+        it('renders a CloseButton', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__close').find(CloseButton)).to.have.lengthOf(1);
+        });
+
+        it('calls props.closeKeyboardShortcutsPanel if clicked', () => {
+          const closeKeyboardShortcutsPanelStub = sinon.stub();
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+              closeKeyboardShortcutsPanel={closeKeyboardShortcutsPanelStub}
+            />,
+          );
+          const closeButton = wrapper.find('.DayPickerKeyboardShortcuts__close');
+          closeButton.simulate('click');
+          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
+        });
+      });
+
+      describe('.DayPickerKeyboardShortcuts__list', () => {
+        it('is rendered', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__list')).to.have.lengthOf(1);
+        });
+
+        it('is a ul', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__list').is('ul')).to.equal(true);
+        });
+
+        it('renders 7 KeyboardShortcutRow components', () => {
+          const wrapper = shallow(
+            <DayPickerKeyboardShortcuts
+              showKeyboardShortcutsPanel
+            />,
+          );
+          expect(wrapper.find('.DayPickerKeyboardShortcuts__list').find(KeyboardShortcutRow)).to.have.lengthOf(7);
+        });
+      });
+    });
+  });
+});

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -391,7 +391,7 @@ describe('DayPicker', () => {
         });
 
         it('calls closeKeyboardShortcutsPanel if state.showKeyboardShortcuts === true', () => {
-          const closeKeyboardShortcutsPanelSpy = sinon.stub(DayPicker.prototype, 'closeKeyboardShortcutsPanelSpy');
+          const closeKeyboardShortcutsPanelSpy = sinon.stub(DayPicker.prototype, 'closeKeyboardShortcutsPanel');
           const wrapper = shallow(<DayPicker />);
           wrapper.setState({
             focusedDate: today,
@@ -510,18 +510,6 @@ describe('DayPicker', () => {
 
         wrapper.instance().getFocusedDay(today);
         expect(getFirstFocusableDayStub.getCall(0).args[0].isSame(today, 'day')).to.equal(true);
-      });
-
-      it('calls getFirstFocusableDay with state.currentMonth if no arg', () => {
-        const test = moment().add(3, 'months');
-        const getFirstFocusableDayStub = sinon.stub();
-        const wrapper = shallow(<DayPicker getFirstFocusableDay={getFirstFocusableDayStub} />);
-        wrapper.setState({
-          currentMonth: test,
-        });
-        getFirstFocusableDayStub.reset(); // getFirstFocusableDay gets called in the constructor
-        wrapper.instance().getFocusedDay();
-        expect(getFirstFocusableDayStub.getCall(0).args[0].isSame(test, 'day')).to.equal(true);
       });
 
       it('returns getFirstFocusableDay() value', () => {

--- a/test/utils/getPhrasePropTypes_spec.js
+++ b/test/utils/getPhrasePropTypes_spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { PropTypes } from 'react';
 
 import getPhrasePropTypes from '../../src/utils/getPhrasePropTypes';
 
@@ -14,13 +13,6 @@ describe('#getPhrasePropTypes', () => {
     const propTypes = getPhrasePropTypes(PhraseObject);
     Object.keys(PhraseObject).forEach((key) => {
       expect(Object.keys(propTypes).filter(type => type === key).length).to.not.equal(0);
-    });
-  });
-
-  it('each value is equal to PropTypes.node', () => {
-    const propTypes = getPhrasePropTypes(PhraseObject);
-    Object.values(propTypes).forEach((value) => {
-      expect(value).to.equal(PropTypes.node);
     });
   });
 });


### PR DESCRIPTION
This is an MVP of keyboard accessibility! I imagine there will still be some polish to take care of, especially when it comes to managing focus and aria roles throughout. BUT I would really like to get this merged so that we can iterate more on it (and add better messaging/validation/accessibility to the inputs themselves as well).

HAVE A GIF!
![react-dates](https://cloud.githubusercontent.com/assets/1383861/23485019/72d9aa3e-fe8e-11e6-8711-f14dbc7391ea.gif)

- [x] Fix issue where you navigate from April 2017 to May 2017 with keyboard with outside days enabled
- [X] second param in `onNextMonthClick`/`onPrevMonthClick`???
- [x] Update SingleDatePicker 
- [x] if a CalendarDay has been blurred in the DOM, (ie going to the prev month/next month buttons) but the month transition doesn't trigger a different focusedDate... then the day doesn't get updates and therefore doesn't get refocused. :/  
- [x] unavailable messaging on days
- [X] keyboard shortcuts explanation
- [x] hide keyboard shortcuts menu on touch devices
- [x] write some tests!
- [x] fix vertical orientation keyboard shortcuts panel
- [x] fix safari `?` shortcut
- [x] enable keyboard on `DayPickerRangeController`
- [x] return focus appropriately after the keyboard shortcuts dialog is closed
- [x] adjust phrase props for final copy

@airbnb/webinfra plz give me some love. #