### PR TITLE
DaySize update

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -11,4 +11,6 @@ module.exports = {
 
   ANCHOR_LEFT: 'left',
   ANCHOR_RIGHT: 'right',
+
+  DAY_SIZE: 39,
 };

--- a/css/CalendarMonthGrid.scss
+++ b/css/CalendarMonthGrid.scss
@@ -16,16 +16,13 @@
 .CalendarMonthGrid--horizontal {
   position: absolute;
   left: 9px;
-  width: 4 * $react-dates-width-day-picker;
 }
 
 .CalendarMonthGrid--vertical {
-  width: $react-dates-width-day-picker;
   margin: 0 auto;
 }
 
 .CalendarMonthGrid--vertical-scrollable {
-  width: $react-dates-width-day-picker;
   margin: 0 auto;
   overflow-y: scroll;
 }

--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -39,7 +39,6 @@
 .DayPicker__week-header {
   color: $react-dates-color-placeholder-text;
   position: absolute;
-  width: $react-dates-width-day-picker;
   top: 62px;
   z-index: 2;
   padding: 0 13px;
@@ -53,13 +52,11 @@
 
   li {
     display: inline-block;
-    width: 39px;
     text-align: center;
   }
 }
 
 .DayPicker--vertical .DayPicker__week-header {
-  margin-left: -1 * $react-dates-width-day-picker / 2;
   left: 50%;
 }
 

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -1,7 +1,6 @@
 $react-dates-width-input: 130px !default;
 $react-dates-width-arrow: 24px !default;
 $react-dates-width-tooltip-arrow: 20px !default;
-$react-dates-width-day-picker: 300px !default;
 $react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,12 +1,15 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
+import { DAY_SIZE } from '../../constants';
+
 const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
+  daySize: nonNegativeInteger,
   isOutsideDay: PropTypes.bool,
   modifiers: PropTypes.object,
   onDayClick: PropTypes.func,
@@ -17,6 +20,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   day: moment(),
+  daySize: DAY_SIZE,
   isOutsideDay: false,
   modifiers: {},
   onDayClick() {},
@@ -52,6 +56,7 @@ export default class CalendarDay extends React.Component {
   render() {
     const {
       day,
+      daySize,
       isOutsideDay,
       modifiers,
       renderDay,
@@ -61,9 +66,15 @@ export default class CalendarDay extends React.Component {
       'CalendarDay--outside': !day || isOutsideDay,
     }, getModifiersForDay(modifiers, day).map(mod => `CalendarDay--${mod}`));
 
+    const daySizeStyles = {
+      width: daySize,
+      height: daySize - 1,
+    };
+
     return (day ?
       <td
         className={className}
+        style={daySizeStyles}
         onMouseEnter={e => this.onDayMouseEnter(day, e)}
         onMouseLeave={e => this.onDayMouseLeave(day, e)}
         onClick={e => this.onDayClick(day, e)}

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -3,7 +3,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
@@ -17,6 +17,7 @@ import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
   VERTICAL_SCROLLABLE,
+  DAY_SIZE,
 } from '../../constants';
 
 const propTypes = forbidExtraProps({
@@ -25,6 +26,7 @@ const propTypes = forbidExtraProps({
   enableOutsideDays: PropTypes.bool,
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
+  daySize: nonNegativeInteger,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
@@ -40,6 +42,7 @@ const defaultProps = {
   enableOutsideDays: false,
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
+  daySize: DAY_SIZE,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
@@ -81,6 +84,7 @@ export default class CalendarMonth extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       renderDay,
+      daySize,
     } = this.props;
 
     const { weeks } = this.state;
@@ -105,6 +109,7 @@ export default class CalendarMonth extends React.Component {
                 {week.map((day, dayOfWeek) => (
                   <CalendarDay
                     day={day}
+                    daySize={daySize}
                     isOutsideDay={!day || day.month() !== month.month()}
                     modifiers={modifiers}
                     key={dayOfWeek}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 import { addEventListener, removeEventListener } from 'consolidated-events';
@@ -10,6 +10,7 @@ import CalendarMonth from './CalendarMonth';
 
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
+import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -17,6 +18,7 @@ import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
   VERTICAL_SCROLLABLE,
+  DAY_SIZE,
 } from '../../constants';
 
 const propTypes = forbidExtraProps({
@@ -33,6 +35,7 @@ const propTypes = forbidExtraProps({
   onMonthTransitionEnd: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
+  daySize: nonNegativeInteger,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -52,6 +55,7 @@ const defaultProps = {
   onMonthTransitionEnd() {},
   renderDay: null,
   transformValue: 'none',
+  daySize: DAY_SIZE,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -147,6 +151,7 @@ export default class CalendarMonthGrid extends React.Component {
       monthFormat,
       orientation,
       transformValue,
+      daySize,
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
@@ -154,21 +159,33 @@ export default class CalendarMonthGrid extends React.Component {
       onMonthTransitionEnd,
     } = this.props;
 
-
     const { months } = this.state;
+    const isVertical = orientation === VERTICAL_ORIENTATION;
+    const isVerticalScrollable = orientation === VERTICAL_SCROLLABLE;
 
     const className = cx('CalendarMonthGrid', {
       'CalendarMonthGrid--horizontal': orientation === HORIZONTAL_ORIENTATION,
-      'CalendarMonthGrid--vertical': orientation === VERTICAL_ORIENTATION,
-      'CalendarMonthGrid--vertical-scrollable': orientation === VERTICAL_SCROLLABLE,
+      'CalendarMonthGrid--vertical': isVertical,
+      'CalendarMonthGrid--vertical-scrollable': isVerticalScrollable,
       'CalendarMonthGrid--animating': isAnimating,
     });
+
+    const calendarMonthWidth = getCalendarMonthWidth(daySize);
+
+    const width = isVertical || isVerticalScrollable ?
+      calendarMonthWidth :
+      (numberOfMonths + 2) * calendarMonthWidth;
+
+    const style = {
+      ...getTransformStyles(transformValue),
+      width,
+    };
 
     return (
       <div
         ref={(ref) => { this.container = ref; }}
         className={className}
-        style={getTransformStyles(transformValue)}
+        style={style}
         onTransitionEnd={onMonthTransitionEnd}
       >
         {months.map((month, i) => {
@@ -187,6 +204,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
               renderDay={renderDay}
+              daySize={daySize}
             />
           );
         })}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -29,6 +29,7 @@ import {
   VERTICAL_ORIENTATION,
   ANCHOR_LEFT,
   ANCHOR_RIGHT,
+  DAY_SIZE,
 } from '../../constants';
 
 const propTypes = forbidExtraProps(DateRangePickerShape);
@@ -64,10 +65,12 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
   renderCalendarInfo: null,
+  daySize: DAY_SIZE,
 
   // navigation related props
   navPrev: null,
   navNext: null,
+
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
@@ -266,6 +269,7 @@ export default class DateRangePicker extends React.Component {
       onFocusChange,
       withPortal,
       withFullScreenPortal,
+      daySize,
       enableOutsideDays,
       focusedInput,
       startDate,
@@ -307,6 +311,7 @@ export default class DateRangePicker extends React.Component {
           endDate={endDate}
           monthFormat={monthFormat}
           withPortal={withPortal || withFullScreenPortal}
+          daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}
           onOutsideClick={onOutsideClick}
           navPrev={navPrev}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import ReactDOM from 'react-dom';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 import cx from 'classnames';
 
@@ -13,6 +13,7 @@ import CalendarMonthGrid from './CalendarMonthGrid';
 import DayPickerNavigation from './DayPickerNavigation';
 
 import getTransformStyles from '../utils/getTransformStyles';
+import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -20,11 +21,11 @@ import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
   VERTICAL_SCROLLABLE,
+  DAY_SIZE,
 } from '../../constants';
 
-const CALENDAR_MONTH_WIDTH = 300;
-const DAY_PICKER_PADDING = 9;
 const MONTH_PADDING = 23;
+const DAY_PICKER_PADDING = 9;
 const PREV_TRANSITION = 'prev';
 const NEXT_TRANSITION = 'next';
 
@@ -38,6 +39,7 @@ const propTypes = forbidExtraProps({
   hidden: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
+  daySize: nonNegativeInteger,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -70,6 +72,7 @@ const defaultProps = {
   hidden: false,
   initialVisibleMonth: () => moment(),
   renderCalendarInfo: null,
+  daySize: DAY_SIZE,
 
   // navigation props
   navPrev: null,
@@ -158,6 +161,7 @@ export default class DayPicker extends React.Component {
       monthTransition: null,
       translationValue: 0,
       scrollableMonthMultiple: 1,
+      calendarMonthWidth: getCalendarMonthWidth(props.daySize),
     };
 
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
@@ -190,6 +194,12 @@ export default class DayPicker extends React.Component {
         this.initializeDayPickerWidth();
         this.adjustDayPickerHeight();
       }
+    }
+
+    if (nextProps.daySize !== this.props.daySize) {
+      this.setState({
+        calendarMonthWidth: getCalendarMonthWidth(nextProps.daySize),
+      });
     }
   }
 
@@ -358,16 +368,30 @@ export default class DayPicker extends React.Component {
   }
 
   renderWeekHeader(index) {
+    const { daySize, orientation } = this.props;
+    const { calendarMonthWidth } = this.state;
+
+    const verticalScrollable = orientation === VERTICAL_SCROLLABLE;
+
     const horizontalStyle = {
-      left: index * CALENDAR_MONTH_WIDTH,
+      left: index * calendarMonthWidth,
     };
 
-    const style = this.isHorizontal() ? horizontalStyle : {};
+    const verticalStyle = {
+      marginLeft: -calendarMonthWidth / 2,
+    };
+
+    let style = {}; // no styles applied to the vertical-scrollable orientation
+    if (this.isHorizontal()) {
+      style = horizontalStyle;
+    } else if (this.isVertical() && !verticalScrollable) {
+      style = verticalStyle;
+    }
 
     const header = [];
     for (let i = 0; i < 7; i += 1) {
       header.push(
-        <li key={i}>
+        <li key={i} style={{ width: daySize }}>
           <small>{moment().weekday(i).format('dd')}</small>
         </li>,
       );
@@ -406,7 +430,10 @@ export default class DayPicker extends React.Component {
       renderCalendarInfo,
       onOutsideClick,
       monthFormat,
+      daySize,
     } = this.props;
+
+    const { calendarMonthWidth } = this.state;
 
     const numOfWeekHeaders = this.isVertical() ? 1 : numberOfMonths;
     const weekHeaders = [];
@@ -435,18 +462,18 @@ export default class DayPicker extends React.Component {
       'transition-container--vertical': this.isVertical(),
     });
 
-    const horizontalWidth = (CALENDAR_MONTH_WIDTH * numberOfMonths) + (2 * DAY_PICKER_PADDING);
+    const horizontalWidth = (calendarMonthWidth * numberOfMonths) + (2 * DAY_PICKER_PADDING);
 
     // this is a kind of made-up value that generally looks good. we'll
     // probably want to let the user set this explicitly.
-    const verticalHeight = 1.75 * CALENDAR_MONTH_WIDTH;
+    const verticalHeight = 1.75 * calendarMonthWidth;
 
     const dayPickerStyle = {
       width: this.isHorizontal() && horizontalWidth,
 
       // These values are to center the datepicker (approximately) on the page
       marginLeft: this.isHorizontal() && withPortal && -horizontalWidth / 2,
-      marginTop: this.isHorizontal() && withPortal && -CALENDAR_MONTH_WIDTH / 2,
+      marginTop: this.isHorizontal() && withPortal && -calendarMonthWidth / 2,
     };
 
     const transitionContainerStyle = {
@@ -498,6 +525,7 @@ export default class DayPicker extends React.Component {
                 renderDay={renderDay}
                 onMonthTransitionEnd={this.updateStateAfterMonthTransition}
                 monthFormat={monthFormat}
+                daySize={daySize}
               />
               {verticalScrollable && this.renderNavigation()}
             </div>

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
 
 import { DayPickerPhrases } from '../defaultPhrases';
@@ -19,6 +19,7 @@ import {
   START_DATE,
   END_DATE,
   HORIZONTAL_ORIENTATION,
+  DAY_SIZE,
 } from '../../constants';
 
 import DayPicker from './DayPicker';
@@ -43,6 +44,7 @@ const propTypes = forbidExtraProps({
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
+  daySize: nonNegativeInteger,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -82,6 +84,7 @@ const defaultProps = {
   withPortal: false,
 
   initialVisibleMonth: () => moment(),
+  daySize: DAY_SIZE,
 
   navPrev: null,
   navNext: null,
@@ -251,6 +254,7 @@ export default class DayPickerRangeController extends React.Component {
       withPortal,
       enableOutsideDays,
       initialVisibleMonth,
+      daySize,
       focusedInput,
       renderDay,
       renderCalendarInfo,
@@ -308,6 +312,7 @@ export default class DayPickerRangeController extends React.Component {
         withPortal={withPortal}
         hidden={!focusedInput}
         initialVisibleMonth={initialVisibleMonth}
+        daySize={daySize}
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -29,6 +29,7 @@ import {
   VERTICAL_ORIENTATION,
   ANCHOR_LEFT,
   ANCHOR_RIGHT,
+  DAY_SIZE,
 } from '../../constants';
 
 const propTypes = forbidExtraProps(SingleDatePickerShape);
@@ -58,10 +59,12 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
   renderCalendarInfo: null,
+  daySize: DAY_SIZE,
 
   // navigation related props
   navPrev: null,
   navNext: null,
+
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
@@ -343,6 +346,7 @@ export default class SingleDatePicker extends React.Component {
       initialVisibleMonth,
       customCloseIcon,
       phrases,
+      daySize,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
 
@@ -389,6 +393,7 @@ export default class SingleDatePicker extends React.Component {
           isFocused={isDayPickerFocused}
           onBlur={this.onDayPickerBlur}
           phrases={phrases}
+          daySize={daySize}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -1,5 +1,6 @@
 import { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
+import { nonNegativeInteger } from 'airbnb-prop-types';
 
 import { DateRangePickerPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -37,6 +38,8 @@ export default {
   horizontalMargin: PropTypes.number,
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  daySize: nonNegativeInteger,
+
   initialVisibleMonth: PropTypes.func,
   numberOfMonths: PropTypes.number,
   keepOpenOnDateSelect: PropTypes.bool,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -1,5 +1,6 @@
 import { PropTypes } from 'react';
 import momentPropTypes from 'react-moment-proptypes';
+import { nonNegativeInteger } from 'airbnb-prop-types';
 
 import { SingleDatePickerPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -35,10 +36,12 @@ export default {
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDate: PropTypes.bool,
   renderCalendarInfo: PropTypes.func,
+  daySize: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 

--- a/src/utils/getCalendarMonthWidth.js
+++ b/src/utils/getCalendarMonthWidth.js
@@ -1,0 +1,5 @@
+const CALENDAR_MONTH_PADDING = 9;
+
+export default function getCalendarMonthWidth(daySize) {
+  return (7 * (daySize + 1)) + (2 * (CALENDAR_MONTH_PADDING + 1));
+}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -54,6 +54,9 @@ storiesOf('DRP - Calendar Props', module)
   .addWithInfo('3 months', () => (
     <DateRangePickerWrapper numberOfMonths={3} autoFocus />
   ))
+  .addWithInfo('with custom day size', () => (
+    <DateRangePickerWrapper daySize={50} autoFocus />
+  ))
   .addWithInfo('anchored right', () => (
     <div style={{ float: 'right' }}>
       <DateRangePickerWrapper

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -19,6 +19,7 @@ const TestPrevIcon = () => (
     Prev
   </span>
 );
+
 const TestNextIcon = () => (
   <span
     style={{
@@ -48,6 +49,9 @@ storiesOf('DayPicker', module)
   .addWithInfo('default', () => (
     <DayPicker />
   ))
+  .addWithInfo('with custom day size', () => (
+    <DayPicker daySize={50} />
+  ))
   .addWithInfo('more than one month', () => (
     <DayPicker numberOfMonths={2} />
   ))
@@ -58,15 +62,24 @@ storiesOf('DayPicker', module)
     />
   ))
   .addWithInfo('vertically scrollable with 12 months', () => (
-    <div style={{
-      height: '568px',
-      width: '320px',
-    }}>
+    <div
+      style={{
+        height: 568,
+        width: 320,
+      }}
+    >
       <DayPicker
         numberOfMonths={12}
         orientation={VERTICAL_SCROLLABLE}
       />
     </div>
+  ))
+  .addWithInfo('vertical with custom day size', () => (
+    <DayPicker
+      numberOfMonths={2}
+      orientation={VERTICAL_ORIENTATION}
+      daySize={50}
+    />
   ))
   .addWithInfo('with custom arrows', () => (
     <DayPicker

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -54,6 +54,9 @@ storiesOf('SDP - Calendar Props', module)
       autoFocus
     />
   ))
+  .addWithInfo('with custom day size', () => (
+    <SingleDatePickerWrapper daySize={50} autoFocus />
+  ))
   .addWithInfo('anchored right', () => (
     <div style={{ float: 'right' }}>
       <SingleDatePickerWrapper

--- a/test/utils/getCalendarMonthWidth_spec.js
+++ b/test/utils/getCalendarMonthWidth_spec.js
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+
+import getCalendarMonthWidth from '../../src/utils/getCalendarMonthWidth';
+
+describe('#getCalendarMonthWidth', () => {
+  it('correctly calculates width for default day size of 39', () => {
+    expect(getCalendarMonthWidth(39)).to.equal(300);
+  });
+});


### PR DESCRIPTION
to: @majapw @ljharb 

Continuation of Maja's [original PR](https://github.com/airbnb/react-dates/pull/249) to add customizable daySize's. I rebased and inlined a [`39 + 1` calculation](https://github.com/airbnb/react-dates/commit/6dfdab41c721f484fb10bf8d4e18a0e9efc431c8#diff-7b46ca2b2b498da14bfa494d3106eea5L4) to `40` daySize default for a [slightly cleaner number](https://github.com/airbnb/react-dates/pull/249#discussion_r95916020).

I punted on my request to make the [padding configurable as well](https://github.com/airbnb/react-dates/pull/249#discussion_r95908679). It's on of a few remaining hardcoded sizes, and I think we can revisit with a more general solution like sizing with pure css. On this topic, is there any sizing logic that strictly requires js? I think the transition animation should be doable without knowing pixel sizes in js, e.g. using translate `-100%`.

This current version should be sufficient for our use, so PTAL.