### PR TITLE
[Feature] - Add onClose callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ navPrev: PropTypes.node,
 navNext: PropTypes.node,
 onPrevMonthClick: PropTypes.func,
 onNextMonthClick: PropTypes.func,
+onClose: PropTypes.func,
 
 // day presentation and interaction related props
 renderDay: PropTypes.func,
@@ -171,6 +172,7 @@ navPrev: PropTypes.node,
 navNext: PropTypes.node,
 onPrevMonthClick: PropTypes.func,
 onNextMonthClick: PropTypes.func,
+onClose: PropTypes.func,
 
 // day presentation and interaction related props
 renderDay: PropTypes.func,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -19,6 +19,7 @@ const propTypes = forbidExtraProps({
 
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  onClose: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
 
@@ -41,6 +42,7 @@ const defaultProps = {
 
   onChange() {},
   onFocus() {},
+  onClose() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
 
@@ -141,6 +143,7 @@ export default class DateInput extends React.Component {
       focused,
       showCaret,
       onFocus,
+      onClose,
       disabled,
       required,
     } = this.props;
@@ -167,6 +170,7 @@ export default class DateInput extends React.Component {
           onChange={this.onChange}
           onKeyDown={throttle(this.onKeyDown, 300)}
           onFocus={onFocus}
+          onClose={onClose}
           placeholder={placeholder}
           autoComplete="off"
           disabled={disabled}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -74,6 +74,8 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  onClose() {},
+
   // day presentation and interaction related props
   renderDay: null,
   minimumNights: 1,
@@ -143,7 +145,7 @@ export default class DateRangePicker extends React.Component {
   }
 
   onOutsideClick() {
-    const { onFocusChange } = this.props;
+    const { onFocusChange, onClose, startDate, endDate } = this.props;
     if (!this.isOpened()) return;
 
     this.setState({
@@ -153,6 +155,7 @@ export default class DateRangePicker extends React.Component {
     });
 
     onFocusChange(null);
+    onClose({ startDate, endDate });
   }
 
   onDateRangePickerInputFocus(focusedInput) {
@@ -296,6 +299,7 @@ export default class DateRangePicker extends React.Component {
       renderCalendarInfo,
       initialVisibleMonth,
       customCloseIcon,
+      onClose,
       phrases,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
@@ -324,6 +328,7 @@ export default class DateRangePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           onDatesChange={onDatesChange}
           onFocusChange={onFocusChange}
+          onClose={onClose}
           focusedInput={focusedInput}
           startDate={startDate}
           endDate={endDate}
@@ -387,6 +392,7 @@ export default class DateRangePicker extends React.Component {
       reopenPickerOnClearDates,
       keepOpenOnDateSelect,
       onDatesChange,
+      onClose,
     } = this.props;
 
     const { isDateRangePickerInputFocused } = this.state;
@@ -422,6 +428,7 @@ export default class DateRangePicker extends React.Component {
             onFocusChange={this.onDateRangePickerInputFocus}
             onArrowDown={this.onDayPickerFocus}
             onQuestionMark={this.showKeyboardShortcutsPanel}
+            onClose={onClose}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
             isFocused={isDateRangePickerInputFocused}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -44,6 +44,7 @@ const propTypes = forbidExtraProps({
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
   onFocusChange: PropTypes.func,
+  onClose: PropTypes.func,
   onDatesChange: PropTypes.func,
   onArrowDown: PropTypes.func,
   onQuestionMark: PropTypes.func,
@@ -84,6 +85,7 @@ const defaultProps = {
   displayFormat: () => moment.localeData().longDateFormat('L'),
 
   onFocusChange() {},
+  onClose() {},
   onDatesChange() {},
   onArrowDown() {},
   onQuestionMark() {},
@@ -112,7 +114,10 @@ export default class DateRangePickerInputController extends React.Component {
   }
 
   onClearFocus() {
-    this.props.onFocusChange(null);
+    const { onFocusChange, onClose, startDate, endDate } = this.props;
+
+    onFocusChange(null);
+    onClose({ startDate, endDate });
   }
 
   onEndDateChange(endDateString) {
@@ -121,7 +126,6 @@ export default class DateRangePickerInputController extends React.Component {
       isOutsideRange,
       keepOpenOnDateSelect,
       onDatesChange,
-      onFocusChange,
     } = this.props;
 
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
@@ -130,7 +134,7 @@ export default class DateRangePickerInputController extends React.Component {
       !isInclusivelyBeforeDay(endDate, startDate);
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });
-      if (!keepOpenOnDateSelect) onFocusChange(null);
+      if (!keepOpenOnDateSelect) this.onClearFocus();
     } else {
       onDatesChange({
         startDate,

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -32,6 +32,7 @@ const propTypes = forbidExtraProps({
 
   focusedInput: FocusedInputShape,
   onFocusChange: PropTypes.func,
+  onClose: PropTypes.func,
 
   keepOpenOnDateSelect: PropTypes.bool,
   minimumNights: PropTypes.number,
@@ -73,6 +74,7 @@ const defaultProps = {
 
   focusedInput: null,
   onFocusChange() {},
+  onClose() {},
 
   keepOpenOnDateSelect: false,
   minimumNights: 1,
@@ -134,11 +136,11 @@ export default class DayPickerRangeController extends React.Component {
     if (e) e.preventDefault();
     if (this.isBlocked(day)) return;
 
-    const { focusedInput } = this.props;
+    const { focusedInput, onFocusChange, onClose } = this.props;
     let { startDate, endDate } = this.props;
 
     if (focusedInput === START_DATE) {
-      this.props.onFocusChange(END_DATE);
+      onFocusChange(END_DATE);
 
       startDate = day;
 
@@ -150,10 +152,13 @@ export default class DayPickerRangeController extends React.Component {
 
       if (!startDate) {
         endDate = day;
-        this.props.onFocusChange(START_DATE);
+        onFocusChange(START_DATE);
       } else if (isInclusivelyAfterDay(day, firstAllowedEndDate)) {
         endDate = day;
-        if (!keepOpenOnDateSelect) this.props.onFocusChange(null);
+        if (!keepOpenOnDateSelect) {
+          onFocusChange(null);
+          onClose({ startDate, endDate });
+        }
       } else {
         startDate = day;
         endDate = null;

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -66,6 +66,7 @@ const defaultProps = {
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  onClose() {},
 
   // day presentation and interaction related props
   renderDay: null,
@@ -145,13 +146,23 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onChange(dateString) {
-    const { isOutsideRange, keepOpenOnDateSelect, onDateChange, onFocusChange } = this.props;
-    const date = toMomentObject(dateString, this.getDisplayFormat());
+    const {
+      startDate,
+      isOutsideRange,
+      keepOpenOnDateSelect,
+      onDateChange,
+      onFocusChange,
+      onClose,
+    } = this.props;
+    const endDate = toMomentObject(dateString, this.getDisplayFormat());
 
-    const isValid = date && !isOutsideRange(date);
+    const isValid = endDate && !isOutsideRange(endDate);
     if (isValid) {
-      onDateChange(date);
-      if (!keepOpenOnDateSelect) onFocusChange({ focused: false });
+      onDateChange(endDate);
+      if (!keepOpenOnDateSelect) {
+        onFocusChange({ focused: false });
+        onClose({ startDate, endDate });
+      }
     } else {
       onDateChange(null);
     }
@@ -160,9 +171,20 @@ export default class SingleDatePicker extends React.Component {
   onDayClick(day, e) {
     if (e) e.preventDefault();
     if (this.isBlocked(day)) return;
+    const {
+      onDateChange,
+      keepOpenOnDateSelect,
+      onFocusChange,
+      onClose,
+      startDate,
+      endDate,
+    } = this.props;
 
-    this.props.onDateChange(day);
-    if (!this.props.keepOpenOnDateSelect) this.props.onFocusChange({ focused: false });
+    onDateChange(day);
+    if (!keepOpenOnDateSelect) {
+      onFocusChange({ focused: null });
+      onClose({ startDate, endDate });
+    }
   }
 
   onDayMouseEnter(day) {
@@ -193,7 +215,7 @@ export default class SingleDatePicker extends React.Component {
   }
 
   onClearFocus() {
-    const { focused, onFocusChange } = this.props;
+    const { startDate, endDate, focused, onFocusChange, onClose } = this.props;
     if (!focused) return;
 
     this.setState({
@@ -202,6 +224,7 @@ export default class SingleDatePicker extends React.Component {
     });
 
     onFocusChange({ focused: false });
+    onClose({ startDate, endDate });
   }
 
   onDayPickerFocus() {

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -26,6 +26,7 @@ const propTypes = forbidExtraProps({
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
+  onClose: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
   onKeyDownArrowDown: PropTypes.func,
@@ -50,6 +51,7 @@ const defaultProps = {
   onChange() {},
   onClearDate() {},
   onFocus() {},
+  onClose() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
   onKeyDownArrowDown() {},
@@ -98,6 +100,7 @@ export default class SingleDatePickerInput extends React.Component {
       onClearDate,
       onChange,
       onFocus,
+      onClose,
       onKeyDownShiftTab,
       onKeyDownTab,
       onKeyDownArrowDown,
@@ -123,6 +126,7 @@ export default class SingleDatePickerInput extends React.Component {
           showCaret={showCaret}
           onChange={onChange}
           onFocus={onFocus}
+          onClose={onClose}
           onKeyDownShiftTab={onKeyDownShiftTab}
           onKeyDownTab={onKeyDownTab}
           onKeyDownArrowDown={onKeyDownArrowDown}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -18,6 +18,8 @@ export default {
   focusedInput: FocusedInputShape,
   onFocusChange: PropTypes.func.isRequired,
 
+  onClose: PropTypes.func,
+
   // input related props
   startDateId: PropTypes.string.isRequired,
   startDatePlaceholderText: PropTypes.string,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -44,6 +44,7 @@ export default {
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onClose: PropTypes.func,
 
   // day presentation and interaction related props
   renderDay: PropTypes.func,

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -89,6 +89,25 @@ describe('DateRangePickerInputController', () => {
       wrapper.instance().onClearFocus();
       expect(onFocusChangeStub.calledWith(null)).to.equal(true);
     });
+
+    it('calls props.onClose with startDate and endDate args', () => {
+      const onCloseStub = sinon.stub();
+      const endDate = moment(today).add(1, 'days');
+
+      const wrapper = shallow(
+        <DateRangePickerInputController
+          onFocusChange={() => null}
+          onClose={onCloseStub}
+          startDate={today}
+          endDate={endDate}
+        />,
+      );
+
+      wrapper.instance().onClearFocus();
+      const args = onCloseStub.getCall(0).args[0];
+      expect(args.startDate).to.equal(today);
+      expect(args.endDate).to.equal(endDate);
+    });
   });
 
   describe('#onEndDateChange', () => {

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -220,6 +220,40 @@ describe('DateRangePicker', () => {
       wrapper.instance().onOutsideClick();
       expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
     });
+
+    it('does not call props.onClose if props.focusedInput = null', () => {
+      const onCloseStub = sinon.stub();
+      const wrapper = shallow(
+        <DateRangePicker
+          focusedInput={null}
+          onClose={onCloseStub}
+          onFocusChange={() => null}
+        />,
+      );
+      wrapper.instance().onOutsideClick();
+      expect(onCloseStub.callCount).to.equal(0);
+    });
+
+    it('calls props.onClose with startDate and endDate if props.focusedInput != null', () => {
+      const startDate = moment();
+      const endDate = startDate.add(1, 'days');
+      const onCloseStub = sinon.stub();
+      const wrapper = shallow(
+        <DateRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          focusedInput={START_DATE}
+          onClose={onCloseStub}
+          onFocusChange={() => null}
+        />,
+      );
+
+      wrapper.instance().onOutsideClick();
+      expect(onCloseStub.callCount).to.equal(1);
+      const args = onCloseStub.getCall(0).args[0];
+      expect(args.startDate).to.equal(startDate);
+      expect(args.endDate).to.equal(endDate);
+    });
   });
 
   describe('#onDateRangePickerInputFocus', () => {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -238,6 +238,28 @@ describe('DayPickerRangeController', () => {
             });
           });
         });
+
+        describe('props.onClose', () => {
+          describe('props.startDate is truthy', () => {
+            it('is called with startDate and endDate', () => {
+              const onCloseStub = sinon.stub();
+              const wrapper = shallow(
+                <DayPickerRangeController
+                  focusedInput={END_DATE}
+                  startDate={today}
+                  onClose={onCloseStub}
+                />,
+              );
+
+              const endDate = moment(today).add(1, 'days');
+
+              wrapper.instance().onDayClick(endDate);
+              const args = onCloseStub.getCall(0).args[0];
+              expect(args.startDate).to.equal(today);
+              expect(args.endDate).to.equal(endDate);
+            });
+          });
+        });
       });
 
       describe('minimumNights is 0', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -333,6 +333,39 @@ describe('SingleDatePicker', () => {
         wrapper.instance().onChange(futureDateString);
         expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
       });
+
+      it('calls props.onClose once', () => {
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />,
+        );
+        wrapper.instance().onChange(futureDateString);
+        expect(onCloseStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onClose with { startDate, endDate } as arg', () => {
+        const startDate = moment();
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            startDate={startDate}
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />,
+        );
+        wrapper.instance().onChange(futureDateString);
+        expect(onCloseStub.getCall(0).args[0].startDate).to.equal(startDate);
+
+        const newDate = onCloseStub.getCall(0).args[0].endDate;
+        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
+      });
     });
 
     describe('matches custom display format', () => {
@@ -495,6 +528,41 @@ describe('SingleDatePicker', () => {
         wrapper.instance().onDayClick(moment());
         expect(onFocusChangeStub.callCount).to.equal(0);
       });
+
+      it('props.onClose is not called', () => {
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+            isDayBlocked={() => true}
+          />,
+        );
+        wrapper.instance().onDayClick(moment());
+        expect(onCloseStub.callCount).to.equal(0);
+      });
+
+      it('calls props.onClose with { startDate, endDate } as arg', () => {
+        const startDate = moment();
+        const endDate = moment().add(5, 'days');
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            startDate={startDate}
+            endDate={endDate}
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />,
+        );
+
+        wrapper.instance().onDayClick(endDate);
+        expect(onCloseStub.getCall(0).args[0].startDate).to.equal(startDate);
+        expect(onCloseStub.getCall(0).args[0].endDate).to.equal(endDate);
+      });
     });
 
     describe('day arg is not blocked', () => {
@@ -514,6 +582,20 @@ describe('SingleDatePicker', () => {
         );
         wrapper.instance().onDayClick(moment());
         expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('props.onClose is called', () => {
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow(
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />,
+        );
+        wrapper.instance().onDayClick(moment());
+        expect(onCloseStub.callCount).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
This PR is related to #264 

We are having some troubles when the user close the picker on the `<DateRangePicker />` component, because it calls the `onDatesChange` and the `onFocusChange` at the same time, and when the `onFocusChange` is called without the focus there wasn't time to reset the state.