### PR TITLE
Fix blocked days when moment obj time isn't noon

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -163,7 +163,7 @@ export default class DayPickerRangeController extends React.Component {
     if (focusedInput !== END_DATE) return false;
 
     if (startDate) {
-      const dayDiff = day.diff(startDate, 'days');
+      const dayDiff = day.diff(startDate.clone().startOf('day').hour(12), 'days');
       return dayDiff < minimumNights && dayDiff >= 0;
     }
     return isOutsideRange(moment(day).subtract(minimumNights, 'days'));

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -17,7 +17,8 @@ import {
   END_DATE,
 } from '../../constants';
 
-const today = moment().startOf('day');
+// Set to noon to mimic how days in the picker are configured internally
+const today = moment().startOf('day').hours(12);
 
 describe('DateRangePickerInputController', () => {
   describe('#render', () => {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -12,7 +12,8 @@ import isInclusivelyAfterDay from '../../src/utils/isInclusivelyAfterDay';
 
 import { START_DATE, END_DATE } from '../../constants';
 
-const today = moment().startOf('day');
+// Set to noon to mimic how days in the picker are configured internally
+const today = moment().startOf('day').hours(12);
 
 describe('DayPickerRangeController', () => {
   describe('#render()', () => {
@@ -298,6 +299,19 @@ describe('DayPickerRangeController', () => {
               <DayPickerRangeController
                 focusedInput={END_DATE}
                 startDate={startDate}
+                minimumNights={MIN_NIGHTS}
+              />,
+            );
+            expect(wrapper.instance().doesNotMeetMinimumNights(testDate)).to.equal(false);
+          });
+
+          it('handles time differences of less than 1 full day properly', () => {
+            const partialDate = moment(startDate).add(5, 'minutes');
+            const testDate = moment(startDate).add(MIN_NIGHTS, 'days');
+            const wrapper = shallow(
+              <DayPickerRangeController
+                focusedInput={END_DATE}
+                startDate={partialDate}
                 minimumNights={MIN_NIGHTS}
               />,
             );

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -18,7 +18,8 @@ import SingleDatePicker from '../../src/components/SingleDatePicker';
 
 import isSameDay from '../../src/utils/isSameDay';
 
-const today = moment();
+// Set to noon to mimic how days in the picker are configured internally
+const today = moment().startOf('day').hours(12);
 
 describe('SingleDatePicker', () => {
   describe('#render', () => {


### PR DESCRIPTION
References #306.

Currently, the logic for checking if days are blocked by looking at number of days difference in `doesNotMeetMinimumNights()`. However, the day difference rounds down to zero if the time difference is anything < 24hr.

This patch checks if `minimumNights === 1` and if so uses `isSameDay()` instead.

I looked through the specs and couldn't figure out a good place to add a check for this base case, and would appreciate suggestions. 

**Before**
![screen shot 2017-02-08 at 2 53 52 am](https://cloud.githubusercontent.com/assets/5831434/22728258/fc69d4c6-edaa-11e6-8dee-8a30dde6a6ba.png)
![screen shot 2017-02-08 at 2 54 01 am](https://cloud.githubusercontent.com/assets/5831434/22728259/fc6a0c48-edaa-11e6-893d-df57f1657116.png)
(Note that after adding 5 minutes, the next day is now blocked)

**After**
![screen shot 2017-02-08 at 2 56 52 am](https://cloud.githubusercontent.com/assets/5831434/22728261/fc6a7f66-edaa-11e6-80b9-7e1bc00469ea.png)
![screen shot 2017-02-08 at 2 56 59 am](https://cloud.githubusercontent.com/assets/5831434/22728260/fc6a482a-edaa-11e6-9611-b8fbc020e5da.png)
(Day is not blocked after adding 5 minutes)
![screen shot 2017-02-08 at 2 57 10 am](https://cloud.githubusercontent.com/assets/5831434/22728262/fc6d7090-edaa-11e6-8faa-34549bda05aa.png)
(Looking @ the console output, we see that the date has successfully been selected)