### PR TITLE
Remove override of day picker width

### DIFF
--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -1,4 +1,4 @@
-$react-dates-width-day-picker: 300px;
+@import 'variables';
 
 .CalendarMonthGrid {
   background: $react-dates-color-white;


### PR DESCRIPTION
The `$react-dates-width-day-picker: 300px;` defined in `CalendarMonthGrid.scss` overrides any custom variables provided.