### PR TITLE
Revert "Prevent outside day boxes from resizing on hover"

### DIFF
--- a/css/CalendarDay.scss
+++ b/css/CalendarDay.scss
@@ -26,7 +26,7 @@
 }
 
 .CalendarDay--outside {
-  border: 1px solid rgba(0, 0, 0, 0);
+  border: 0;
   cursor: default;
 
   &:active {


### PR DESCRIPTION
Reverts airbnb/react-dates#309

Accidentally included a bug as outlined in https://github.com/airbnb/react-dates/pull/309#issuecomment-278240198. 
