### PR TITLE
Use consolidated-events for adding event listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "airbnb-prop-types": "^2.1.0",
     "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
+    "consolidated-events": "^1.0.1",
     "react-moment-proptypes": "^1.2.1",
     "react-portal": "^3.0.0"
   },

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -3,6 +3,7 @@ import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import cx from 'classnames';
+import { addEventListener, removeEventListener } from 'consolidated-events';
 
 import CalendarMonth from './CalendarMonth';
 
@@ -79,7 +80,11 @@ export default class CalendarMonthGrid extends React.Component {
   }
 
   componentDidMount() {
-    this.container.addEventListener('transitionend', this.onTransitionEnd);
+    this.eventHandle = addEventListener(
+      this.container,
+      'transitionend',
+      this.onTransitionEnd,
+    );
   }
 
   componentWillReceiveProps(nextProps) {
@@ -124,7 +129,7 @@ export default class CalendarMonthGrid extends React.Component {
   }
 
   componentWillUnmount() {
-    this.container.removeEventListener('transitionend', this.onTransitionEnd);
+    removeEventListener(this.eventHandle);
   }
 
   onTransitionEnd() {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -4,6 +4,7 @@ import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
+import { addEventListener, removeEventListener } from 'consolidated-events';
 
 import OutsideClickHandler from './OutsideClickHandler';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
@@ -86,7 +87,11 @@ export default class DateRangePicker extends React.Component {
   }
 
   componentDidMount() {
-    window.addEventListener('resize', this.responsivizePickerPosition);
+    this.resizeHandle = addEventListener(
+      window,
+      'resize',
+      this.responsivizePickerPosition,
+    );
     this.responsivizePickerPosition();
   }
 
@@ -102,7 +107,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.responsivizePickerPosition);
+    removeEventListener(this.resizeHandle);
   }
 
   onOutsideClick() {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -91,6 +91,7 @@ export default class DateRangePicker extends React.Component {
       window,
       'resize',
       this.responsivizePickerPosition,
+      { passive: true },
     );
     this.responsivizePickerPosition();
   }

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { addEventListener, removeEventListener } from 'consolidated-events';
 
 const propTypes = {
   children: PropTypes.node,
@@ -17,21 +18,18 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   componentDidMount() {
-    if (document.addEventListener) {
-      // `useCapture` flag is set to true so that a `stopPropagation` in the children will
-      // not prevent all outside click handlers from firing - maja
-      document.addEventListener('click', this.onOutsideClick, true);
-    } else {
-      document.attachEvent('onclick', this.onOutsideClick);
-    }
+    // `capture` flag is set to true so that a `stopPropagation` in the children
+    // will not prevent all outside click handlers from firing - maja
+    this.clickHandle = addEventListener(
+      document,
+      'click',
+      this.onOutsideClick,
+      { capture: true },
+    );
   }
 
   componentWillUnmount() {
-    if (document.removeEventListener) {
-      document.removeEventListener('click', this.onOutsideClick, true);
-    } else {
-      document.detachEvent('onclick', this.onOutsideClick);
-    }
+    removeEventListener(this.clickHandle);
   }
 
   onOutsideClick(e) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -100,6 +100,7 @@ export default class SingleDatePicker extends React.Component {
       window,
       'resize',
       this.responsivizePickerPosition,
+      { passive: true },
     );
     this.responsivizePickerPosition();
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
+import { addEventListener, removeEventListener } from 'consolidated-events';
 
 import OutsideClickHandler from './OutsideClickHandler';
 import toMomentObject from '../utils/toMomentObject';
@@ -95,7 +96,11 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentDidMount() {
-    window.addEventListener('resize', this.responsivizePickerPosition);
+    this.resizeHandle = addEventListener(
+      window,
+      'resize',
+      this.responsivizePickerPosition,
+    );
     this.responsivizePickerPosition();
   }
 
@@ -111,7 +116,7 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentWillUnmount() {
-    window.removeEventListener('resize', this.responsivizePickerPosition);
+    removeEventListener(this.resizeHandle);
   }
 
   onChange(dateString) {


### PR DESCRIPTION
This is the same package that react-waypoint uses to efficiently add
event listeners to nodes. It has two important features:

1. It will try to create as few event listeners as possible by
   delegating to a single event listener on the node. This should
   improve performance, especially when combined with other modules that
   are using consolidated-events.

2. It allows the third argument to be safely used by browsers that
   support it. In other words, we will be able to use safely passive
   event listeners in browsers that support them. This should improve
   performance.

---

Use passive event listeners for window resize

By default, any event listener has the option to call
`e.preventDefault()` to prevent the default event from happening. This
means that the browser has to wait for the event handler to finish
before it can perform the default. For events like scrolling, this can
have a dramatically negative impact on the scrolling animation, which
needs to run at 60fps in order for it to feel good.

Thankfully, modern browsers offer us an escape hatch: passive event
listeners. By setting this flag, we are saying that `e.preventDefault()`
will never be called by the event handler. This makes it so the browser
is free to run the default.

In the case of a scroll event, this is the scroll animation. In the case
of window resize, I don't think this will have much of an effect. But, I
don't see any harm in doing it.

To: @majapw @mikefowler 
