### PR TITLE
Fix input focus bottom bar on iOS

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -345,6 +345,11 @@ export default class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={onFocusChange}
+            focusDayPicker={() => {
+              if (this.dayPicker) {
+                setTimeout(() => this.dayPicker.focus(), 0);
+              }
+            }}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}
           />

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -12,6 +12,7 @@ import DateRangePickerInput from './DateRangePickerInput';
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
 import toISODateString from '../utils/toISODateString';
+import isTouchDevice from '../utils/isTouchDevice';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isInclusivelyBeforeDay from '../utils/isInclusivelyBeforeDay';
@@ -44,6 +45,7 @@ const propTypes = forbidExtraProps({
 
   onFocusChange: PropTypes.func,
   onDatesChange: PropTypes.func,
+  focusDayPicker: PropTypes.func,
 
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
@@ -79,6 +81,7 @@ const defaultProps = {
 
   onFocusChange() {},
   onDatesChange() {},
+  focusDayPicker() {},
 
   customInputIcon: null,
   customArrowIcon: null,
@@ -139,6 +142,10 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
     } else if (!disabled) {
       onFocusChange(END_DATE);
     }
+
+    if (isTouchDevice()) {
+      this.props.focusDayPicker();
+    }
   }
 
   onStartDateChange(startDateString) {
@@ -165,6 +172,10 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
   onStartDateFocus() {
     if (!this.props.disabled) {
       this.props.onFocusChange(START_DATE);
+    }
+
+    if (isTouchDevice()) {
+      this.props.focusDayPicker();
     }
   }
 


### PR DESCRIPTION
@majapw @backwardok 

There's an issue on  iOS>=8 where focusing on an `<input>` element brings up a native form navigation bottom bar. This covers UI at the bottom of the page and sometimes requires extra confirmation to dismiss. In this PR, I'm shifting focus to the DayPicker element where the tap interaction occurs. There's still a brief flash of that bar, and I'm open to other ideas. Would swapping the `<input type="text">` with an `<input type="button">` for touch devices check out from an accessibility perspective?