### PR TITLE
Prevent outside day boxes from resizing on hover

### DIFF
--- a/css/CalendarDay.scss
+++ b/css/CalendarDay.scss
@@ -26,7 +26,7 @@
 }
 
 .CalendarDay--outside {
-  border: 0;
+  border: 1px solid rgba(0, 0, 0, 0);
   cursor: default;
 
   &:active {


### PR DESCRIPTION
Fixes #308.

Right now because outside days have no border and hovering does, the box for outside days slightly resizes when hovered over.

Adding a 1px invisible border is the easiest way to fix this.

Comparison:

Old: 
![feb-07-2017 18-13-30](https://cloud.githubusercontent.com/assets/5831434/22715926/4e39b02c-ed61-11e6-85d3-a5d43027a73a.gif)

New: 
![feb-07-2017 18-13-36](https://cloud.githubusercontent.com/assets/5831434/22715927/4e3f5cac-ed61-11e6-908d-f3602d8a0983.gif)
