### PR TITLE
Clean up prop types definitions for top-level components

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -1,6 +1,68 @@
 import React from 'react';
+import moment from 'moment';
+import omit from 'lodash.omit';
 
 import DateRangePicker from '../src/components/DateRangePicker';
+
+import DateRangePickerShape from '../src/shapes/DateRangePickerShape';
+import { START_DATE, END_DATE, HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
+import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+
+const propTypes = omit(DateRangePickerShape, [
+  'startDate',
+  'endDate',
+  'onDatesChange',
+  'focusedInput',
+  'onFocusChange',
+]);
+
+const defaultProps = {
+  // input related props
+  startDateId: START_DATE,
+  startDatePlaceholderText: 'Start Date',
+  endDateId: END_DATE,
+  endDatePlaceholderText: 'End Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDates: false,
+  showDefaultInputIcon: false,
+  customInputIcon: null,
+  customArrowIcon: null,
+
+  // calendar presentation and interaction related props
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDates: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+
+  // day presentation and interaction related props
+  renderDay: null,
+  minimumNights: 1,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => false,
+
+  // internationalization
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: {
+    closeDatePicker: 'Close',
+    clearDates: 'Clear Dates',
+  },
+};
 
 class DateRangePickerWrapper extends React.Component {
   constructor(props) {
@@ -39,5 +101,8 @@ class DateRangePickerWrapper extends React.Component {
     );
   }
 }
+
+DateRangePickerWrapper.propTypes = propTypes;
+DateRangePickerWrapper.defaultProps = defaultProps;
 
 export default DateRangePickerWrapper;

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -1,6 +1,61 @@
 import React from 'react';
+import moment from 'moment';
+import omit from 'lodash.omit';
 
 import SingleDatePicker from '../src/components/SingleDatePicker';
+
+import SingleDatePickerShape from '../src/shapes/SingleDatePickerShape';
+import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../constants';
+import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+
+const propTypes = omit(SingleDatePickerShape, [
+  'date',
+  'onDateChange',
+  'focused',
+  'onFocusChange',
+]);
+
+const defaultProps = {
+  // input related props
+  id: 'date',
+  placeholder: 'Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDate: false,
+
+  // calendar presentation and interaction related props
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+
+  // day presentation and interaction related props
+  renderDay: null,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => {},
+
+  // internationalization props
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: {
+    closeDatePicker: 'Close',
+    clearDate: 'Clear Date',
+  },
+};
 
 class SingleDatePickerWrapper extends React.Component {
   constructor(props) {
@@ -37,5 +92,8 @@ class SingleDatePickerWrapper extends React.Component {
     );
   }
 }
+
+SingleDatePickerWrapper.propTypes = propTypes;
+SingleDatePickerWrapper.defaultProps = defaultProps;
 
 export default SingleDatePickerWrapper;

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "karma-mocha": "^1.3.0",
     "karma-sinon": "^1.0.5",
     "karma-webpack": "^2.0.1",
+    "lodash.omit": "^4.5.0",
     "mocha": "^3.2.0",
     "mocha-wrap": "^2.1.0",
     "moment": "^2.17.1",

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,10 +1,11 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
   isOutsideDay: PropTypes.bool,
   modifiers: PropTypes.object,
@@ -12,7 +13,7 @@ const propTypes = {
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderDay: PropTypes.func,
-};
+});
 
 const defaultProps = {
   day: moment(),

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -3,6 +3,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
@@ -18,7 +19,7 @@ import {
   VERTICAL_SCROLLABLE,
 } from '../../constants';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   month: momentPropTypes.momentObj,
   isVisible: PropTypes.bool,
   enableOutsideDays: PropTypes.bool,
@@ -31,7 +32,7 @@ const propTypes = {
 
   // i18n
   monthFormat: PropTypes.string,
-};
+});
 
 const defaultProps = {
   month: moment(),

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 import { addEventListener, removeEventListener } from 'consolidated-events';
@@ -18,7 +19,7 @@ import {
   VERTICAL_SCROLLABLE,
 } from '../../constants';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   enableOutsideDays: PropTypes.bool,
   firstVisibleMonthIndex: PropTypes.number,
   initialMonth: momentPropTypes.momentObj,
@@ -35,7 +36,7 @@ const propTypes = {
 
   // i18n
   monthFormat: PropTypes.string,
-};
+});
 
 const defaultProps = {
   enableOutsideDays: false,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -1,9 +1,10 @@
 import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import cx from 'classnames';
 
 import isTouchDevice from '../utils/isTouchDevice';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
@@ -18,7 +19,7 @@ const propTypes = {
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
-};
+});
 
 const defaultProps = {
   placeholder: 'Select Date',

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -30,42 +30,50 @@ import {
 const propTypes = DateRangePickerShape;
 
 const defaultProps = {
-  startDateId: START_DATE,
-  endDateId: END_DATE,
+  // required props for a functional interactive DateRangePicker
+  startDate: null,
+  endDate: null,
   focusedInput: null,
+
+  // input related props
+  startDateId: START_DATE,
+  startDatePlaceholderText: 'Start Date',
+  endDateId: END_DATE,
+  endDatePlaceholderText: 'End Date',
+  disabled: false,
+  required: false,
   screenReaderInputMessage: '',
-  minimumNights: 1,
-  isDayBlocked: () => false,
-  isDayHighlighted: () => false,
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
-  enableOutsideDays: false,
-  numberOfMonths: 2,
   showClearDates: false,
   showDefaultInputIcon: false,
   customInputIcon: null,
   customArrowIcon: null,
-  disabled: false,
-  required: false,
-  reopenPickerOnClearDates: false,
-  keepOpenOnDateSelect: false,
-  initialVisibleMonth: null,
-  navPrev: null,
-  navNext: null,
 
+  // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
   withPortal: false,
   withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDates: false,
 
-  onDatesChange() {},
-  onFocusChange() {},
+  // navigation related props
+  navPrev: null,
+  navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  // day presentation and interaction related props
   renderDay: null,
+  minimumNights: 1,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => false,
 
-  // i18n
+  // internationalization
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {
@@ -296,7 +304,6 @@ export default class DateRangePicker extends React.Component {
       keepOpenOnDateSelect,
       onDatesChange,
       onFocusChange,
-      renderDay,
     } = this.props;
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
@@ -327,7 +334,6 @@ export default class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={onFocusChange}
-            renderDay={renderDay}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
           />

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import cx from 'classnames';
 
 import DateInput from './DateInput';
@@ -8,7 +9,7 @@ import CalendarIcon from '../svg/calendar.svg';
 
 import { START_DATE, END_DATE } from '../../constants';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
   screenReaderMessage: PropTypes.string,
@@ -43,7 +44,7 @@ const propTypes = {
   phrases: PropTypes.shape({
     clearDates: PropTypes.node,
   }),
-};
+});
 
 const defaultProps = {
   startDateId: START_DATE,

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import moment from 'moment';
 
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 
 import DateRangePickerInput from './DateRangePickerInput';
 
@@ -14,7 +15,7 @@ import isInclusivelyBeforeDay from '../utils/isInclusivelyBeforeDay';
 
 import { START_DATE, END_DATE } from '../../constants';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
@@ -48,7 +49,7 @@ const propTypes = {
   phrases: PropTypes.shape({
     clearDates: PropTypes.node,
   }),
-};
+});
 
 const defaultProps = {
   startDate: null,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import ReactDOM from 'react-dom';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
@@ -24,53 +25,57 @@ const MONTH_PADDING = 23;
 const PREV_TRANSITION = 'prev';
 const NEXT_TRANSITION = 'next';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
+  // calendar presentation props
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
-  modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
+  onOutsideClick: PropTypes.func,
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
 
+  // navigation props
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  onPrevMonthClick: PropTypes.func,
+  onNextMonthClick: PropTypes.func,
 
+  // day props
+  modifiers: PropTypes.object,
+  renderDay: PropTypes.func,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
-  onPrevMonthClick: PropTypes.func,
-  onNextMonthClick: PropTypes.func,
-  onOutsideClick: PropTypes.func,
 
-  renderDay: PropTypes.func,
-
-  // i18n
+  // internationalization
   monthFormat: PropTypes.string,
-};
+});
 
 const defaultProps = {
+  // calendar presentation props
   enableOutsideDays: false,
-  numberOfMonths: 1,
-  modifiers: {},
+  numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
+  onOutsideClick() {},
   hidden: false,
-
   initialVisibleMonth: () => moment(),
 
+  // navigation props
   navPrev: null,
   navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
 
+  // day props
+  modifiers: {},
+  renderDay: null,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
-  onPrevMonthClick() {},
-  onNextMonthClick() {},
-  onOutsideClick() {},
 
-  renderDay: null,
-  // i18n
+  // internationalization
   monthFormat: 'MMMM YYYY',
 };
 
@@ -326,7 +331,7 @@ export default class DayPicker extends React.Component {
         onNextMonthClick={onNextMonthClick}
         navPrev={navPrev}
         navNext={navNext}
-        orientation={orientation}j
+        orientation={orientation}
       />
     );
   }
@@ -454,7 +459,6 @@ export default class DayPicker extends React.Component {
               isAnimating={isCalendarMonthGridAnimating}
               modifiers={modifiers}
               orientation={orientation}
-              withPortal={withPortal}
               numberOfMonths={numberOfMonths * scrollableMonthMultiple}
               onDayClick={onDayClick}
               onDayMouseEnter={onDayMouseEnter}

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import cx from 'classnames';
 
 import LeftArrow from '../svg/arrow-left.svg';
@@ -12,14 +13,15 @@ import {
   VERTICAL_SCROLLABLE,
 } from '../../constants';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
   orientation: ScrollableOrientationShape,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
-};
+});
+
 const defaultProps = {
   navPrev: null,
   navNext: null,

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import moment from 'moment';
 
 import isTouchDevice from '../utils/isTouchDevice';
@@ -19,7 +20,7 @@ import {
 
 import DayPicker from './DayPicker';
 
-const propTypes = {
+const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
   endDate: momentPropTypes.momentObj,
   onDatesChange: PropTypes.func,
@@ -50,7 +51,7 @@ const propTypes = {
 
   // i18n
   monthFormat: PropTypes.string,
-};
+});
 
 const defaultProps = {
   startDate: undefined, // TODO: use null

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener, removeEventListener } from 'consolidated-events';
 
 const propTypes = {
@@ -6,10 +7,10 @@ const propTypes = {
   onOutsideClick: PropTypes.func,
 };
 
-const defaultProps = {
+const defaultProps = forbidExtraProps({
   children: <span />,
   onOutsideClick: () => {},
-};
+});
 
 export default class OutsideClickHandler extends React.Component {
   constructor(props) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -30,40 +30,43 @@ import {
 const propTypes = SingleDatePickerShape;
 
 const defaultProps = {
+  // required props for a functional interactive SingleDatePicker
   date: null,
   focused: false,
+
+  // input related props
+  id: 'date',
+  placeholder: 'Date',
   disabled: false,
   required: false,
+  screenReaderInputMessage: '',
   showClearDate: false,
-  reopenPickerOnClearDate: false,
-  keepOpenOnDateSelect: false,
 
-  navPrev: null,
-  navNext: null,
-
-  onDateChange() {},
-  onFocusChange() {},
-
-  isDayBlocked: () => false,
-  isDayHighlighted: () => false,
-  disabledDays: [],
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
-  enableOutsideDays: false,
-  numberOfMonths: 2,
+  // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
   withPortal: false,
   withFullScreenPortal: false,
-  screenReaderInputMessage: '',
   initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
 
+  // navigation related props
+  navPrev: null,
+  navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  // day presentation and interaction related props
   renderDay: null,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => {},
 
-  // i18n
+  // internationalization props
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -1,52 +1,63 @@
 import { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 
 import FocusedInputShape from '../shapes/FocusedInputShape';
 import OrientationShape from '../shapes/OrientationShape';
 import anchorDirectionShape from '../shapes/AnchorDirectionShape';
 
-export default {
+export default forbidExtraProps({
+  // required props for a functional interactive DateRangePicker
   startDate: momentPropTypes.momentObj,
   endDate: momentPropTypes.momentObj,
+  onDatesChange: PropTypes.func.isRequired,
+
   focusedInput: FocusedInputShape,
-  screenReaderInputMessage: PropTypes.string,
-  minimumNights: PropTypes.number,
-  isDayBlocked: PropTypes.func,
-  isOutsideRange: PropTypes.func,
-  enableOutsideDays: PropTypes.bool,
-  reopenPickerOnClearDates: PropTypes.bool,
-  keepOpenOnDateSelect: PropTypes.bool,
-  numberOfMonths: PropTypes.number,
-  showClearDates: PropTypes.bool,
+  onFocusChange: PropTypes.func.isRequired,
+
+  // input related props
+  startDateId: PropTypes.string.isRequired,
+  startDatePlaceholderText: PropTypes.string,
+  endDateId: PropTypes.string.isRequired,
+  endDatePlaceholderText: PropTypes.string,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
+  screenReaderInputMessage: PropTypes.string,
+  showClearDates: PropTypes.bool,
   showDefaultInputIcon: PropTypes.bool,
+  customInputIcon: PropTypes.node,
+  customArrowIcon: PropTypes.node,
 
+  // calendar presentation and interaction related props
   orientation: OrientationShape,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,
-  // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
-
-  startDateId: PropTypes.string,
-  startDatePlaceholderText: PropTypes.string,
-  endDateId: PropTypes.string,
-  endDatePlaceholderText: PropTypes.string,
-
   initialVisibleMonth: PropTypes.func,
-  onDatesChange: PropTypes.func,
-  onFocusChange: PropTypes.func,
+  numberOfMonths: PropTypes.number,
+  keepOpenOnDateSelect: PropTypes.bool,
+  reopenPickerOnClearDates: PropTypes.bool,
+
+  // navigation related props
+  navPrev: PropTypes.node,
+  navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  // day presentation and interaction related props
   renderDay: PropTypes.func,
+  minimumNights: PropTypes.number,
+  enableOutsideDays: PropTypes.bool,
+  isDayBlocked: PropTypes.func,
+  isOutsideRange: PropTypes.func,
+  isDayHighlighted: PropTypes.func,
 
-  // i18n
+  // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape({
     closeDatePicker: PropTypes.node,
     clearDates: PropTypes.node,
   }),
-};
+});

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -1,49 +1,54 @@
 import { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
 
 import OrientationShape from '../shapes/OrientationShape';
 import anchorDirectionShape from '../shapes/AnchorDirectionShape';
 
-export default {
+export default forbidExtraProps({
+  // required props for a functional interactive SingleDatePicker
+  date: momentPropTypes.momentObj,
+  onDateChange: PropTypes.func.isRequired,
+
+  focused: PropTypes.bool,
+  onFocusChange: PropTypes.func.isRequired,
+
+  // input related props
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
-  date: momentPropTypes.momentObj,
-  focused: PropTypes.bool,
-  showClearDate: PropTypes.bool,
-  reopenPickerOnClearDates: PropTypes.bool,
-  keepOpenOnDateSelect: PropTypes.bool,
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   screenReaderInputMessage: PropTypes.string,
+  showClearDate: PropTypes.bool,
 
-  onDateChange: PropTypes.func,
-  onFocusChange: PropTypes.func,
-
-  isDayBlocked: PropTypes.func,
-  isOutsideRange: PropTypes.func,
-  enableOutsideDays: PropTypes.bool,
-  numberOfMonths: PropTypes.number,
+  // calendar presentation and interaction related props
   orientation: OrientationShape,
-  initialVisibleMonth: PropTypes.func,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,
-
-  navPrev: PropTypes.node,
-  navNext: PropTypes.node,
-
-  // portal options
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  initialVisibleMonth: PropTypes.func,
+  numberOfMonths: PropTypes.number,
+  keepOpenOnDateSelect: PropTypes.bool,
+  reopenPickerOnClearDate: PropTypes.bool,
 
+  // navigation related props
+  navPrev: PropTypes.node,
+  navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  // day presentation and interaction related props
   renderDay: PropTypes.func,
+  enableOutsideDays: PropTypes.bool,
+  isDayBlocked: PropTypes.func,
+  isOutsideRange: PropTypes.func,
+  isDayHighlighted: PropTypes.func,
 
-  // i18n
+  // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape({
     closeDatePicker: PropTypes.node,
   }),
-};
+});

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -24,69 +24,137 @@ const today = moment().startOf('day').hours(12);
 describe('SingleDatePicker', () => {
   describe('#render', () => {
     it('is .SingleDatePicker class', () => {
-      const wrapper = shallow(<SingleDatePicker id="date" />);
+      const wrapper = shallow(
+        <SingleDatePicker
+          id="date"
+          onDateChange={() => {}}
+          onFocusChange={() => {}}
+        />,
+      );
       expect(wrapper.is('.SingleDatePicker')).to.equal(true);
     });
 
     it('renders a SingleDatePickerInput', () => {
-      const wrapper = shallow(<SingleDatePicker id="date" />);
+      const wrapper = shallow(
+        <SingleDatePicker
+          id="date"
+          onDateChange={() => {}}
+          onFocusChange={() => {}}
+        />,
+      );
       expect(wrapper.find(SingleDatePickerInput)).to.have.lengthOf(1);
     });
 
     describe('DayPicker', () => {
       describe('props.focused === true', () => {
         it('renders a <DayPicker>', () => {
-          const wrapper = shallow(<SingleDatePicker id="date" focused />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           expect(wrapper.find(DayPicker)).to.have.lengthOf(1);
         });
       });
 
       it('has .SingleDatePicker__picker class', () => {
-        const wrapper = shallow(<SingleDatePicker focused id="date" />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            focused
+          />,
+        );
         expect(wrapper.find('.SingleDatePicker__picker')).to.have.lengthOf(1);
       });
 
       describe('props.focused === false', () => {
         it('does not render a <DayPicker>', () => {
-          const wrapper = shallow(<SingleDatePicker id="date" focused={false} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused={false}
+            />,
+          );
           expect(wrapper.find(DayPicker)).to.have.lengthOf(0);
         });
       });
 
       describe('props.orientation === HORIZONTAL_ORIENTATION', () => {
         it('has .SingleDatePicker__picker--horizontal class', () => {
-          const wrapper =
-            shallow(<SingleDatePicker id="date" focused orientation={HORIZONTAL_ORIENTATION} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              orientation={HORIZONTAL_ORIENTATION}
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           expect(wrapper.find('.SingleDatePicker__picker--horizontal')).to.have.lengthOf(1);
         });
       });
 
       describe('props.orientation === VERTICAL_ORIENTATION', () => {
         it('has .SingleDatePicker__picker--vertical class', () => {
-          const wrapper =
-            shallow(<SingleDatePicker id="date" focused orientation={VERTICAL_ORIENTATION} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              orientation={VERTICAL_ORIENTATION}
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           expect(wrapper.find('.SingleDatePicker__picker--vertical')).to.have.lengthOf(1);
         });
       });
 
       describe('props.anchorDirection === ANCHOR_LEFT', () => {
         it('renders .SingleDatePicker__picker--direction-left class', () => {
-          const wrapper = shallow(<SingleDatePicker focused anchorDirection={ANCHOR_LEFT} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              anchorDirection={ANCHOR_LEFT}
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           expect(wrapper.find('.SingleDatePicker__picker--direction-left')).to.have.length(1);
         });
       });
 
       describe('props.orientation === ANCHOR_RIGHT', () => {
         it('renders .SingleDatePicker__picker--direction-right class', () => {
-          const wrapper = shallow(<SingleDatePicker focused anchorDirection={ANCHOR_RIGHT} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              anchorDirection={ANCHOR_RIGHT}
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           expect(wrapper.find('.SingleDatePicker__picker--direction-right')).to.have.length(1);
         });
       });
 
       describe('a valid date is hovered', () => {
         it('has .SingleDatePicker__picker--valid-date-hovered class', () => {
-          const wrapper =
-            shallow(<SingleDatePicker focused id="date" orientation={VERTICAL_ORIENTATION} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              orientation={VERTICAL_ORIENTATION}
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              focused
+            />,
+          );
           wrapper.setState({
             hoverDate: moment(),
           });
@@ -97,24 +165,50 @@ describe('SingleDatePicker', () => {
 
     describe('props.withPortal is truthy', () => {
       it('renders .SingleDatePicker__picker--portal class', () => {
-        const wrapper = shallow(<SingleDatePicker focused withPortal />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            withPortal
+            focused
+          />,
+        );
         expect(wrapper.find('.SingleDatePicker__picker--portal')).to.have.length(1);
       });
 
       describe('<Portal />', () => {
         it('is rendered', () => {
-          const wrapper = shallow(<SingleDatePicker focused withPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withPortal
+              focused
+            />,
+          );
           expect(wrapper.find(Portal)).to.have.length(1);
         });
 
         it('is not rendered if props.focused is falsey', () => {
-          const wrapper =
-            shallow(<SingleDatePicker withPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withPortal
+            />,
+          );
           expect(wrapper.find(Portal)).to.have.length(0);
         });
 
         it('isOpened prop is true if props.focused is true', () => {
-          const wrapper = shallow(<SingleDatePicker focused withPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withPortal
+              focused
+            />,
+          );
           expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
@@ -122,35 +216,74 @@ describe('SingleDatePicker', () => {
 
     describe('props.withFullScreenPortal is truthy', () => {
       it('renders .SingleDatePicker__picker--portal class', () => {
-        const wrapper = shallow(<SingleDatePicker focused withFullScreenPortal />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            withFullScreenPortal
+            focused
+          />,
+        );
         expect(wrapper.find('.SingleDatePicker__picker--portal')).to.have.length(1);
       });
 
       it('renders .SingleDatePicker__picker--full-screen-portal class', () => {
-        const wrapper = shallow(<SingleDatePicker focused withFullScreenPortal />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            withFullScreenPortal
+            focused
+          />,
+        );
         expect(wrapper.find('.SingleDatePicker__picker--full-screen-portal')).to.have.length(1);
       });
 
       it('renders .SingleDatePicker__close class', () => {
-        const wrapper = shallow(<SingleDatePicker focused withFullScreenPortal />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            withFullScreenPortal
+            focused
+          />,
+        );
         expect(wrapper.find('.SingleDatePicker__close')).to.have.length(1);
       });
 
       describe('<Portal />', () => {
         it('is rendered', () => {
-          const wrapper = shallow(<SingleDatePicker focused withFullScreenPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withFullScreenPortal
+              focused
+            />,
+          );
           expect(wrapper.find(Portal)).to.have.length(1);
         });
 
         it('is not rendered when props.focused is falsey', () => {
-          const wrapper =
-            shallow(<SingleDatePicker withFullScreenPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withFullScreenPortal
+            />,
+          );
           expect(wrapper.find(Portal)).to.have.length(0);
         });
 
         it('isOpened prop is true if props.focused is truthy', () => {
-          const wrapper =
-            shallow(<SingleDatePicker focused withFullScreenPortal />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              withFullScreenPortal
+              focused
+            />,
+          );
           expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
@@ -162,14 +295,18 @@ describe('SingleDatePicker', () => {
       const futureDateString = moment().add(10, 'days').format('YYYY-MM-DD');
       it('calls props.onDateChange once', () => {
         const onDateChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+        );
         wrapper.instance().onChange(futureDateString);
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
       it('calls props.onDateChange with date as arg', () => {
         const onDateChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+        );
         wrapper.instance().onChange(futureDateString);
         const newDate = onDateChangeStub.getCall(0).args[0];
         expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
@@ -177,14 +314,18 @@ describe('SingleDatePicker', () => {
 
       it('calls props.onFocusChange once', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+        );
         wrapper.instance().onChange(futureDateString);
         expect(onFocusChangeStub.callCount).to.equal(1);
       });
 
       it('calls props.onFocusChange with { focused: false } as arg', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+        );
         wrapper.instance().onChange(futureDateString);
         expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
       });
@@ -199,6 +340,7 @@ describe('SingleDatePicker', () => {
           id="date"
           displayFormat={customFormat}
           onDateChange={onDateChangeStub}
+          onFocusChange={() => {}}
         />);
         wrapper.instance().onChange(customFormatDateString);
         expect(onDateChangeStub.callCount).to.equal(1);
@@ -210,6 +352,7 @@ describe('SingleDatePicker', () => {
           id="date"
           displayFormat={customFormat}
           onDateChange={onDateChangeStub}
+          onFocusChange={() => {}}
         />);
         wrapper.instance().onChange(customFormatDateString);
         const formattedFirstArg = onDateChangeStub.getCall(0).args[0].format(customFormat);
@@ -221,6 +364,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(<SingleDatePicker
           id="date"
           displayFormat={customFormat}
+          onDateChange={() => {}}
           onFocusChange={onFocusChangeStub}
         />);
         wrapper.instance().onChange(customFormatDateString);
@@ -232,6 +376,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(<SingleDatePicker
           id="date"
           displayFormat={customFormat}
+          onDateChange={() => {}}
           onFocusChange={onFocusChangeStub}
         />);
         wrapper.instance().onChange(customFormatDateString);
@@ -243,21 +388,27 @@ describe('SingleDatePicker', () => {
       const invalidDateString = 'foobar';
       it('calls props.onDateChange once', () => {
         const onDateChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+        );
         wrapper.instance().onChange(invalidDateString);
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
       it('calls props.onDateChange with null as arg', () => {
         const onDateChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+        );
         wrapper.instance().onChange(invalidDateString);
         expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
       });
 
       it('does not call props.onFocusChange', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+        );
         wrapper.instance().onChange(invalidDateString);
         expect(onFocusChangeStub.callCount).to.equal(0);
       });
@@ -273,6 +424,7 @@ describe('SingleDatePicker', () => {
           <SingleDatePicker
             id="date"
             onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
             isOutsideRange={isOutsideRangeStub}
           />,
         );
@@ -286,6 +438,7 @@ describe('SingleDatePicker', () => {
           <SingleDatePicker
             id="date"
             onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
             isOutsideRange={isOutsideRangeStub}
           />,
         );
@@ -298,6 +451,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(
           <SingleDatePicker
             id="date"
+            onDateChange={() => {}}
             onFocusChange={onFocusChangeStub}
             isOutsideRange={isOutsideRangeStub}
           />,
@@ -316,6 +470,7 @@ describe('SingleDatePicker', () => {
           <SingleDatePicker
             id="date"
             onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
             isDayBlocked={() => true}
           />,
         );
@@ -328,6 +483,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(
           <SingleDatePicker
             id="date"
+            onDateChange={() => {}}
             onFocusChange={onFocusChangeStub}
             isDayBlocked={() => true}
           />,
@@ -340,14 +496,18 @@ describe('SingleDatePicker', () => {
     describe('day arg is not blocked', () => {
       it('props.onDateChange is called', () => {
         const onDateChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onDateChange={onDateChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+        );
         wrapper.instance().onDayClick(moment());
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
       it('props.onFocusChange is called', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+        );
         wrapper.instance().onDayClick(moment());
         expect(onFocusChangeStub.callCount).to.equal(1);
       });
@@ -356,7 +516,9 @@ describe('SingleDatePicker', () => {
 
   describe('#onDayMouseEnter', () => {
     it('sets state.hoverDate to day arg', () => {
-      const wrapper = shallow(<SingleDatePicker id="date" />);
+      const wrapper = shallow(
+        <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={() => {}} />,
+      );
       wrapper.instance().onDayMouseEnter(today);
       expect(wrapper.state().hoverDate).to.equal(today);
     });
@@ -364,7 +526,9 @@ describe('SingleDatePicker', () => {
 
   describe('#onDayMouseLeave', () => {
     it('sets state.hoverDate to null', () => {
-      const wrapper = shallow(<SingleDatePicker id="date" />);
+      const wrapper = shallow(
+        <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={() => {}} />,
+      );
       wrapper.instance().onDayMouseLeave();
       expect(wrapper.state().hoverDate).to.equal(null);
     });
@@ -373,14 +537,18 @@ describe('SingleDatePicker', () => {
   describe('#onFocus', () => {
     it('calls props.onFocusChange once', () => {
       const onFocusChangeStub = sinon.stub();
-      const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+      const wrapper = shallow(
+        <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+      );
       wrapper.instance().onFocus();
       expect(onFocusChangeStub.callCount).to.equal(1);
     });
 
     it('calls props.onFocusChange with { focused: true } as arg', () => {
       const onFocusChangeStub = sinon.stub();
-      const wrapper = shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} />);
+      const wrapper = shallow(
+        <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />,
+      );
       wrapper.instance().onFocus();
       expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(true);
     });
@@ -392,6 +560,7 @@ describe('SingleDatePicker', () => {
           <SingleDatePicker
             id="date"
             disabled
+            onDateChange={() => {}}
             onFocusChange={onFocusChangeStub}
           />);
         wrapper.instance().onFocus();
@@ -404,8 +573,14 @@ describe('SingleDatePicker', () => {
     describe('props.focused = false', () => {
       it('does not call props.onFocusChange', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} focused={false} />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused={false}
+          />,
+        );
         wrapper.instance().onClearFocus();
         expect(onFocusChangeStub.callCount).to.equal(0);
       });
@@ -414,16 +589,28 @@ describe('SingleDatePicker', () => {
     describe('props.focused = true', () => {
       it('calls props.onFocusChange once', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} focused />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused
+          />,
+        );
         wrapper.instance().onClearFocus();
         expect(onFocusChangeStub.callCount).to.equal(1);
       });
 
       it('calls props.onFocusChange with { focused: false } as arg', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<SingleDatePicker id="date" onFocusChange={onFocusChangeStub} focused />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused
+          />,
+        );
         wrapper.instance().onClearFocus();
         expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
       });
@@ -437,6 +624,7 @@ describe('SingleDatePicker', () => {
           const onFocusChangeStub = sinon.stub();
           const wrapper = shallow(
             <SingleDatePicker
+              onDateChange={() => {}}
               onFocusChange={onFocusChangeStub}
               reopenPickerOnClearDate
             />);
@@ -450,7 +638,13 @@ describe('SingleDatePicker', () => {
       describe('props.onFocusChange', () => {
         it('is not called', () => {
           const onFocusChangeStub = sinon.stub();
-          const wrapper = shallow(<SingleDatePicker onFocusChange={onFocusChangeStub} />);
+          const wrapper = shallow(
+            <SingleDatePicker
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={onFocusChangeStub}
+            />,
+          );
           wrapper.instance().clearDate();
           expect(onFocusChangeStub.callCount).to.equal(0);
         });
@@ -459,7 +653,9 @@ describe('SingleDatePicker', () => {
 
     it('calls props.onDateChange with null date', () => {
       const onDateChangeStub = sinon.stub();
-      const wrapper = shallow(<SingleDatePicker onDateChange={onDateChangeStub} />);
+      const wrapper = shallow(
+        <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />,
+      );
       wrapper.instance().clearDate();
       expect(onDateChangeStub.callCount).to.equal(1);
     });
@@ -477,6 +673,8 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(
           <SingleDatePicker
             id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
             isDayBlocked={isDayBlockedStub}
             isOutsideRange={isOutsideRangeStub}
           />,
@@ -486,7 +684,14 @@ describe('SingleDatePicker', () => {
 
       it('returns true if props.isOutsideRange returns true', () => {
         const isOutsideRangeStub = sinon.stub().returns(true);
-        const wrapper = shallow(<SingleDatePicker id="date" isOutsideRange={isOutsideRangeStub} />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            isOutsideRange={isOutsideRangeStub}
+          />,
+        );
         expect(wrapper.instance().isBlocked()).to.equal(true);
       });
 
@@ -496,6 +701,8 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow(
           <SingleDatePicker
             id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
             isDayBlocked={isDayBlockedStub}
             isOutsideRange={isOutsideRangeStub}
           />,
@@ -506,14 +713,26 @@ describe('SingleDatePicker', () => {
 
     describe('#isHovered', () => {
       it('returns true if day arg is equal to state.hoverDate', () => {
-        const wrapper = shallow(<SingleDatePicker id="date" />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />,
+        );
         wrapper.setState({ hoverDate: today });
         expect(wrapper.instance().isHovered(today)).to.equal(true);
       });
 
       it('returns false if day arg is not equal to state.hoverDate', () => {
         const tomorrow = moment().add(1, 'days');
-        const wrapper = shallow(<SingleDatePicker id="date" />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />,
+        );
         wrapper.setState({ hoverDate: today });
         expect(wrapper.instance().isHovered(tomorrow)).to.equal(false);
       });
@@ -521,30 +740,62 @@ describe('SingleDatePicker', () => {
 
     describe('#isSelected', () => {
       it('returns true if day arg is equal to props.date', () => {
-        const wrapper = shallow(<SingleDatePicker id="date" date={today} />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            date={today}
+          />,
+        );
         expect(wrapper.instance().isSelected(today)).to.equal(true);
       });
 
       it('returns false if day arg is not equal to props.date', () => {
         const tomorrow = moment().add(1, 'days');
-        const wrapper = shallow(<SingleDatePicker id="date" date={tomorrow} />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            date={tomorrow}
+          />,
+        );
         expect(wrapper.instance().isSelected(today)).to.equal(false);
       });
     });
 
     describe('#isToday', () => {
       it('returns true if today', () => {
-        const wrapper = shallow(<SingleDatePicker />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />,
+        );
         expect(wrapper.instance().isToday(today)).to.equal(true);
       });
 
       it('returns false if tomorrow', () => {
-        const wrapper = shallow(<SingleDatePicker />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />,
+        );
         expect(wrapper.instance().isToday(moment(today).add(1, 'days'))).to.equal(false);
       });
 
       it('returns false if last month', () => {
-        const wrapper = shallow(<SingleDatePicker />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />,
+        );
         expect(wrapper.instance().isToday(moment(today).subtract(1, 'months'))).to.equal(false);
       });
     });
@@ -554,8 +805,15 @@ describe('SingleDatePicker', () => {
     describe('initialVisibleMonth is passed in', () => {
       it('DayPicker.props.initialVisibleMonth is equal to initialVisibleMonth', () => {
         const initialVisibleMonth = () => {};
-        const wrapper =
-          shallow(<SingleDatePicker initialVisibleMonth={initialVisibleMonth} focused />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            initialVisibleMonth={initialVisibleMonth}
+            focused
+          />,
+        );
         const dayPicker = wrapper.find(DayPicker);
         expect(dayPicker.props().initialVisibleMonth).to.equal(initialVisibleMonth);
       });
@@ -564,13 +822,28 @@ describe('SingleDatePicker', () => {
     describe('initialVisibleMonth is not passed in', () => {
       it('DayPicker.props.initialVisibleMonth evaluates to date', () => {
         const date = moment().add(10, 'days');
-        const wrapper = shallow(<SingleDatePicker date={date} focused />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            date={date}
+            focused
+          />,
+        );
         const dayPicker = wrapper.find(DayPicker);
         expect(dayPicker.props().initialVisibleMonth()).to.equal(date);
       });
 
       it('DayPickerRangeController.props.initialVisibleMonth evaluates to today if !startDate && !endDate', () => {
-        const wrapper = shallow(<SingleDatePicker focused />);
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            focused
+          />,
+        );
         const dayPicker = wrapper.find(DayPicker);
         expect(dayPicker.props().initialVisibleMonth().isSame(today, 'day')).to.equal(true);
       });


### PR DESCRIPTION
This change does the following
- Make `onDate(s)Change` and `onFocusChange` required
- Sort `DateRangePicker`, `SingleDatePicker`, `DayPicker` by category with comments
- Use `forbidExtraProps` on all components
- Add propTypes and defaultProps to the examples so that information shows up in the info addon

I would like ideally to have `focusedInput`/`startDate`/`endDate` and `focused`/`date` to be required as well, but since those can take a value of `null` that's a bit trickier. I might make a validator that allows for this (something like `isDefined`).

to: @airbnb/webinfra 