### PR TITLE
Add customCloseIcon prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ To replace the default arrow icon, you may pass a React node to `props.customArr
   customArrowIcon: PropTypes.node,
 ```
 
+To replace the default close icon, you may pass a React node to `props.customCloseIcon`.
+```js
+  customCloseIcon: PropTypes.node,
+```
+
 If the `disabled` prop is set to true, onFocusChange is not called when onStartDateFocus or onEndDateFocus are invoked and disabled is assigned to the actual `<input>` DOM elements.
 ```js
   disabled: PropTypes.bool,

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -44,6 +44,7 @@ const defaultProps = {
   showDefaultInputIcon: false,
   customInputIcon: null,
   customArrowIcon: null,
+  customCloseIcon: null,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -50,6 +50,7 @@ const defaultProps = {
   showDefaultInputIcon: false,
   customInputIcon: null,
   customArrowIcon: null,
+  customCloseIcon: null,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -222,6 +223,7 @@ export default class DateRangePicker extends React.Component {
       keepOpenOnDateSelect,
       renderDay,
       initialVisibleMonth,
+      customCloseIcon,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -230,6 +232,8 @@ export default class DateRangePicker extends React.Component {
       : undefined;
     const initialVisibleMonthThunk =
       initialVisibleMonth || (() => (startDate || endDate || moment()));
+
+    const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
       <div
@@ -272,7 +276,9 @@ export default class DateRangePicker extends React.Component {
             <span className="screen-reader-only">
               {this.props.phrases.closeDatePicker}
             </span>
-            <CloseButton />
+            <div className="DateRangePicker__close">
+              {closeIcon}
+            </div>
           </button>
         }
       </div>
@@ -293,6 +299,7 @@ export default class DateRangePicker extends React.Component {
       showDefaultInputIcon,
       customInputIcon,
       customArrowIcon,
+      customCloseIcon,
       disabled,
       required,
       phrases,
@@ -326,6 +333,7 @@ export default class DateRangePicker extends React.Component {
             showDefaultInputIcon={showDefaultInputIcon}
             customInputIcon={customInputIcon}
             customArrowIcon={customArrowIcon}
+            customCloseIcon={customCloseIcon}
             disabled={disabled}
             required={required}
             reopenPickerOnClearDates={reopenPickerOnClearDates}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -131,11 +131,13 @@ export default class DateRangePickerInput extends React.Component {
       showDefaultInputIcon,
       customInputIcon,
       customArrowIcon,
+      customCloseIcon,
       phrases,
     } = this.props;
 
     const inputIcon = customInputIcon || (<CalendarIcon />);
     const arrowIcon = customArrowIcon || (<RightArrow />);
+    const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
       <div
@@ -204,7 +206,9 @@ export default class DateRangePickerInput extends React.Component {
             <span className="screen-reader-only">
               {phrases.clearDates}
             </span>
-            <CloseButton />
+            <div className="DateRangePickerInput__close-icon">
+              {closeIcon}
+            </div>
           </button>
         }
       </div>

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -47,6 +47,7 @@ const propTypes = forbidExtraProps({
 
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
+  customCloseIcon: PropTypes.node,
 
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerInputPhrases)),
@@ -81,6 +82,7 @@ const defaultProps = {
 
   customInputIcon: null,
   customArrowIcon: null,
+  customCloseIcon: null,
 
   // i18n
   phrases: DateRangePickerInputPhrases,
@@ -203,6 +205,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
       showDefaultInputIcon,
       customInputIcon,
       customArrowIcon,
+      customCloseIcon,
       disabled,
       required,
       phrases,
@@ -231,6 +234,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
         showDefaultInputIcon={showDefaultInputIcon}
         customInputIcon={customInputIcon}
         customArrowIcon={customArrowIcon}
+        customCloseIcon={customCloseIcon}
         phrases={phrases}
         onStartDateChange={this.onStartDateChange}
         onStartDateFocus={this.onStartDateFocus}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -44,6 +44,7 @@ const defaultProps = {
   required: false,
   screenReaderInputMessage: '',
   showClearDate: false,
+  customCloseIcon: null,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -295,6 +296,7 @@ export default class SingleDatePicker extends React.Component {
       renderDay,
       date,
       initialVisibleMonth,
+      customCloseIcon,
     } = this.props;
     const { dayPickerContainerStyles } = this.state;
 
@@ -311,6 +313,7 @@ export default class SingleDatePicker extends React.Component {
 
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
     const initialVisibleMonthThunk = initialVisibleMonth || (() => (date || moment()));
+    const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
       <div
@@ -347,7 +350,9 @@ export default class SingleDatePicker extends React.Component {
             <span className="screen-reader-only">
               {this.props.phrases.closeDatePicker}
             </span>
-            <CloseButton />
+            <div className="SingleDatePicker__close-icon">
+              {closeIcon}
+            </div>
           </button>
         }
       </div>

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -19,6 +19,7 @@ const propTypes = forbidExtraProps({
   required: PropTypes.bool,
   showCaret: PropTypes.bool,
   showClearDate: PropTypes.bool,
+  customCloseIcon: PropTypes.node,
 
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
@@ -40,6 +41,7 @@ const defaultProps = {
   required: false,
   showCaret: false,
   showClearDate: false,
+  customCloseIcon: null,
 
   onChange() {},
   onClearDate() {},
@@ -93,7 +95,10 @@ export default class SingleDatePickerInput extends React.Component {
       onKeyDownShiftTab,
       onKeyDownTab,
       screenReaderMessage,
+      customCloseIcon,
     } = this.props;
+
+    const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
       <div className="SingleDatePickerInput">
@@ -126,7 +131,9 @@ export default class SingleDatePickerInput extends React.Component {
             onMouseLeave={this.onClearDateMouseLeave}
             onClick={onClearDate}
           >
-            <CloseButton />
+            <div className="DateRangePickerInput__close">
+              {closeIcon}
+            </div>
           </button>
         }
       </div>

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -29,6 +29,7 @@ export default {
   showDefaultInputIcon: PropTypes.bool,
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
+  customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
   orientation: OrientationShape,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -22,6 +22,7 @@ export default {
   required: PropTypes.bool,
   screenReaderInputMessage: PropTypes.string,
   showClearDate: PropTypes.bool,
+  customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
   orientation: OrientationShape,

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -30,6 +30,17 @@ const TestCustomArrowIcon = () => (
   </span>
 );
 
+const TestCustomCloseIcon = () => (
+  <span
+    style={{
+      border: '1px solid #dce0e0',
+      backgroundColor: '#fff',
+      color: '#484848',
+      padding: '3px',
+    }}
+  >'X'</span>
+);
+
 storiesOf('DRP - Input Props', module)
   .addWithInfo('default', () => (
     <DateRangePickerWrapper
@@ -78,6 +89,14 @@ storiesOf('DRP - Input Props', module)
       initialStartDate={moment().add(3, 'days')}
       initialEndDate={moment().add(10, 'days')}
       customArrowIcon={<TestCustomArrowIcon />}
+    />
+  ))
+  .addWithInfo('with custom close icon', () => (
+    <DateRangePickerWrapper
+      initialStartDate={moment().add(3, 'days')}
+      initialEndDate={moment().add(10, 'days')}
+      showClearDates
+      customCloseIcon={<TestCustomCloseIcon />}
     />
   ))
   .addWithInfo('with screen reader message', () => (

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -101,7 +101,7 @@ describe('DateRangePickerInput', () => {
             <DateRangePickerInput
               customInputIcon={<span className="custom-icon" />}
             />);
-          expect(wrapper.find('.DateRangePickerInput__calendar-icon .custom-icon'));
+          expect(wrapper.find('.DateRangePickerInput__calendar-icon .custom-icon')).to.have.lengthOf(1);
         });
       });
     });
@@ -113,7 +113,18 @@ describe('DateRangePickerInput', () => {
         <DateRangePickerInput
           customArrowIcon={<span className="custom-arrow-icon" />}
         />);
-      expect(wrapper.find('.DateRangePickerInput__calendar-icon .custom-arrow-icon'));
+      expect(wrapper.find('.DateRangePickerInput .custom-arrow-icon')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('props.customCloseIcon is a React Element', () => {
+    it('has custom icon', () => {
+      const wrapper = shallow(
+        <DateRangePickerInput
+          showClearDates
+          customCloseIcon={<span className="custom-close-icon" />}
+        />);
+      expect(wrapper.find('.DateRangePickerInput .custom-close-icon')).to.have.lengthOf(1);
     });
   });
 

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -54,6 +54,17 @@ describe('SingleDatePickerInput', () => {
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
         });
     });
+
+    describe('props.customCloseIcon is a React Element', () => {
+      it('has custom icon', () => {
+        const wrapper = shallow(
+          <SingleDatePickerInput
+            showClearDate
+            customCloseIcon={<span className="custom-close-icon" />}
+          />);
+        expect(wrapper.find('.SingleDatePickerInput .custom-close-icon')).to.have.lengthOf(1);
+      });
+    });
   });
 
   describe('#onClearDateMouseEnter', () => {


### PR DESCRIPTION
@majapw @ljharb 

Adds a `customCloseIcon` prop to allow overriding the default `<CloseButton />`. I matched the behavior of `customArrowIcon`: default prop of null, fallback to original component inside `render`, and a wrapping css class.