### PR TITLE
Avoid transition padding months for scrollable

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -5,13 +5,6 @@
   padding: 0 13px;
   vertical-align: top;
 
-  &:first-of-type {
-    position: absolute;
-    z-index: -1;
-    opacity: 0;
-    pointer-events: none;
-  }
-
   table {
     border-collapse: collapse;
     border-spacing: 0;
@@ -30,6 +23,18 @@
 
 .CalendarMonth--vertical {
   display: block;
+}
+
+// On orientations with transitions, hide the first month offscreen for a
+// smoother transition if it's displayed.
+.CalendarMonth--horizontal,
+.CalendarMonth--vertical {
+  &:first-of-type {
+    position: absolute;
+    z-index: -1;
+    opacity: 0;
+    pointer-events: none;
+  }
 }
 
 .CalendarMonth__caption {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "airbnb-prop-types": "^2.1.0",
     "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
+    "lodash.range": "^3.2.0",
     "react-moment-proptypes": "^1.2.1",
     "react-portal": "^3.0.0"
   },

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -382,14 +382,16 @@ export default class DayPicker extends React.Component {
       weekHeaders.push(this.renderWeekHeader(i));
     }
 
-    let firstVisibleMonthIndex = 1;
-    if (monthTransition === PREV_TRANSITION) {
-      firstVisibleMonthIndex -= 1;
-    } else if (monthTransition === NEXT_TRANSITION) {
-      firstVisibleMonthIndex += 1;
-    }
-
     const verticalScrollable = this.props.orientation === VERTICAL_SCROLLABLE;
+
+    let firstVisibleMonthIndex;
+    if (monthTransition === PREV_TRANSITION || verticalScrollable) {
+      firstVisibleMonthIndex = 0;
+    } else if (monthTransition === NEXT_TRANSITION) {
+      firstVisibleMonthIndex = 2;
+    } else {
+      firstVisibleMonthIndex = 1;
+    }
 
     const dayPickerClassNames = cx('DayPicker', {
       'DayPicker--horizontal': this.isHorizontal(),
@@ -441,6 +443,7 @@ export default class DayPicker extends React.Component {
             style={transitionContainerStyle}
           >
             <CalendarMonthGrid
+              addTransitionMonths={orientation !== VERTICAL_SCROLLABLE}
               ref="calendarMonthGrid"
               transformValue={transformValue}
               enableOutsideDays={enableOutsideDays}

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 
 import CalendarMonth from '../../src/components/CalendarMonth';
-import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
+import CalendarMonthGrid, { getMonths } from '../../src/components/CalendarMonthGrid';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
@@ -73,5 +73,77 @@ describe('CalendarMonthGrid', () => {
       ), {});
 
     expect(Object.keys(collisions).length).to.equal(months.length);
+  });
+
+  describe('#getMonths', () => {
+    it('returns the same number of months when addTransitionMonths is false', () => {
+      expect(getMonths({
+        initialMonth: moment(),
+        numberOfMonths: 2,
+        addTransitionMonths: false,
+      })).to.have.length(2);
+    });
+
+    it('adds additional month before and after when addTransitionMonths is true', () => {
+      expect(getMonths({
+        initialMonth: moment(),
+        numberOfMonths: 10,
+        addTransitionMonths: true,
+      })).to.have.length(12);
+    });
+
+    it('prepends previous month when addTransitionMonths is true', () => {
+      const initialMonth = moment();
+      const prevMonth = initialMonth.clone().subtract(1, 'month');
+
+      const months = getMonths({
+        initialMonth,
+        numberOfMonths: 2,
+        addTransitionMonths: true,
+      });
+
+      expect(months[0].format('YYYY-MM')).to.equal(prevMonth.format('YYYY-MM'));
+    });
+
+    it('appends additional month when addTransitionMonths is true', () => {
+      const initialMonth = moment();
+      const numberOfMonths = 2;
+
+      // Example:
+      // initialMonth = Jan
+      // numberOfMonths = 2
+      // followingMonth = Jan + 2 = Mar
+      // expected months = [ Dec, Jan, Feb, Mar ]
+      const followingMonth = initialMonth.clone().add(numberOfMonths, 'month');
+
+      const months = getMonths({
+        initialMonth,
+        numberOfMonths,
+        addTransitionMonths: true,
+      });
+
+      expect(
+        months[months.length - 1].format('YYYY-MM')
+      ).to.equal(followingMonth.format('YYYY-MM'));
+    });
+  });
+
+  describe('#componentWillReceiveProps', () => {
+    it('updates months when numberOfMonths changes', () => {
+      const initialMonth = moment();
+      const wrapper = shallow(
+        <CalendarMonthGrid
+          addTransitionMonths={false}
+          numberOfMonths={2}
+          initialMonth={initialMonth}
+        />
+      );
+
+      wrapper.instance().componentWillReceiveProps({
+        initialMonth,
+        numberOfMonths: 4,
+      });
+      expect(wrapper.state('months')).to.have.length(4);
+    });
   });
 });


### PR DESCRIPTION
to: @majapw @ljharb 

Another perf PR that avoids rendering the hidden leading and trailing months for the scrollable version of DayPicker. These additional months are used to improve sliding animation for the horizontal and vertical orientation daypickers. The new scrollable daypicker doesn't use this animation, and removing will save some rendering.

Along the way, I refactored and add specs for `getMonths` and `componentWillReceiveProps`.