### PR TITLE
Calendar caption with renderCalendarCaption

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ By default, we do not show days from the previous month and the next month in th
 
 Optionally you can provide calendar caption block renderer.
 ```js
-   renderCalendarCaption: PropTypes.func,
+   renderCalendarInfo: PropTypes.func,
 ```
 
 **DayPicker presentation:**

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ By default, we do not show days from the previous month and the next month in th
    initialVisibleMonth: PropTypes.func,
 ```
 
+Optionally you can provide calendar caption block renderer.
+```js
+   renderCalendarCaption: PropTypes.func,
+```
+
 **DayPicker presentation:**
 
 The `orientation` prop indicates whether months are stacked on top of each other or displayed side-by-side. You can import the `HORIZONTAL_ORIENTATION` and `VERTICAL_ORIENTATION` constants from `react-dates/constants`.

--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -30,6 +30,7 @@ const propTypes = forbidExtraProps({
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -64,6 +65,7 @@ const defaultProps = {
   numberOfMonths: 2,
   onOutsideClick() {},
   keepOpenOnDateSelect: false,
+  renderCalendarInfo: null,
 
   // navigation related props
   navPrev: null,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -62,7 +62,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
-  renderCalendarCaption: null,
+  renderCalendarInfo: null,
 
   // navigation related props
   navPrev: null,
@@ -223,7 +223,7 @@ export default class DateRangePicker extends React.Component {
       minimumNights,
       keepOpenOnDateSelect,
       renderDay,
-      renderCalendarCaption,
+      renderCalendarInfo,
       initialVisibleMonth,
       customCloseIcon,
     } = this.props;
@@ -267,7 +267,7 @@ export default class DateRangePicker extends React.Component {
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
           renderDay={renderDay}
-          renderCalendarCaption={renderCalendarCaption}
+          renderCalendarInfo={renderCalendarInfo}
         />
 
         {withFullScreenPortal &&

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -62,6 +62,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
+  renderCalendarCaption: null,
 
   // navigation related props
   navPrev: null,
@@ -222,6 +223,7 @@ export default class DateRangePicker extends React.Component {
       minimumNights,
       keepOpenOnDateSelect,
       renderDay,
+      renderCalendarCaption,
       initialVisibleMonth,
       customCloseIcon,
     } = this.props;
@@ -265,6 +267,7 @@ export default class DateRangePicker extends React.Component {
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
           renderDay={renderDay}
+          renderCalendarCaption={renderCalendarCaption}
         />
 
         {withFullScreenPortal &&

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -37,6 +37,7 @@ const propTypes = forbidExtraProps({
   onOutsideClick: PropTypes.func,
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  renderCalendarCaption: PropTypes.func,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -65,6 +66,7 @@ const defaultProps = {
   onOutsideClick() {},
   hidden: false,
   initialVisibleMonth: () => moment(),
+  renderCalendarCaption: null,
 
   // navigation props
   navPrev: null,
@@ -387,6 +389,7 @@ export default class DayPicker extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       renderDay,
+      renderCalendarCaption,
       onOutsideClick,
       monthFormat,
     } = this.props;
@@ -474,6 +477,7 @@ export default class DayPicker extends React.Component {
             />
             {verticalScrollable && this.renderNavigation()}
           </div>
+          {renderCalendarCaption && renderCalendarCaption()}
         </OutsideClickHandler>
       </div>
     );

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -37,7 +37,7 @@ const propTypes = forbidExtraProps({
   onOutsideClick: PropTypes.func,
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
-  renderCalendarCaption: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -66,7 +66,7 @@ const defaultProps = {
   onOutsideClick() {},
   hidden: false,
   initialVisibleMonth: () => moment(),
-  renderCalendarCaption: null,
+  renderCalendarInfo: null,
 
   // navigation props
   navPrev: null,
@@ -389,7 +389,7 @@ export default class DayPicker extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       renderDay,
-      renderCalendarCaption,
+      renderCalendarInfo,
       onOutsideClick,
       monthFormat,
     } = this.props;
@@ -477,7 +477,7 @@ export default class DayPicker extends React.Component {
             />
             {verticalScrollable && this.renderNavigation()}
           </div>
-          {renderCalendarCaption && renderCalendarCaption()}
+          {renderCalendarInfo && renderCalendarInfo()}
         </OutsideClickHandler>
       </div>
     );

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -51,6 +51,7 @@ const propTypes = forbidExtraProps({
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
   renderDay: PropTypes.func,
+  renderCalendarCaption: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -87,6 +88,7 @@ const defaultProps = {
   onOutsideClick() {},
 
   renderDay: null,
+  renderCalendarCaption: null,
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -244,6 +246,7 @@ export default class DayPickerRangeController extends React.Component {
       initialVisibleMonth,
       focusedInput,
       renderDay,
+      renderCalendarCaption,
     } = this.props;
 
     const modifiers = {
@@ -288,6 +291,7 @@ export default class DayPickerRangeController extends React.Component {
         navPrev={navPrev}
         navNext={navNext}
         renderDay={renderDay}
+        renderCalendarCaption={renderCalendarCaption}
       />
     );
   }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -51,7 +51,7 @@ const propTypes = forbidExtraProps({
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
   renderDay: PropTypes.func,
-  renderCalendarCaption: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -88,7 +88,7 @@ const defaultProps = {
   onOutsideClick() {},
 
   renderDay: null,
-  renderCalendarCaption: null,
+  renderCalendarInfo: null,
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -246,7 +246,7 @@ export default class DayPickerRangeController extends React.Component {
       initialVisibleMonth,
       focusedInput,
       renderDay,
-      renderCalendarCaption,
+      renderCalendarInfo,
     } = this.props;
 
     const modifiers = {
@@ -291,7 +291,7 @@ export default class DayPickerRangeController extends React.Component {
         navPrev={navPrev}
         navNext={navNext}
         renderDay={renderDay}
-        renderCalendarCaption={renderCalendarCaption}
+        renderCalendarInfo={renderCalendarInfo}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -56,7 +56,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
-  renderCalendarCaption: null,
+  renderCalendarInfo: null,
 
   // navigation related props
   navPrev: null,
@@ -295,7 +295,7 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       renderDay,
-      renderCalendarCaption,
+      renderCalendarInfo,
       date,
       initialVisibleMonth,
       customCloseIcon,
@@ -341,7 +341,7 @@ export default class SingleDatePicker extends React.Component {
           navPrev={navPrev}
           navNext={navNext}
           renderDay={renderDay}
-          renderCalendarCaption={renderCalendarCaption}
+          renderCalendarInfo={renderCalendarInfo}
         />
 
         {withFullScreenPortal &&

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -56,6 +56,7 @@ const defaultProps = {
   numberOfMonths: 2,
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
+  renderCalendarCaption: null,
 
   // navigation related props
   navPrev: null,
@@ -294,6 +295,7 @@ export default class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       focused,
       renderDay,
+      renderCalendarCaption,
       date,
       initialVisibleMonth,
       customCloseIcon,
@@ -339,6 +341,7 @@ export default class SingleDatePicker extends React.Component {
           navPrev={navPrev}
           navNext={navNext}
           renderDay={renderDay}
+          renderCalendarCaption={renderCalendarCaption}
         />
 
         {withFullScreenPortal &&

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -41,7 +41,7 @@ export default {
   numberOfMonths: PropTypes.number,
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
-  renderCalendarCaption: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -41,6 +41,7 @@ export default {
   numberOfMonths: PropTypes.number,
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
+  renderCalendarCaption: PropTypes.func,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -34,6 +34,7 @@ export default {
   numberOfMonths: PropTypes.number,
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDate: PropTypes.bool,
+  renderCalendarCaption: PropTypes.func,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -34,7 +34,7 @@ export default {
   numberOfMonths: PropTypes.number,
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDate: PropTypes.bool,
-  renderCalendarCaption: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -32,6 +32,19 @@ const TestNextIcon = () => (
   </span>
 );
 
+const TestCaption = () => (
+  <div
+    style={{
+      padding: '10px 21px',
+      borderTop: '1px solid #dce0e0',
+      color: '#484848',
+
+    }}
+  >
+    &#x2755; Some useful info here
+  </div>
+)
+
 storiesOf('DRP - Calendar Props', module)
   .addWithInfo('default', () => (
     <DateRangePickerWrapper autoFocus />
@@ -104,6 +117,14 @@ storiesOf('DRP - Calendar Props', module)
   .addWithInfo('with month specified on open', () => (
     <DateRangePickerWrapper
       initialVisibleMonth={() => moment('04 2017', 'MM YYYY')}
+      autoFocus
+    />
+  ))
+  .addWithInfo('with caption', () => (
+    <DateRangePickerWrapper
+      renderCalendarCaption={() => (
+        <TestCaption />
+      )}
       autoFocus
     />
   ));

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -32,18 +32,17 @@ const TestNextIcon = () => (
   </span>
 );
 
-const TestCaption = () => (
+const TestCustomInfoPanel = () => (
   <div
     style={{
       padding: '10px 21px',
       borderTop: '1px solid #dce0e0',
       color: '#484848',
-
     }}
   >
     &#x2755; Some useful info here
   </div>
-)
+);
 
 storiesOf('DRP - Calendar Props', module)
   .addWithInfo('default', () => (
@@ -120,10 +119,10 @@ storiesOf('DRP - Calendar Props', module)
       autoFocus
     />
   ))
-  .addWithInfo('with caption', () => (
+  .addWithInfo('with info panel', () => (
     <DateRangePickerWrapper
-      renderCalendarCaption={() => (
-        <TestCaption />
+      renderCalendarInfo={() => (
+        <TestCustomInfoPanel />
       )}
       autoFocus
     />

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -7,36 +7,37 @@ import {
   VERTICAL_SCROLLABLE,
 } from '../constants';
 
-const TestPrevIcon = props => (
-  <span style={{
+const TestPrevIcon = () => (
+  <span
+    style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
-      padding: '3px'
+      padding: '3px',
     }}
   >
     Prev
   </span>
 );
-const TestNextIcon = props => (
-  <span style={{
-    border: '1px solid #dce0e0',
-    backgroundColor: '#fff',
-    color: '#484848',
-    padding: '3px'
+const TestNextIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
     }}
   >
     Next
   </span>
 );
 
-const TestCaption = () => (
+const TestCustomInfoPanel = () => (
   <div
     style={{
       padding: '10px 21px',
       borderTop: '1px solid #dce0e0',
       color: '#484848',
-
     }}
   >
     &#x2755; Some useful info here
@@ -86,10 +87,10 @@ storiesOf('DayPicker', module)
       />
     </div>
   ))
-  .addWithInfo('with caption', () => (
+  .addWithInfo('with info panel', () => (
     <DayPicker
-      renderCalendarCaption={() => (
-        <TestCaption />
+      renderCalendarInfo={() => (
+        <TestCustomInfoPanel />
       )}
     />
   ));

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -30,6 +30,19 @@ const TestNextIcon = props => (
   </span>
 );
 
+const TestCaption = () => (
+  <div
+    style={{
+      padding: '10px 21px',
+      borderTop: '1px solid #dce0e0',
+      color: '#484848',
+
+    }}
+  >
+    &#x2755; Some useful info here
+  </div>
+);
+
 storiesOf('DayPicker', module)
   .addWithInfo('default', () => (
     <DayPicker />
@@ -72,4 +85,11 @@ storiesOf('DayPicker', module)
         orientation={VERTICAL_ORIENTATION}
       />
     </div>
+  ))
+  .addWithInfo('with caption', () => (
+    <DayPicker
+      renderCalendarCaption={() => (
+        <TestCaption />
+      )}
+    />
   ));

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -75,6 +75,18 @@ const TestNextIcon = () => (
   </span>
 );
 
+const TestCustomInfoPanel = () => (
+  <div
+    style={{
+      padding: '10px 21px',
+      borderTop: '1px solid #dce0e0',
+      color: '#484848',
+    }}
+  >
+    &#x2755; Some useful info here
+  </div>
+);
+
 const datesList = [
   moment(),
   moment().add(1, 'days'),
@@ -233,5 +245,15 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       renderDay={day => day.format('ddd')}
+    />
+  ))
+  .addWithInfo('with info panel', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      renderCalendarInfo={() => (
+        <TestCustomInfoPanel />
+      )}
     />
   ));

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -32,13 +32,12 @@ const TestNextIcon = () => (
   </span>
 );
 
-const TestCaption = () => (
+const TestCustomInfoPanel = () => (
   <div
     style={{
       padding: '10px 21px',
       borderTop: '1px solid #dce0e0',
       color: '#484848',
-
     }}
   >
     &#x2755; Some useful info here
@@ -111,10 +110,10 @@ storiesOf('SDP - Calendar Props', module)
       autoFocus
     />
   ))
-  .addWithInfo('with caption', () => (
+  .addWithInfo('with info panel', () => (
     <SingleDatePickerWrapper
-      renderCalendarCaption={() => (
-        <TestCaption />
+      renderCalendarInfo={() => (
+        <TestCustomInfoPanel />
       )}
       autoFocus
     />

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -32,6 +32,19 @@ const TestNextIcon = () => (
   </span>
 );
 
+const TestCaption = () => (
+  <div
+    style={{
+      padding: '10px 21px',
+      borderTop: '1px solid #dce0e0',
+      color: '#484848',
+
+    }}
+  >
+    &#x2755; Some useful info here
+  </div>
+);
+
 storiesOf('SDP - Calendar Props', module)
   .addWithInfo('default', () => (
     <SingleDatePickerWrapper autoFocus />
@@ -95,6 +108,14 @@ storiesOf('SDP - Calendar Props', module)
     <SingleDatePickerWrapper
       numberOfMonths={1}
       enableOutsideDays
+      autoFocus
+    />
+  ))
+  .addWithInfo('with caption', () => (
+    <SingleDatePickerWrapper
+      renderCalendarCaption={() => (
+        <TestCaption />
+      )}
       autoFocus
     />
   ));

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -64,6 +64,15 @@ describe('DayPicker', () => {
       });
     });
 
+    describe('renderCaption', () => {
+      it('caption exists', () => {
+        const testCaptionClass = 'test-cation-container';
+        const captionElement = <div className={testCaptionClass} />;
+        const wrapper = shallow(<DayPicker renderCalendarCaption={() => captionElement} />);
+        expect(wrapper.find(`.${testCaptionClass}`)).to.have.lengthOf(1);
+      });
+    });
+
     describe('CalendarMonthGrid', () => {
       it('component exists', () => {
         const wrapper = shallow(<DayPicker />);

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -64,12 +64,12 @@ describe('DayPicker', () => {
       });
     });
 
-    describe('renderCaption', () => {
-      it('caption exists', () => {
-        const testCaptionClass = 'test-cation-container';
-        const captionElement = <div className={testCaptionClass} />;
-        const wrapper = shallow(<DayPicker renderCalendarCaption={() => captionElement} />);
-        expect(wrapper.find(`.${testCaptionClass}`)).to.have.lengthOf(1);
+    describe('renderCalendarInfo', () => {
+      it('info exists', () => {
+        const testInfoClass = 'test-info-container';
+        const infoElement = <div className={testInfoClass} />;
+        const wrapper = shallow(<DayPicker renderCalendarInfo={() => infoElement} />);
+        expect(wrapper.find(`.${testInfoClass}`)).to.have.lengthOf(1);
       });
     });
 


### PR DESCRIPTION
#### An excerpt from README:
> Optionally you can provide calendar caption block renderer.
> ```js
>    renderCalendarInfo: PropTypes.func,
> ```

#### Usage example:
```js
  const CustomInfo = ({day, format}) => (
    <div>
      ❕ Some useful info here
    </div>
  );

  <SingleDatePickerWrapper
    renderCalendarInfo={() => (
      <CustomInfo />
    )}
  />
```
#### Example screenshot:
![2017-02-20 19 20 29](https://cloud.githubusercontent.com/assets/1659008/23133366/dec422b8-f7a1-11e6-8b43-752c57c79168.png)

The `renderCalendarInfo` prop are universal, and available in `DateRangePicker`, `SingleDatePicker` and `DayPicker`.

> As a part of #331 