### PR TITLE
Fix blinking cursor on iOS

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -17,10 +17,10 @@
     border-spacing: 0;
   }
 
-  user-select: none;
   -moz-user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
+  user-select: none;
 }
 
 .CalendarMonth--horizontal {

--- a/css/DateInput.scss
+++ b/css/DateInput.scss
@@ -50,6 +50,13 @@ $caret-top: $react-dates-spacing-vertical-picker - $react-dates-width-tooltip-ar
   border: 0;
   height: 100%;
   width: 100%;
+
+  &[readonly] {
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
 }
 
 .DateInput__display-text {

--- a/css/DayPickerNavigation.scss
+++ b/css/DayPickerNavigation.scss
@@ -4,10 +4,10 @@
 .DayPickerNavigation__next {
   cursor: pointer;
   line-height: 0.78;
-  user-select: none;
   -webkit-user-select: none; /* Chrome/Safari */
   -moz-user-select: none; /* Firefox */
   -ms-user-select: none; /* IE10+ */
+  user-select: none;
 }
 
 .DayPickerNavigation__prev--default,


### PR DESCRIPTION
to: @majapw @ljharb 

Removes the blinking cursor appearing in DateInput on iOS by adding `user-select: none;` ([recommended as a workaround in another project](https://github.com/Dogfalo/materialize/issues/2448#issuecomment-242662049)). This PR should resolve the ["Blinking cursor in mobile" issue](https://github.com/airbnb/react-dates/issues/253).

Here's a gif of the blinking cursor and "Done" bottom bar:
![ios-cursor-flash](https://cloud.githubusercontent.com/assets/8942/22706424/0a1e7be4-ed24-11e6-8107-4685d7c50788.gif)
