### PR TITLE
Fix lint warnings where possible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,10 +8,6 @@
 
   "rules": {
     "no-mixed-operators": [2, { "allowSamePrecedence": true }],
-    "react/no-find-dom-node": 1,
-    "react/no-string-refs": 1,
-    "react/no-unused-prop-types": 1, // TODO: enable
     "jsx-a11y/no-static-element-interactions": 1, // TODO: enable
-    "no-plusplus": 1, // TODO: enable
   }
 }

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
@@ -60,7 +59,7 @@ function getMonths(initialMonth, numberOfMonths) {
   let month = initialMonth.clone().subtract(1, 'month');
 
   const months = [];
-  for (let i = 0; i < numberOfMonths + 2; i++) {
+  for (let i = 0; i < numberOfMonths + 2; i += 1) {
     months.push(month);
     month = month.clone().add(1, 'month');
   }
@@ -80,7 +79,6 @@ export default class CalendarMonthGrid extends React.Component {
   }
 
   componentDidMount() {
-    this.container = ReactDOM.findDOMNode(this.containerRef);
     this.container.addEventListener('transitionend', this.onTransitionEnd);
   }
 
@@ -162,7 +160,7 @@ export default class CalendarMonthGrid extends React.Component {
 
     return (
       <div
-        ref={(ref) => { this.containerRef = ref; }}
+        ref={(ref) => { this.container = ref; }}
         className={className}
         style={getTransformStyles(transformValue)}
         onTransitionEnd={onMonthTransitionEnd}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -132,7 +132,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   getDayPickerDOMNode() {
-    return ReactDOM.findDOMNode(this.dayPicker);
+    return ReactDOM.findDOMNode(this.dayPicker); // eslint-disable-line react/no-find-dom-node
   }
 
   isOpened() {
@@ -235,7 +235,6 @@ export default class DateRangePicker extends React.Component {
           endDate={endDate}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
-          hidden={!this.isOpened()}
           initialVisibleMonth={initialVisibleMonth}
           onOutsideClick={onOutsideClick}
           navPrev={navPrev}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -223,9 +223,7 @@ export default class DayPicker extends React.Component {
   }
 
   getMonthHeightByIndex(i) {
-    return getMonthHeight(
-      ReactDOM.findDOMNode(this.refs.transitionContainer).querySelectorAll('.CalendarMonth')[i],
-    );
+    return getMonthHeight(this.transitionContainer.querySelectorAll('.CalendarMonth')[i]);
   }
 
   multiplyScrollableMonths(e) {
@@ -247,7 +245,8 @@ export default class DayPicker extends React.Component {
 
   initializeDayPickerWidth() {
     this.dayPickerWidth = calculateDimension(
-      ReactDOM.findDOMNode(this.refs.calendarMonthGrid).querySelector('.CalendarMonth'),
+      // eslint-disable-next-line react/no-find-dom-node
+      ReactDOM.findDOMNode(this.calendarMonthGrid).querySelector('.CalendarMonth'),
       'width',
       true,
     );
@@ -265,7 +264,8 @@ export default class DayPicker extends React.Component {
 
     // clear the previous transforms
     applyTransformStyles(
-      ReactDOM.findDOMNode(this.refs.calendarMonthGrid).querySelector('.CalendarMonth'),
+      // eslint-disable-next-line react/no-find-dom-node
+      ReactDOM.findDOMNode(this.calendarMonthGrid).querySelector('.CalendarMonth'),
       'none',
     );
 
@@ -277,20 +277,21 @@ export default class DayPicker extends React.Component {
   }
 
   adjustDayPickerHeight() {
-    const transitionContainer = ReactDOM.findDOMNode(this.refs.transitionContainer);
     const heights = [];
 
-    Array.prototype.forEach.call(transitionContainer.querySelectorAll('.CalendarMonth'), (el) => {
-      if (el.getAttribute('data-visible') === 'true') {
-        heights.push(getMonthHeight(el));
-      }
-    });
+    Array.prototype.forEach.call(this.transitionContainer.querySelectorAll('.CalendarMonth'),
+      (el) => {
+        if (el.getAttribute('data-visible') === 'true') {
+          heights.push(getMonthHeight(el));
+        }
+      },
+    );
 
     const newMonthHeight = Math.max(...heights) + MONTH_PADDING;
 
-    if (newMonthHeight !== calculateDimension(transitionContainer, 'height')) {
+    if (newMonthHeight !== calculateDimension(this.transitionContainer, 'height')) {
       this.monthHeight = newMonthHeight;
-      transitionContainer.style.height = `${newMonthHeight}px`;
+      this.transitionContainer.style.height = `${newMonthHeight}px`;
     }
   }
 
@@ -299,7 +300,7 @@ export default class DayPicker extends React.Component {
     const transformValue = `${transformType}(-${translationValue}px)`;
 
     applyTransformStyles(
-      ReactDOM.findDOMNode(this.refs.transitionContainer).querySelector('.CalendarMonth'),
+      this.transitionContainer.querySelector('.CalendarMonth'),
       transformValue,
       1,
     );
@@ -338,7 +339,7 @@ export default class DayPicker extends React.Component {
     const style = this.isHorizontal() ? horizontalStyle : {};
 
     const header = [];
-    for (let i = 0; i < 7; i++) {
+    for (let i = 0; i < 7; i += 1) {
       header.push(
         <li key={i}>
           <small>{moment().weekday(i).format('dd')}</small>
@@ -382,7 +383,7 @@ export default class DayPicker extends React.Component {
 
     const numOfWeekHeaders = this.isVertical() ? 1 : numberOfMonths;
     const weekHeaders = [];
-    for (let i = 0; i < numOfWeekHeaders; i++) {
+    for (let i = 0; i < numOfWeekHeaders; i += 1) {
       weekHeaders.push(this.renderWeekHeader(i));
     }
 
@@ -441,11 +442,11 @@ export default class DayPicker extends React.Component {
 
           <div
             className={transitionContainerClasses}
-            ref="transitionContainer"
+            ref={(ref) => { this.transitionContainer = ref; }}
             style={transitionContainerStyle}
           >
             <CalendarMonthGrid
-              ref="calendarMonthGrid"
+              ref={(ref) => { this.calendarMonthGrid = ref; }}
               transformValue={transformValue}
               enableOutsideDays={enableOutsideDays}
               firstVisibleMonthIndex={firstVisibleMonthIndex}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -38,7 +38,6 @@ const propTypes = {
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
-  hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
 
   navPrev: PropTypes.node,
@@ -72,7 +71,6 @@ const defaultProps = {
   numberOfMonths: 1,
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
-  hidden: false,
 
   initialVisibleMonth: () => moment(),
 

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 
 const propTypes = {
   children: PropTypes.node,
@@ -36,7 +35,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   onOutsideClick(e) {
-    const isDescendantOfRoot = ReactDOM.findDOMNode(this.refs.childNode).contains(e.target);
+    const isDescendantOfRoot = this.childNode.contains(e.target);
     if (!isDescendantOfRoot) {
       this.props.onOutsideClick(e);
     }
@@ -44,7 +43,7 @@ export default class OutsideClickHandler extends React.Component {
 
   render() {
     return (
-      <div ref="childNode">
+      <div ref={(ref) => { this.childNode = ref; }}>
         {this.props.children}
       </div>
     );

--- a/src/utils/getCalendarMonthWeeks.js
+++ b/src/utils/getCalendarMonthWeeks.js
@@ -9,7 +9,7 @@ export default function getCalendarMonthWeeks(month, enableOutsideDays) {
   const weeksInMonth = [];
 
   // days belonging to the previous month
-  for (let i = 0; i < currentDay.weekday(); i++) {
+  for (let i = 0; i < currentDay.weekday(); i += 1) {
     const prevDay = enableOutsideDays ? currentDay.clone().subtract(i + 1, 'day') : null;
     currentWeek.unshift(prevDay);
   }
@@ -28,7 +28,7 @@ export default function getCalendarMonthWeeks(month, enableOutsideDays) {
   // this means if the week starts on Monday, weekday() will return 0 for a Monday date, not 1
   if (currentDay.weekday() !== 0) {
     // days belonging to the next month
-    for (let k = currentDay.weekday(), count = 0; k < 7; k++, count++) {
+    for (let k = currentDay.weekday(), count = 0; k < 7; k += 1, count += 1) {
       const nextDay = enableOutsideDays ? currentDay.clone().add(count, 'day') : null;
       currentWeek.push(nextDay);
     }

--- a/test/components/OutsideClickHandler_spec.jsx
+++ b/test/components/OutsideClickHandler_spec.jsx
@@ -1,19 +1,12 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import wrap from 'mocha-wrap';
 
 import OutsideClickHandler from '../../src/components/OutsideClickHandler';
 
 describe('OutsideClickHandler', () => {
-  describe('#render', () => {
-    it('has `childNode` ref', () => {
-      const wrapper = shallow(<OutsideClickHandler />);
-      expect(wrapper.node.ref).to.equal('childNode');
-    });
-  });
-
   describe.skip('lifecycle methods', () => {
     wrap()
     .withOverride(() => document, 'attachEvent', () => sinon.stub())


### PR DESCRIPTION
This is the more up to date version of https://github.com/airbnb/react-dates/pull/99.

Basically, remove all the lint warnings that we can. There are a few places where `ReactDOM.findDOMNode` is still in place with disabling, because that's necessary to return the actual dom node representing react components, but those should be removed by https://github.com/airbnb/react-dates/pull/137 eventually. Similarly, I left the `jsx-a11y/no-static-element-interactions` rule ignored because those should all be fixed by https://github.com/airbnb/react-dates/pull/301.

Woo!

to: @ljharb @airbnb/webinfra 