### PR TITLE
Replace react-addons-shallow-compare by React.PureComponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure packages are installed with correct version numbers by running:
   Which produces and runs a command like:
 
   ```sh
-  npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.## react-addons-shallow-compare@>=#.##
+  npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.##
   ```
 
 #### Include component

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
   "peerDependencies": {
     "moment": "2.10 - 2.14 || ^2.15.1",
     "react": ">=15.3.0",
-    "react-dom": ">=0.14",
+    "react-dom": ">=0.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "node-sass": "^4.4.0",
     "raw-loader": "^0.5.1",
     "react": "^15.4.2",
-    "react-addons-shallow-compare": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-svg-loader": "^1.1.1",
@@ -102,8 +101,7 @@
   },
   "peerDependencies": {
     "moment": "2.10 - 2.14 || ^2.15.1",
-    "react": ">=0.14",
+    "react": ">=15.3.0",
     "react-dom": ">=0.14",
-    "react-addons-shallow-compare": ">=0.14"
   }
 }

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import cx from 'classnames';
@@ -28,11 +27,7 @@ export function getModifiersForDay(modifiers, day) {
   return day ? Object.keys(modifiers).filter(key => modifiers[key](day)) : [];
 }
 
-export default class CalendarDay extends React.Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
-
+export default class CalendarDay extends React.PureComponent {
   onDayClick(day, e) {
     const { onDayClick } = this.props;
     onDayClick(day, e);

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -1,7 +1,6 @@
 /* eslint react/no-array-index-key: 0 */
 
 import React, { PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import cx from 'classnames';
@@ -48,7 +47,7 @@ const defaultProps = {
   monthFormat: 'MMMM YYYY', // english locale
 };
 
-export default class CalendarMonth extends React.Component {
+export default class CalendarMonth extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -63,10 +62,6 @@ export default class CalendarMonth extends React.Component {
         weeks: getCalendarMonthWeeks(month, enableOutsideDays),
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import ReactDOM from 'react-dom';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import cx from 'classnames';
@@ -68,7 +67,7 @@ function getMonths(initialMonth, numberOfMonths) {
   return months;
 }
 
-export default class CalendarMonthGrid extends React.Component {
+export default class CalendarMonthGrid extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -109,10 +108,6 @@ export default class CalendarMonthGrid extends React.Component {
     this.setState({
       months: newMonths,
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate() {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
@@ -73,7 +72,7 @@ const defaultProps = {
   },
 };
 
-export default class DateRangePicker extends React.Component {
+export default class DateRangePicker extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -88,10 +87,6 @@ export default class DateRangePicker extends React.Component {
   componentDidMount() {
     window.addEventListener('resize', this.responsivizePickerPosition);
     this.responsivizePickerPosition();
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import ReactDOM from 'react-dom';
 import moment from 'moment';
 import cx from 'classnames';
@@ -130,7 +129,7 @@ function getMonthHeight(el) {
   );
 }
 
-export default class DayPicker extends React.Component {
+export default class DayPicker extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -169,10 +168,6 @@ export default class DayPicker extends React.Component {
         this.adjustDayPickerHeight();
       }
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
 [shallow-compare](https://facebook.github.io/react/docs/shallow-compare.html) is a legacy since react@15.3.0. It should be major update.