### PR TITLE
Avoid passing false as day

### DIFF
--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -10,7 +10,7 @@ export default function getCalendarMonthWeeks(month, enableOutsideDays) {
 
   // days belonging to the previous month
   for (let i = 0; i < currentDay.weekday(); i++) {
-    const prevDay = enableOutsideDays && currentDay.clone().subtract(i + 1, 'day');
+    const prevDay = enableOutsideDays ? currentDay.clone().subtract(i + 1, 'day') : null;
     currentWeek.unshift(prevDay);
   }
 
@@ -29,7 +29,7 @@ export default function getCalendarMonthWeeks(month, enableOutsideDays) {
   if (currentDay.weekday() !== 0) {
     // days belonging to the next month
     for (let k = currentDay.weekday(), count = 0; k < 7; k++, count++) {
-      const nextDay = enableOutsideDays && currentDay.clone().add(count, 'day');
+      const nextDay = enableOutsideDays ? currentDay.clone().add(count, 'day') : null;
       currentWeek.push(nextDay);
     }
 

--- a/test/utils/getCalendarMonthWeeks_spec.js
+++ b/test/utils/getCalendarMonthWeeks_spec.js
@@ -38,6 +38,32 @@ describe('getCalendarMonthWeeks', () => {
     });
   });
 
+  describe('padding when enableOutsideDays is false', () => {
+    let weeksWithPadding;
+
+    before(() => {
+      // using specific month Feb 2017 to manually compare with calendar
+      weeksWithPadding = getCalendarMonthWeeks(moment('2017-02-01'), false);
+    });
+
+    it('null pads leading days', () => {
+      const firstWeek = weeksWithPadding[0];
+      expect(firstWeek[0]).to.equal(null); // Sun Jan 29
+      expect(firstWeek[1]).to.equal(null); // Mon Jan 30
+      expect(firstWeek[2]).to.equal(null); // Tue Jan 31
+      expect(firstWeek[3]).to.not.equal(null); // Wed Feb 1
+    });
+
+    it('null pads trailing days', () => {
+      const lastWeek = weeksWithPadding[weeksWithPadding.length - 1];
+      expect(lastWeek[2]).to.not.equal(null); // Tue Feb 28
+      expect(lastWeek[3]).to.equal(null); // Wed Mar 1
+      expect(lastWeek[4]).to.equal(null); // Thu Mar 2
+      expect(lastWeek[5]).to.equal(null); // Fri Mar 3
+      expect(lastWeek[6]).to.equal(null); // Sat Mar 4
+    });
+  });
+
   describe('Daylight Savings Time issues', () => {
     it('last of February does not equal first of March', () => {
       const february = getCalendarMonthWeeks(today.clone().month(1));


### PR DESCRIPTION
to: @majapw @ljharb 

Small PropType fix for my [previous CalendarDay PR](https://github.com/airbnb/react-dates/pull/291). In `CalendarMonth`, `day` is `false` instead of a moment object for outside days, which fails PropType checks.

<img width="820" alt="screen shot 2017-02-07 at 12 11 17 pm" src="https://cloud.githubusercontent.com/assets/8942/22709413/8d19465a-ed2e-11e6-84f9-17b4b28649ee.png">
