### PR TITLE
Custom content in CalendarDay with #renderDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ The `navPrev` and `navNext` props are used to assign custom icons to the "Next",
   navNext: PropTypes.node,
 ```
 
+**Custom content in calendar days:**
+
+If you want to customize the content in a calendar day, you can specify a `renderDay` function which receives the `day` moment object as its only argument. `renderDay` will be responsible for rendering _every_ day and should return `day.format('D')` for the default display.
+```
+  renderDay: PropTypes.func,
+```
+
 **Some useful callbacks:**
 
 If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -7,19 +7,21 @@ import cx from 'classnames';
 const propTypes = {
   day: momentPropTypes.momentObj,
   isOutsideDay: PropTypes.bool,
+  modifiers: PropTypes.object,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  modifiers: PropTypes.object,
+  renderDay: PropTypes.func,
 };
 
 const defaultProps = {
   day: moment(),
   isOutsideDay: false,
+  modifiers: {},
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  modifiers: {},
+  renderDay: null,
 };
 
 export function getModifiersForDay(modifiers, day) {
@@ -51,6 +53,7 @@ export default class CalendarDay extends React.Component {
       day,
       isOutsideDay,
       modifiers,
+      renderDay,
     } = this.props;
 
     const className = cx('CalendarDay', {
@@ -64,7 +67,7 @@ export default class CalendarDay extends React.Component {
         onMouseLeave={e => this.onDayMouseLeave(day, e)}
         onClick={e => this.onDayClick(day, e)}
       >
-        {day.format('D')}
+        {renderDay ? renderDay(day) : day.format('D')}
       </td>
       :
       <td />

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -27,6 +27,7 @@ const propTypes = {
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  renderDay: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -41,6 +42,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  renderDay: null,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -77,6 +79,7 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderDay,
     } = this.props;
 
     const { weeks } = this.state;
@@ -107,6 +110,7 @@ export default class CalendarMonth extends React.Component {
                     onDayMouseEnter={onDayMouseEnter}
                     onDayMouseLeave={onDayMouseLeave}
                     onDayClick={onDayClick}
+                    renderDay={renderDay}
                   />
                 ))}
               </tr>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -30,6 +30,7 @@ const propTypes = {
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
+  renderDay: PropTypes.func,
   transformValue: PropTypes.string,
 
   // i18n
@@ -48,6 +49,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
+  renderDay: null,
   transformValue: 'none',
 
   // i18n
@@ -144,6 +146,7 @@ export default class CalendarMonthGrid extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
+      renderDay,
       onMonthTransitionEnd,
     } = this.props;
 
@@ -179,6 +182,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
+              renderDay={renderDay}
             />
           );
         })}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -62,6 +62,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  renderDay: null,
+
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
@@ -205,6 +207,7 @@ export default class DateRangePicker extends React.Component {
       endDate,
       minimumNights,
       keepOpenOnDateSelect,
+      renderDay,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -242,6 +245,7 @@ export default class DateRangePicker extends React.Component {
           isDayHighlighted={isDayHighlighted}
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
+          renderDay={renderDay}
         />
 
         {withFullScreenPortal &&
@@ -285,6 +289,7 @@ export default class DateRangePicker extends React.Component {
       keepOpenOnDateSelect,
       onDatesChange,
       onFocusChange,
+      renderDay,
     } = this.props;
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
@@ -315,6 +320,7 @@ export default class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={onFocusChange}
+            renderDay={renderDay}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
           />

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -43,6 +43,8 @@ const propTypes = {
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
 
+  renderDay: PropTypes.func,
+
   // i18n
   monthFormat: PropTypes.string,
 };
@@ -67,6 +69,7 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick() {},
 
+  renderDay: null,
   // i18n
   monthFormat: 'MMMM YYYY',
 };
@@ -372,6 +375,7 @@ export default class DayPicker extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderDay,
       onOutsideClick,
       monthFormat,
     } = this.props;
@@ -454,6 +458,7 @@ export default class DayPicker extends React.Component {
               onDayClick={onDayClick}
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
+              renderDay={renderDay}
               onMonthTransitionEnd={this.updateStateAfterMonthTransition}
               monthFormat={monthFormat}
             />

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -47,6 +47,7 @@ const propTypes = {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
+  renderDay: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -81,6 +82,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onOutsideClick() {},
+
+  renderDay: null,
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -236,6 +239,7 @@ export default class DayPickerRangeController extends React.Component {
       enableOutsideDays,
       initialVisibleMonth,
       focusedInput,
+      renderDay,
     } = this.props;
 
     const modifiers = {
@@ -279,6 +283,7 @@ export default class DayPickerRangeController extends React.Component {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
+        renderDay={renderDay}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -60,6 +60,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  renderDay: null,
+
   // i18n
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
@@ -282,6 +284,7 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       initialVisibleMonth,
+      renderDay,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -323,6 +326,7 @@ export default class SingleDatePicker extends React.Component {
           onOutsideClick={onOutsideClick}
           navPrev={navPrev}
           navNext={navNext}
+          renderDay={renderDay}
         />
 
         {withFullScreenPortal &&

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -40,6 +40,8 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  renderDay: PropTypes.func,
+
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -38,6 +38,8 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  renderDay: PropTypes.func,
+
   // i18n
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -277,8 +277,14 @@ storiesOf('DateRangePicker', module)
       customArrowIcon={<TestCustomArrowIcon />}
     />
   ))
+  .addWithInfo('with custom daily details', () => (
+    <DateRangePickerWrapper
+      renderDay={day => day.format('ddd')}
+    />
+  ))
   .addWithInfo('with screen reader message', () => (
     <DateRangePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
   ));
+

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -60,6 +60,11 @@ storiesOf('DayPicker', module)
       navNext={<TestNextIcon />}
     />
   ))
+  .addWithInfo('with custom details', () => (
+    <DayPicker
+      renderDay={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}
+    />
+  ))
   .addWithInfo('vertical with fixed-width container', () => (
     <div style={{ width: '400px' }}>
       <DayPicker

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -141,4 +141,10 @@ storiesOf('SingleDatePicker', module)
     <SingleDatePickerWrapper
       screenReaderInputMessage='Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc'
     />
+  ))
+  .addWithInfo('with custom daily details', () => (
+    <SingleDatePickerWrapper
+      numberOfMonths={1}
+      renderDay={day => day.format('ddd')}
+    />
   ));

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -29,6 +29,13 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay day={lastOfMonth} />);
       expect(wrapper.text()).to.equal(lastOfMonth.format('D'));
     });
+
+    it('contains arbitrary content if renderDay is provided', () => {
+      const dayName = moment().format('dddd');
+      const renderDay = day => day.format('dddd');
+      const wrapper = shallow(<CalendarDay renderDay={renderDay} />);
+      expect(wrapper.text()).to.equal(dayName);
+    });
   });
 
   describe('#onDayClick', () => {


### PR DESCRIPTION
Replaces #283

```js
/**
 * @param day - the Moment object representing the day
 * @returns {string|element} - a single text or JSX node
 */
 // example
 // print a happy cat on Fridays
 <CalendarDay
   renderDay={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}
 />
```

![screenshot 2017-02-07 13 41 54](https://cloud.githubusercontent.com/assets/971616/22714713/bc9ee20e-ed5b-11e6-8698-b2c06017af6b.png)
