### PR TITLE
Simplify the README

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import moment from 'moment';
 import { configure, addDecorator, setAddon } from '@kadira/storybook';
 import infoAddon from '@kadira/react-storybook-addon-info';
@@ -7,6 +8,40 @@ addDecorator((story) => {
   moment.locale('en');
   return (story());
 });
+
+function getLink(href, text) {
+  return `<a href=${href} rel="noopener noreferrer" target="_blank">${text}</a>`;
+}
+
+const README = getLink('https://github.com/airbnb/react-dates/blob/master/README.md', 'README');
+const wrapperSource = getLink('https://github.com/airbnb/react-dates/tree/master/examples', 'wrapper source');
+
+const helperText = `All examples are built using a wrapper component that is not exported by
+  react-dates. Please see the ${README} for more information about minimal setup or explore
+  the ${wrapperSource} to see how to integrate react-dates into your own app.`;
+
+addDecorator(story => (
+  <div>
+    <div
+      style={{
+        background: '#fff',
+        height: 6 * 8,
+        width: '100%',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        padding: '8px 40px 8px 8px',
+        overflow: 'scroll',
+      }}
+    >
+      <span dangerouslySetInnerHTML={{ __html: helperText }} />
+    </div>
+
+    <div style={{ marginTop: 7 * 8 }}>
+      {story()}
+    </div>
+  </div>
+));
 
 function loadStories() {
   require('../stories/DateRangePicker');

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run that demo on your own computer:
 * Visit http://localhost:9001/
 
 ## Getting Started
-#### Install dependencies
+### Install dependencies
 Ensure packages are installed with correct version numbers by running:
   ```sh
   (
@@ -40,493 +40,197 @@ Ensure packages are installed with correct version numbers by running:
   npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.## react-addons-shallow-compare@>=#.##
   ```
 
-#### Include component
+### Include component
 ```js
-import { SingleDatePicker } from 'react-dates';
+import { DateRangePicker, SingleDatePicker, DayPickerRangeController } from 'react-dates';
 ```
 
-#### Include CSS
-When you use Webpack with CSS loader:
+### Include CSS
+#### Webpack
+Using Webpack with CSS loader, add the following import to your app:
 ```js
 import 'react-dates/lib/css/_datepicker.css';
 ```
-Otherwise create a CSS file with the contents of `require.resolve('react-dates/lib/css/_datepicker.css')` and include it in the html `<head>` section.
 
-#### Make some awesome datepickers
+#### Without Webpack:
+Create a CSS file with the contents of `require.resolve('react-dates/lib/css/_datepicker.css')` and include it in your html `<head>` section.
+
+### Make some awesome datepickers
+
+We provide a handful of components for your use. If you supply essential props to each component, you'll get a full featured interactive date picker. With additional optional props, you can customize the look and feel of the inputs, calendar, etc. You can see what each of the props do in the [live demo](http://airbnb.io/react-dates/) or explore
+how to properly wrap the pickers in the [examples folder](https://github.com/airbnb/react-dates/tree/master/examples).
+
+#### DateRangePicker
+The `DateRangePicker` is a fully controlled component that allows users to select a date range. You can control the selected
+dates using the `startDate`, `endDate`, and `onDatesChange` props as shown below. The `DateRangePicker` also manages internal
+state for partial dates entered by typing (although `onDatesChange` will not trigger until a date has been entered
+completely in that case). Similarly, you can control which input is focused as well as calendar visibility (the calendar is
+only visible if `focusedInput` is defined) with the `focusedInput` and `onFocusChange` props as shown below.
+
+Here is the minimum *REQUIRED* setup you need to get the `DateRangePicker` working:
 ```jsx
-<SingleDatePicker
-  id="date_input"
-  date={this.state.date}
-  focused={this.state.focused}
-  onDateChange={(date) => { this.setState({ date }); }}
-  onFocusChange={({ focused }) => { this.setState({ focused }); }}
+<DateRangePicker
+  startDate={this.state.startDate} // momentPropTypes.momentObj or null,
+  endDate={this.state.endDate} // momentPropTypes.momentObj or null,
+  onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
+  focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
+  onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
 />
 ```
 
-## API
-
-We have a handful of different components and utilities available for all of your date picking needs!
-
-### `DateRangePicker`
-This fully-controlled component is designed to allow a user to select both a start date and an end date. It is best suited for a selecting a relatively short date range some time in the next year.
-
-#### `Props`
-
-**Dates:**
-
-Moment objects representing the currently selected start and end dates. To indicate that a date has not yet been selected, these are set to `null`.
+The following is a list of other *OPTIONAL* props you may provide to the `DateRangePicker` to customize appearance and behavior to your heart's desire. Again, please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
 ```js
-  startDate: momentPropTypes.momentObj,
-  endDate: momentPropTypes.momentObj,
+// input related props
+startDateId: PropTypes.string.isRequired,
+startDatePlaceholderText: PropTypes.string,
+endDateId: PropTypes.string.isRequired,
+endDatePlaceholderText: PropTypes.string,
+disabled: PropTypes.bool,
+required: PropTypes.bool,
+screenReaderInputMessage: PropTypes.string,
+showClearDates: PropTypes.bool,
+showDefaultInputIcon: PropTypes.bool,
+customInputIcon: PropTypes.node,
+customArrowIcon: PropTypes.node,
+customCloseIcon: PropTypes.node,
+
+// calendar presentation and interaction related props
+orientation: OrientationShape,
+anchorDirection: anchorDirectionShape,
+horizontalMargin: PropTypes.number,
+withPortal: PropTypes.bool,
+withFullScreenPortal: PropTypes.bool,
+initialVisibleMonth: PropTypes.func,
+numberOfMonths: PropTypes.number,
+keepOpenOnDateSelect: PropTypes.bool,
+reopenPickerOnClearDates: PropTypes.bool,
+renderCalendarInfo: PropTypes.func,
+
+// navigation related props
+navPrev: PropTypes.node,
+navNext: PropTypes.node,
+onPrevMonthClick: PropTypes.func,
+onNextMonthClick: PropTypes.func,
+
+// day presentation and interaction related props
+renderDay: PropTypes.func,
+minimumNights: PropTypes.number,
+enableOutsideDays: PropTypes.bool,
+isDayBlocked: PropTypes.func,
+isOutsideRange: PropTypes.func,
+isDayHighlighted: PropTypes.func,
+
+// internationalization props
+displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+monthFormat: PropTypes.string,
+phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),
 ```
 
-`onDatesChange` is the callback necessary to update the date state being held in the parent component and pass that back down to the `DateRangePicker` as props. `onDatesChange` receives an object of the form
-`{ startDate: momentPropTypes.momentObj, endDate: momentPropTypes.momentObj }`
-as an argument.
-```js
-  onDatesChange: PropTypes.func,
+#### SingleDatePicker
+The `SingleDatePicker` is a fully controlled component that allows users to select a single date. You can control the selected
+date using the `date` and `onDateChange` props as shown below. The `SingleDatePicker` also manages internal
+state for partial dates entered by typing (although `onDateChange` will not trigger until a date has been entered
+completely in that case). Similarly, you can control whether or not the input is focused (calendar visibility is also
+controlled with the same props) with the `focused` and `onFocusChange` props as shown below.
+
+Here is the minimum *REQUIRED* setup you need to get the `SingleDatePicker` working:
+```jsx
+<SingleDatePicker
+  date={this.state.date} // momentPropTypes.momentObj or null
+  onDateChange={date => this.setState({ date })} // PropTypes.func.isRequired
+  focused={this.state.focused} // PropTypes.bool
+  onFocusChange={({ focused }) => this.setState({ focused })} // PropTypes.func.isRequired
+/>
 ```
 
-**Focus:**
-
-The `focusedInput` prop indicates which of the two inputs is currently focused, if either. You can import the `START_DATE` and `END_DATE` constants from `react-dates/constants`.
+The following is a list of other *OPTIONAL* props you may provide to the `SingleDatePicker` to customize appearance and behavior to your heart's desire. Again, please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
 ```js
-  focusedInput: PropTypes.oneOf([START_DATE, END_DATE]),
+// input related props
+id: PropTypes.string.isRequired,
+placeholder: PropTypes.string,
+disabled: PropTypes.bool,
+required: PropTypes.bool,
+screenReaderInputMessage: PropTypes.string,
+showClearDate: PropTypes.bool,
+customCloseIcon: PropTypes.node,
+
+// calendar presentation and interaction related props
+orientation: OrientationShape,
+anchorDirection: anchorDirectionShape,
+horizontalMargin: PropTypes.number,
+withPortal: PropTypes.bool,
+withFullScreenPortal: PropTypes.bool,
+initialVisibleMonth: PropTypes.func,
+numberOfMonths: PropTypes.number,
+keepOpenOnDateSelect: PropTypes.bool,
+reopenPickerOnClearDate: PropTypes.bool,
+renderCalendarInfo: PropTypes.func,
+
+// navigation related props
+navPrev: PropTypes.node,
+navNext: PropTypes.node,
+onPrevMonthClick: PropTypes.func,
+onNextMonthClick: PropTypes.func,
+
+// day presentation and interaction related props
+renderDay: PropTypes.func,
+enableOutsideDays: PropTypes.bool,
+isDayBlocked: PropTypes.func,
+isOutsideRange: PropTypes.func,
+isDayHighlighted: PropTypes.func,
+
+// internationalization props
+displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+monthFormat: PropTypes.string,
+phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerPhrases)),
 ```
 
-`onFocusChange` is the callback necessary to update the focus state being held in the parent component and pass that back down to the `DateRangePicker` as a prop. `onFocusChange` receives either `START_DATE`, `END_DATE`, or `null` as an argument.
-```js
-  onFocusChange: PropTypes.func,
+#### DayPickerRangeController
+The `DayPickerRangeController` is a calendar-only version of the `DateRangePicker`. There are no inputs (which also means
+that currently, it is not keyboard accessible) and the calendar is always visible, but you can select a date range much in the same way you would with the `DateRangePicker`. You can control the selected
+dates using the `startDate`, `endDate`, and `onDatesChange` props as shown below. Similarly, you can control which input is focused with the `focusedInput` and `onFocusChange` props as shown below. The user will only be able to select a date if `focusedInput` is provided.
+
+Here is the minimum *REQUIRED* setup you need to get the `DayPickerRangeController` working:
+```jsx
+<DayPickerRangeController
+  startDate={this.state.startDate} // momentPropTypes.momentObj or null,
+  endDate={this.state.endDate} // momentPropTypes.momentObj or null,
+  onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
+  focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
+  onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
+/>
 ```
 
-**Date selection rules:**
-
-The value of `minimumNights` indicates the minimum number of days between the start date and the end date.
+The following is a list of other *OPTIONAL* props you may provide to the `DayPickerRangeController` to customize appearance and behavior to your heart's desire. Again, please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DayPickerRangeController&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
 ```js
-  minimumNights: PropTypes.number,
-```
-
-To indicate which days are blocked from selection, you may provide a function to the `isDayBlocked` prop. As of v1.0.0, we allow blocked dates inside of ranges.
-```js
-  isDayBlocked: PropTypes.func,
-```
-
-`isOutsideRange` indicates which days are out of selectable range.
-Past dates out of range by default. If you would like to allow the user to select days in the past, you may set `isOutsideRange` to `() => false`.
-
-Right now we have an expectation that this function returns true for a continuous range of dates from -Infinity to some date and/or from some date to +Infinity. This is relevant to the minimum nights logic. If you would like to prevent the user from selecting a non-continuous set of dates, you should use `isDayBlocked` instead.
-```js
-  isOutsideRange: PropTypes.func,
-```
-
-**Calendar presentation:**
-
-`numberOfMonths` indicates the number of visible months at a time.
-```js
-  numberOfMonths: PropTypes.number,
-```
-
-By default, we do not show days from the previous month and the next month in the same table as the currently visible month. However, sometimes, and especially if the `numberOfMonths` prop is set to 1, it might make sense to allow users to see these days as well. To do, you may set `enabledOutsideDays` to true. These days can still be styled by selecting on the `CalendarMonth__day--outside` class.
-```js
+  // calendar presentation and interaction related props
   enableOutsideDays: PropTypes.bool,
-```
-
-`initialVisibleMonth` indicates the month that should be displayed initially when the calendar is first opened. The prop is a function that must return a Moment.js object. This function will be called the first time the user focuses on the `DateRangePicker`/`SingleDatePicker` inputs or when the `focused` prop is passed to the `DayPicker` component.
-```js
-   initialVisibleMonth: PropTypes.func,
-```
-
-Optionally you can provide calendar caption block renderer.
-```js
-   renderCalendarInfo: PropTypes.func,
-```
-
-**DayPicker presentation:**
-
-The `orientation` prop indicates whether months are stacked on top of each other or displayed side-by-side. You can import the `HORIZONTAL_ORIENTATION` and `VERTICAL_ORIENTATION` constants from `react-dates/constants`.
-```js
-  orientation: PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]),
-```
-
-The `anchorDirection` prop indicates whether the calendar is anchored to the right or left side of the input. You can import the `ANCHOR_LEFT` and `ANCHOR_RIGHT` constants from `react-dates/constants`. Defaults to `ANCHOR_LEFT`.
-```js
-  anchorDirection: PropTypes.oneOf([ANCHOR_LEFT, ANCHOR_RIGHT]),
-```
-
-`withPortal` was designed for use on mobile devices. Namely, if this prop is set to true, the `DayPicker` will be rendered centrally on the screen, above the current plane, with a transparent black background behind it. Clicking on the background will hide the `DayPicker`. This option is currently only available for a `DateRangePicker` with a horizontal orientation.
-```js
+  numberOfMonths: PropTypes.number,
+  orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
-```
+  initialVisibleMonth: PropTypes.func,
+  renderCalendarInfo: PropTypes.func,
+  onOutsideClick: PropTypes.func,
+  keepOpenOnDateSelect: PropTypes.bool,
 
-`withFullScreenPortal` is a full-screen takeover version of the `withPortal` prop. Similarly to `withPortal`, the `DayPicker` is rendered centrally on the screen, above the current plane. However, instead of a clickable transparent black background, the background is solid and white. To close the datepicker, the user must either select a date or click the close button located at the top right of the screen.
-```js
-  withFullScreenPortal: PropTypes.bool,
-```
-
-**Input presentation:**
-
-The `startDateId` and `endDateId` props are assigned to the actual `<input>` DOM elements for accessibility reasons. They default to the values of the `START_DATE` and `END_DATE` constants.
-```js
-  startDateId: PropTypes.string,
-  endDateId: PropTypes.string,
-```
-
-The `startDatePlaceholderText` and `endDatePlaceholderText` props are the placeholders for the two inputs. As of v1.0.0, they are also used as the label text for their respective inputs.
-```js
-  startDatePlaceholderText: PropTypes.string,
-  endDatePlaceholderText: PropTypes.string,
-```
-
-If the `showClearDates` prop is set to true, an `x` shows up in the input box that allows you to clear out both dates and reset the input.
-```js
-  showClearDates: PropTypes.bool,
-```
-
-If the `showDefaultInputIcon` prop is set to true, the default calendar icon is displayed at the start of the input box. Interaction is the same as focusing the start date.
-Optionally, you can display a React node using `props.customInputIcon`
-```js
-  showDefaultInputIcon: PropTypes.bool,
-  customInputIcon: PropTypes.node,
-```
-
-To replace the default arrow icon, you may pass a React node to `props.customArrowIcon`.
-```js
-  customArrowIcon: PropTypes.node,
-```
-
-To replace the default close icon, you may pass a React node to `props.customCloseIcon`.
-```js
-  customCloseIcon: PropTypes.node,
-```
-
-If the `disabled` prop is set to true, onFocusChange is not called when onStartDateFocus or onEndDateFocus are invoked and disabled is assigned to the actual `<input>` DOM elements.
-```js
-  disabled: PropTypes.bool,
-```
-
-If the `required` prop is set to true, the input will have to be filled before the user can submit the form. The standard HTML5 error message will appear on the input when the form is submitted and the input has no value.
-```js
-  required: PropTypes.bool,
-```
-
-The `screenReaderInputMessage` prop accepts a contextual message for screen readers. When an input is focused, the `screenReaderInputMessage` prop value is read. This can inform users about constraints, such as the date format, minimum nights, blocked out dates, etc.
-```js
-  screenReaderInputMessage: PropTypes.string,
-```
-
-**Custom Navigation Icons:**
-
-The `navPrev` and `navNext` props are used to assign custom icons to the "Next", and "Previous" arrows for the top navigation. If you do specify a custom icon you'll have to do the styling of the button yourself (e.g. the color, border, and things of that nature). All that comes "out of the box" is your button being positioned correctly.
-```js
+  // navigation related props
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
-```
+  onPrevMonthClick: PropTypes.func,
+  onNextMonthClick: PropTypes.func,
 
-**Custom content in calendar days:**
-
-If you want to customize the content in a calendar day, you can specify a `renderDay` function which receives the `day` moment object as its only argument. `renderDay` will be responsible for rendering _every_ day and should return `day.format('D')` for the default display.
-```
+  // day presentation and interaction related props
   renderDay: PropTypes.func,
-```
-
-**Some useful callbacks:**
-
-If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.
-```js
-  onPrevMonthClick: PropTypes.func,
-  onNextMonthClick: PropTypes.func,
-```
-
-**Internationalization:**
-
-While we have reasonable defaults for english, we understand that that's not the only language in the world! :) At Airbnb, more than 50% of users visit our site in a language other than english. Thus, in addition to supporting moment locales, the `DateRangePicker` accepts a number of props to allow for this.
-
-The `displayFormat` prop is either a string that abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) or a function that returns a string that follows these rules. It defaults to the value of moment's `L` format in whatever locale you happen to be in at the time of render.
-```js
-  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-```
-
-The `monthFormat` prop abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) and indicates the format in which to display dates at the top of each calendar. It defaults to `MMMM YYYY`.
-```js
-  monthFormat: PropTypes.string,
-```
-
-The `phrases` prop is an object that contains all the English language phrases currently part of the class. As of now, we only have three such phrases and none are visible but they are used for screen-reader navigation of the datepicker.
-```js
-  phrases: PropTypes.shape({
-    closeDatePicker: PropTypes.node,
-    clearDates: PropTypes.node,
-    clearDate: PropTypes.node,
-  }),
-```
-
-**Display picker when clicked on clear button:**
-
-The `reopenPickerOnClearDates` prop helps to control whether to show the date picker when the clear option is clicked. This is set to `false` by default
-which means that the picker does not open when the clear button is clicked by default. To display the picker one must explicitly set it to `true`.
-
-```js
-    reopenPickerOnClearDates: PropTypes.bool,
-```
-
-**Keep picker open on date selection:**
-
-The `keepOpenOnDateSelect` prop allows you to better control in what scenario the `DayPicker` stays visible or not. If it is set to false (the default value), once a date range has been successfully selected, the `DayPicker` will close. If true, it will stay open.
-
-```js
-    keepOpenOnDateSelect: PropTypes.bool,
-```
-
-### `SingleDatePicker`
-This fully-controlled component is designed to allow a user to select a single date.
-
-#### `Props`
-
-**Dates:**
-
-Moment objects representing the currently selected date. This is set to `null` when no date has yet been selected.
-```js
-  date: momentPropTypes.momentObj,
-```
-
-`onDateChange` is the callback necessary to update the date state held in the parent component. It expects a single argument equal to either `null` or a moment object.
-```js
-  onDateChange: PropTypes.func,
-```
-
-**Focus:**
-
-A boolean representing whether or not the date input is currently focused.
-```js
-  focused: PropTypes.bool,
-```
-
-`onFocusChange` is the callback necessary to update the focus state in the parent component. It expects a single argument of the form `{ focused: PropTypes.bool }`.
-```js
-  onFocusChange: PropTypes.func,
-```
-
-**Date selection rules:**
-
-These properties are the same as provided to the `<DateRangePicker />` component.
-
-To indicate which days are blocked from selection, you may provide a function to the `isDayBlocked` prop. As of v1.0.0, we allow blocked dates inside of ranges.
-```js
-  isDayBlocked: PropTypes.func,
-```
-
-`isOutsideRange` indicates which days are out of selectable range.
-Past dates out of range by default. If you would like to allow the user to select days in the past, you may set `isOutsideRange` to `() => false`.
-
-Right now we have an expectation that this function returns true for a continuous range of dates from -Infinity to some date and/or from some date to +Infinity. This is relevant to the minimum nights logic. If you would like to prevent the user from selecting a non-continuous set of dates, you should use `isDayBlocked` instead.
-```js
+  minimumNights: PropTypes.number,
   isOutsideRange: PropTypes.func,
-```
+  isDayBlocked: PropTypes.func,
+  isDayHighlighted: PropTypes.func,
 
-**Calendar presentation:**
-
-These properties are the same as provided to the `<DateRangePicker />` component.
-
-`numberOfMonths` indicates the number of visible months at a time.
-```js
-  numberOfMonths: PropTypes.number,
-```
-
-By default, we do not show days from the previous month and the next month in the same table as the currently visible month. However, sometimes, and especially if the `numberOfMonths` prop is set to 1, it might make sense to allow users to see these days as well. To do, you may set `enabledOutsideDays` to true. These days can still be styled by selecting on the `CalendarMonth__day--outside` class.
-```js
-  enableOutsideDays: PropTypes.bool,
-```
-
-`initialVisibleMonth` indicates the month that should be displayed initially when the calendar is first opened. The prop is a function that must return a Moment.js object. This function will be called the first time the user focuses on the `DateRangePicker`/`SingleDatePicker` inputs or when the `focused` prop is passed to the `DayPicker` component.
-```js
-   initialVisibleMonth: PropTypes.func,
-```
-
-**DayPicker presentation:**
-
-These properties are the same as provided to the `<DateRangePicker />` component.
-
-The `orientation` prop indicates whether months are stacked on top of each other or displayed side-by-side. You can import the `HORIZONTAL_ORIENTATION` and `VERTICAL_ORIENTATION` constants from `react-dates/constants`.
-```js
-  orientation: PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]),
-```
-
-The `anchorDirection` prop indicates whether the calendar is anchored to the right or left side of the input. You can import the `ANCHOR_LEFT` and `ANCHOR_RIGHT` constants from `react-dates/constants`. Defaults to `ANCHOR_LEFT`.
-```js
-  anchorDirection: PropTypes.oneOf([ANCHOR_LEFT, ANCHOR_RIGHT]),
-```
-
-`withPortal` was designed for use on mobile devices. Namely, if this prop is set to true, the `DayPicker` will be rendered centrally on the screen, above the current plane, with a transparent black background behind it. Clicking on the background will hide the `DayPicker`. This option is currently only available for a `DateRangePicker` with a horizontal orientation.
-```js
-  withPortal: PropTypes.bool,
-```
-
-`withFullScreenPortal` is a full-screen takeover version of the `withPortal` prop. Similarly to `withPortal`, the `DayPicker` is rendered centrally on the screen, above the current plane. However, instead of a clickable transparent black background, the background is solid and white. To close the datepicker, the user must either select a date or click the close button located at the top right of the screen.
-```js
-  withFullScreenPortal: PropTypes.bool,
-```
-
-**Input presentation:**
-
-The `id` prop is assigned to the actual `<input>` DOM element. It is currently required for accessibility reasons.
-```js
-  id: PropTypes.string.isRequired,
-```
-
-The `placeholder` props is the placeholder text for the input. It is both applied as an actual placeholder to the DOM `<input>` and as a placeholder for the display text. As of v1.0.0, it is also used as label text.
-```js
-  placeholder: PropTypes.string,
-```
-
-If the `showClearDate` prop is set to true, an `x` shows up in the input box that allows you to clear out both dates and reset the input.
-```js
-  showClearDate: PropTypes.bool,
-```
-
-If the `disabled` prop is set to true, onFocusChange is not called when onStartDateFocus or onEndDateFocus are invoked and disabled is assigned to the actual `<input>` DOM elements.
-```js
-  disabled: PropTypes.bool,
-```
-
-If the `required` prop is set to true, the input will have to be filled before the user can submit the form. The standard HTML5 error message will appear on the input when the form is submitted and the input has no value.
-```js
-  required: PropTypes.bool,
-```
-
-**Some useful callbacks:**
-
-These properties are the same as provided to the `<DateRangePicker />` component.
-
-If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.
-```js
-  onPrevMonthClick: PropTypes.func,
-  onNextMonthClick: PropTypes.func,
-```
-
-**Internationalization:**
-
-The `displayFormat` prop is either a string that abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) or a function that returns a string that follows these rules. It defaults to the value of moment's `L` format in whatever locale you happen to be in at the time of render.
-```js
-  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-```
-
-The `monthFormat` prop abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) and indicates the format in which to display dates at the top of each calendar. It defaults to `MMMM YYYY`.
-```js
+  // internationalization props
   monthFormat: PropTypes.string,
+  phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
+/>
 ```
-
-The `phrases` prop is an object that contains all the English language phrases currently part of the class. As of v1.0.0, we only have one such phrases and it is not visible but is used for screen-reader navigation of the datepicker.
-```js
-  phrases: PropTypes.shape({
-    closeDatePicker: PropTypes.node,
-  })
-```
-
-**Display picker when clicked on clear button:**
-
-The `reopenPickerOnClearDates` prop helps to control whether to show the date picker when the clear option is clicked. This is set to `false` by default
-which means that the picker does not open when the clear button is clicked by default. To display the picker one must explicitly set it to `true`.
-
-```js
-    reopenPickerOnClearDates: PropTypes.bool,
-```
-
-**Keep picker open on date selection:**
-
-The `keepOpenOnDateSelect` prop allows you to better control in what scenario the `DayPicker` stays visible or not. If it is set to false (the default value), once a date range has been successfully selected, the `DayPicker` will close. If true, it will stay open.
-
-```js
-    keepOpenOnDateSelect: PropTypes.bool,
-```
-
-### `DayPicker`
-This fully-controlled component renders a designated number of months and allows for user interaction with days. It is possible to navigate between months using this component.
-
-#### `Props`
-
-**Calendar Presentation:**
-
-These properties are the same as provided to the `<DateRangePicker />` and `<SingleDatePicker />` components.
-
-`numberOfMonths` indicates the number of visible months at a time.
-```js
-  numberOfMonths: PropTypes.number,
-```
-
-By default, we do not show days from the previous month and the next month in the same table as the currently visible month. However, sometimes, and especially if the `numberOfMonths` prop is set to 1, it might make sense to allow users to see these days as well. To do, you may set `enabledOutsideDays` to true. These days can still be styled by selecting on the `CalendarMonth__day--outside` class.
-```js
-  enableOutsideDays: PropTypes.bool,
-```
-
-**DayPicker Presentation:**
-
-The `orientation` prop indicates whether months are stacked on top of each other or displayed side-by-side. You can import the `HORIZONTAL_ORIENTATION` and `VERTICAL_ORIENTATION` constants from `react-dates/constants`.
-```js
-  orientation: PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]),
-```
-
-`withPortal` exists primarily for use in conjunction with the `<DateRangePicker />` and `<SingleDatePicker />` components. It will not do much if a `DayPicker` is rendered on its own with it set to true other than modify some position-related styles and remove a box-shadow.
-```js
-  withPortal: PropTypes.bool,
-```
-
-The `modifiers` object maps modifier names (designated as strings) to functions that take in a moment object and return a boolean value. An example of a `modifiers` object could be as follows:
-```js
-  modifiers={{
-    friday: (day) => moment.weekdays(day.weekday()) === 'Friday',
-  }}
-```
-Then, every Friday in the visible calendar would have the class `CalendarMonth__day--friday` applied to it and could be styled appropriately. By default, the only modifier that is always applied is the `outside` modifier which is applied to dates on the calendar that might still be visible but fall outside of the current month.
-
-```js
-  modifiers: PropTypes.object,
-```
-
-**Day interaction callbacks:**
-
-These callbacks get triggered when the relevant event ('click', 'mouseenter', etc.) occurs on any visible `CalendarDay` component. The callback gets back 3 arguments, the day represented as a moment object, an array of strings representing the modifiers that are applicable to that day, and the event object itself.
-
-`onDayTouchTap` has been implemented in-house and has not yet been thoroughly tested. We recommend using `onDayClick` whenever possible.
-```js
-  onDayClick: PropTypes.func,
-  onDayMouseEnter: PropTypes.func,
-  onDayMouseLeave: PropTypes.func,
-```
-
-**Some other useful callbacks:**
-
-If you need to do something when the user navigates between months (for instance, check the availability of a listing), you can do so using the `onPrevMonthClick` and `onNextMonthClick` props.
-```js
-  onPrevMonthClick: PropTypes.func,
-  onNextMonthClick: PropTypes.func,
-```
-
-If you need to do something when the user clicks outside of the `DayPicker` (for instance, hide the `DayPicker`), you may do so using the `onOutsideClick` prop.
-```js
-  onOutsideClick: PropTypes.func,
-```
-
-**Internationalization:**
-
-The `monthFormat` prop abides by [moment's date formatting rules](http://momentjs.com/docs/#/displaying/format/) and indicates the format in which to display dates at the top of each calendar. It defaults to `MMMM YYYY`.
-
-```js
-  monthFormat: PropTypes.string,
-```
-
-## Utility Methods
-
-### Date Comparison
-
-We provide four utility methods for date comparison:
-```
-  isInclusivelyAfterDay
-  isInclusivelyBeforeDay
-  isNextDay
-  isSameDay
-```
-
-Each of these methods takes in two moment objects and returns a boolean, indicating whether the first argument is inclusively after, inclusively before, the day immediately after, or the same day as the second argument.
 
 ## Theming
 


### PR DESCRIPTION
Describing each prop in detail feels unwieldy, especially since it is ultimately better to just go to the storybook and see what the heck they actually do. It also fails to adequately explain what you actually need to get a functional datepicker. In this change, I try to focus on the required props and point the viewer to the storybook for the optional props.

To view the change, I would recommend ignoring the diff and just looking at the new README on its own.

to: @airbnb/webinfra 