### PR TITLE
Fix caption alignment when used with bootstrap

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -15,6 +15,9 @@
   table {
     border-collapse: collapse;
     border-spacing: 0;
+    caption: {
+      caption-side: initial;
+    }
   }
 
   -moz-user-select: none;
@@ -39,6 +42,7 @@
   text-align: center;
   // necessary to not hide borders in FF
   margin-bottom: 2px;
+  caption-side: initial;
 }
 
 .CalendarMonth--horizontal .CalendarMonth__caption,


### PR DESCRIPTION
Welp, trying to get https://github.com/airbnb/react-dates/pull/101 merged in but failed at pushing correctly. Here's the version with comments addressed.

@airbnb/webinfra 
FYI: @zeroasterisk 