### PR TITLE
Separates out focusedInput from DOM Focus and focuses on the calendar for withPortal implementations

### DIFF
--- a/css/DayPicker.scss
+++ b/css/DayPicker.scss
@@ -23,6 +23,11 @@
   position: initial;
 }
 
+// we can revisit this styling during the a11y picker
+.DayPicker__focus-region {
+  outline: none;
+}
+
 .DayPicker__week-headers {
   position: relative;
 }

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -19,6 +19,8 @@ const propTypes = forbidExtraProps({
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
+
+  isFocused: PropTypes.bool, // describes actual DOM focus
 });
 
 const defaultProps = {
@@ -35,6 +37,8 @@ const defaultProps = {
   onFocus() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
+
+  isFocused: false,
 };
 
 export default class DateInput extends React.Component {
@@ -62,10 +66,10 @@ export default class DateInput extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { focused } = this.props;
-    if (prevProps.focused === focused) return;
+    const { focused, isFocused } = this.props;
+    if (prevProps.focused === focused && prevProps.isFocused === isFocused) return;
 
-    if (focused) {
+    if (focused && isFocused) {
       this.inputRef.focus();
       this.inputRef.select();
     } else {

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -44,6 +44,8 @@ const propTypes = forbidExtraProps({
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
 
+  isFocused: PropTypes.bool, // describes actual DOM focus
+
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerInputPhrases)),
 });
@@ -77,6 +79,8 @@ const defaultProps = {
   customInputIcon: null,
   customArrowIcon: null,
   customCloseIcon: null,
+
+  isFocused: false,
 
   // i18n
   phrases: DateRangePickerInputPhrases,
@@ -134,6 +138,7 @@ export default class DateRangePickerInput extends React.Component {
       customInputIcon,
       customArrowIcon,
       customCloseIcon,
+      isFocused,
       phrases,
     } = this.props;
 
@@ -165,6 +170,7 @@ export default class DateRangePickerInput extends React.Component {
           inputValue={startDateValue}
           screenReaderMessage={screenReaderMessage}
           focused={isStartDateFocused}
+          isFocused={isFocused}
           disabled={disabled}
           required={required}
           showCaret={showCaret}
@@ -185,6 +191,7 @@ export default class DateRangePickerInput extends React.Component {
           inputValue={endDateValue}
           screenReaderMessage={screenReaderMessage}
           focused={isEndDateFocused}
+          isFocused={isFocused}
           disabled={disabled}
           required={required}
           showCaret={showCaret}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -49,6 +49,8 @@ const propTypes = forbidExtraProps({
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
 
+  isFocused: PropTypes.bool,
+
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerInputPhrases)),
 });
@@ -84,11 +86,13 @@ const defaultProps = {
   customArrowIcon: null,
   customCloseIcon: null,
 
+  isFocused: false,
+
   // i18n
   phrases: DateRangePickerInputPhrases,
 };
 
-export default class DateRangePickerInputWithHandlers extends React.Component {
+export default class DateRangePickerInputController extends React.Component {
   constructor(props) {
     super(props);
 
@@ -208,6 +212,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
       customCloseIcon,
       disabled,
       required,
+      isFocused,
       phrases,
     } = this.props;
 
@@ -228,6 +233,7 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}
         isEndDateFocused={isEndDateFocused}
+        isFocused={isFocused}
         disabled={disabled}
         required={required}
         showCaret={showCaret}
@@ -250,5 +256,5 @@ export default class DateRangePickerInputWithHandlers extends React.Component {
   }
 }
 
-DateRangePickerInputWithHandlers.propTypes = propTypes;
-DateRangePickerInputWithHandlers.defaultProps = defaultProps;
+DateRangePickerInputController.propTypes = propTypes;
+DateRangePickerInputController.defaultProps = defaultProps;

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -52,6 +52,9 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
 
+  isFocused: PropTypes.bool,
+  onBlur: PropTypes.func,
+
   // internationalization
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
@@ -80,6 +83,9 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+
+  isFocused: false,
+  onBlur() {},
 
   // internationalization
   monthFormat: 'MMMM YYYY',
@@ -165,6 +171,10 @@ export default class DayPicker extends React.Component {
       this.adjustDayPickerHeight();
       this.initializeDayPickerWidth();
     }
+
+    if (this.props.isFocused) {
+      this.container.focus();
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -192,6 +202,10 @@ export default class DayPicker extends React.Component {
       if (this.isHorizontal()) {
         this.adjustDayPickerHeight();
       }
+    }
+
+    if (!prevProps.isFocused && this.props.isFocused) {
+      this.container.focus();
     }
   }
 
@@ -447,37 +461,49 @@ export default class DayPicker extends React.Component {
     return (
       <div className={dayPickerClassNames} style={dayPickerStyle} >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
-          {!verticalScrollable && this.renderNavigation()}
-
-          <div className="DayPicker__week-headers">
+          <div
+            className="DayPicker__week-headers"
+            aria-hidden="true"
+            role="presentation"
+          >
             {weekHeaders}
           </div>
 
           <div
-            className={transitionContainerClasses}
-            ref={(ref) => { this.transitionContainer = ref; }}
-            style={transitionContainerStyle}
+            className="DayPicker__focus-region"
+            ref={(ref) => { this.container = ref; }}
+            role="region"
+            tabIndex={-1}
           >
-            <CalendarMonthGrid
-              ref={(ref) => { this.calendarMonthGrid = ref; }}
-              transformValue={transformValue}
-              enableOutsideDays={enableOutsideDays}
-              firstVisibleMonthIndex={firstVisibleMonthIndex}
-              initialMonth={currentMonth}
-              isAnimating={isCalendarMonthGridAnimating}
-              modifiers={modifiers}
-              orientation={orientation}
-              numberOfMonths={numberOfMonths * scrollableMonthMultiple}
-              onDayClick={onDayClick}
-              onDayMouseEnter={onDayMouseEnter}
-              onDayMouseLeave={onDayMouseLeave}
-              renderDay={renderDay}
-              onMonthTransitionEnd={this.updateStateAfterMonthTransition}
-              monthFormat={monthFormat}
-            />
-            {verticalScrollable && this.renderNavigation()}
+            {!verticalScrollable && this.renderNavigation()}
+
+            <div
+              className={transitionContainerClasses}
+              ref={(ref) => { this.transitionContainer = ref; }}
+              style={transitionContainerStyle}
+            >
+              <CalendarMonthGrid
+                ref={(ref) => { this.calendarMonthGrid = ref; }}
+                transformValue={transformValue}
+                enableOutsideDays={enableOutsideDays}
+                firstVisibleMonthIndex={firstVisibleMonthIndex}
+                initialMonth={currentMonth}
+                isAnimating={isCalendarMonthGridAnimating}
+                modifiers={modifiers}
+                orientation={orientation}
+                numberOfMonths={numberOfMonths * scrollableMonthMultiple}
+                onDayClick={onDayClick}
+                onDayMouseEnter={onDayMouseEnter}
+                onDayMouseLeave={onDayMouseLeave}
+                renderDay={renderDay}
+                onMonthTransitionEnd={this.updateStateAfterMonthTransition}
+                monthFormat={monthFormat}
+              />
+              {verticalScrollable && this.renderNavigation()}
+            </div>
+
+            {renderCalendarInfo && renderCalendarInfo()}
           </div>
-          {renderCalendarInfo && renderCalendarInfo()}
         </OutsideClickHandler>
       </div>
     );

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -53,6 +53,9 @@ const propTypes = forbidExtraProps({
   renderDay: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
 
+  onBlur: PropTypes.func,
+  isFocused: PropTypes.bool,
+
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
@@ -90,6 +93,9 @@ const defaultProps = {
   renderDay: null,
   renderCalendarInfo: null,
 
+  onBlur() {},
+  isFocused: false,
+
   // i18n
   monthFormat: 'MMMM YYYY',
   phrases: DayPickerPhrases,
@@ -115,7 +121,7 @@ export default class DayPickerRangeController extends React.Component {
   }
 
   onDayClick(day, e) {
-    const { keepOpenOnDateSelect, minimumNights } = this.props;
+    const { keepOpenOnDateSelect, minimumNights, onBlur } = this.props;
     if (e) e.preventDefault();
     if (this.isBlocked(day)) return;
 
@@ -146,6 +152,7 @@ export default class DayPickerRangeController extends React.Component {
     }
 
     this.props.onDatesChange({ startDate, endDate });
+    onBlur();
   }
 
   onDayMouseEnter(day) {
@@ -249,6 +256,9 @@ export default class DayPickerRangeController extends React.Component {
       renderCalendarInfo,
       startDate,
       endDate,
+      onBlur,
+      isFocused,
+      phrases,
     } = this.props;
 
     const modifiers = {
@@ -303,6 +313,9 @@ export default class DayPickerRangeController extends React.Component {
         navNext={navNext}
         renderDay={renderDay}
         renderCalendarInfo={renderCalendarInfo}
+        isFocused={isFocused}
+        onBlur={onBlur}
+        phrases={phrases}
       />
     );
   }

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -15,6 +15,7 @@ const propTypes = forbidExtraProps({
   inputValue: PropTypes.string,
   screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
+  isFocused: PropTypes.bool, // describes actual DOM focus
   disabled: PropTypes.bool,
   required: PropTypes.bool,
   showCaret: PropTypes.bool,
@@ -37,6 +38,7 @@ const defaultProps = {
   inputValue: '',
   screenReaderMessage: '',
   focused: false,
+  isFocused: false,
   disabled: false,
   required: false,
   showCaret: false,
@@ -84,6 +86,7 @@ export default class SingleDatePickerInput extends React.Component {
       displayValue,
       inputValue,
       focused,
+      isFocused,
       disabled,
       required,
       showCaret,
@@ -109,6 +112,7 @@ export default class SingleDatePickerInput extends React.Component {
           inputValue={inputValue}
           screenReaderMessage={screenReaderMessage}
           focused={focused}
+          isFocused={isFocused}
           disabled={disabled}
           required={required}
           showCaret={showCaret}

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -177,6 +177,140 @@ describe('DateRangePicker', () => {
     });
   });
 
+  describe('#onDateRangePickerInputFocus', () => {
+    it('calls onFocusChange', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={onFocusChangeStub}
+        />,
+      );
+      wrapper.instance().onDateRangePickerInputFocus();
+      expect(onFocusChangeStub.callCount).to.equal(1);
+    });
+
+    it('calls onFocusChange with arg', () => {
+      const test = 'foobar';
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={onFocusChangeStub}
+        />,
+      );
+      wrapper.instance().onDateRangePickerInputFocus(test);
+      expect(onFocusChangeStub.getCall(0).args[0]).to.equal(test);
+    });
+
+    describe('new focusedInput is truthy', () => {
+      let onDayPickerFocusSpy;
+      beforeEach(() => {
+        onDayPickerFocusSpy = sinon.spy(DateRangePicker.prototype, 'onDayPickerFocus');
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('calls onDayPickerFocus if focusedInput and withPortal/withFullScreenPortal', () => {
+        const wrapper = shallow(
+          <DateRangePicker
+            onDatesChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+            withPortal
+          />,
+        );
+        wrapper.instance().onDateRangePickerInputFocus(START_DATE);
+        expect(onDayPickerFocusSpy.callCount).to.equal(1);
+      });
+
+      it('calls onDayPickerFocus if focusedInput and withFullScreenPortal', () => {
+        const wrapper = shallow(
+          <DateRangePicker
+            onDatesChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+            withFullScreenPortal
+          />,
+        );
+        wrapper.instance().onDateRangePickerInputFocus(START_DATE);
+        expect(onDayPickerFocusSpy.callCount).to.equal(1);
+      });
+
+      it('calls onDayPickerBlur if focusedInput and !withPortal/!withFullScreenPortal', () => {
+        const onDayPickerBlurSpy = sinon.spy(DateRangePicker.prototype, 'onDayPickerBlur');
+        const wrapper = shallow(
+          <DateRangePicker
+            onDatesChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+          />,
+        );
+        wrapper.instance().onDateRangePickerInputFocus(START_DATE);
+        expect(onDayPickerBlurSpy.callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('#onDayPickerFocus', () => {
+    it('sets state.isDateRangePickerInputFocused to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDateRangePickerInputFocused: true,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().isDateRangePickerInputFocused).to.equal(false);
+    });
+
+    it('sets state.isDayPickerFocused to true', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: false,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().isDayPickerFocused).to.equal(true);
+    });
+  });
+
+  describe('#onDayPickerBlur', () => {
+    it('sets state.isDateRangePickerInputFocused to true', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDateRangePickerInputFocused: false,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().isDateRangePickerInputFocused).to.equal(true);
+    });
+
+    it('sets state.isDayPickerFocused to false', () => {
+      const wrapper = shallow(
+        <DateRangePicker
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: true,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().isDayPickerFocused).to.equal(false);
+    });
+  });
+
   describe('initialVisibleMonth', () => {
     describe('initialVisibleMonth is passed in', () => {
       it('DayPickerRangeController.props.initialVisibleMonth is equal to initialVisibleMonth', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -535,6 +535,15 @@ describe('SingleDatePicker', () => {
   });
 
   describe('#onFocus', () => {
+    let onDayPickerFocusSpy;
+    beforeEach(() => {
+      onDayPickerFocusSpy = sinon.spy(SingleDatePicker.prototype, 'onDayPickerFocus');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('calls props.onFocusChange once', () => {
       const onFocusChangeStub = sinon.stub();
       const wrapper = shallow(
@@ -551,6 +560,42 @@ describe('SingleDatePicker', () => {
       );
       wrapper.instance().onFocus();
       expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(true);
+    });
+
+    it('calls onDayPickerFocus if withPortal', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          withPortal
+        />,
+      );
+      wrapper.instance().onFocus();
+      expect(onDayPickerFocusSpy.callCount).to.equal(1);
+    });
+
+    it('calls onDayPickerFocus if withFullScreenPortal', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          withFullScreenPortal
+        />,
+      );
+      wrapper.instance().onFocus();
+      expect(onDayPickerFocusSpy.callCount).to.equal(1);
+    });
+
+    it('calls onDayPickerBlur if !withPortal/!withFullScreenPortal', () => {
+      const onDayPickerBlurSpy = sinon.spy(SingleDatePicker.prototype, 'onDayPickerBlur');
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.instance().onFocus();
+      expect(onDayPickerBlurSpy.callCount).to.equal(1);
     });
 
     describe('props.disabled = true', () => {
@@ -587,6 +632,36 @@ describe('SingleDatePicker', () => {
     });
 
     describe('props.focused = true', () => {
+      it('sets state.isDayPickerFocused to false', () => {
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+            focused
+          />,
+        );
+        wrapper.setState({
+          isDayPickerFocused: true,
+        });
+        wrapper.instance().onClearFocus();
+        expect(wrapper.state().isDayPickerFocused).to.equal(false);
+      });
+
+      it('sets state.isInputFocused to false', () => {
+        const wrapper = shallow(
+          <SingleDatePicker
+            onDateChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+            focused
+          />,
+        );
+        wrapper.setState({
+          isInputFocused: true,
+        });
+        wrapper.instance().onClearFocus();
+        expect(wrapper.state().isInputFocused).to.equal(false);
+      });
+
       it('calls props.onFocusChange once', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
@@ -614,6 +689,66 @@ describe('SingleDatePicker', () => {
         wrapper.instance().onClearFocus();
         expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
       });
+    });
+  });
+
+  describe('#onDayPickerFocus', () => {
+    it('sets state.isDayPickerFocused to true', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: false,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().isDayPickerFocused).to.equal(true);
+    });
+
+    it('sets state.isInputFocused to false', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isInputFocused: true,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().isInputFocused).to.equal(false);
+    });
+  });
+
+  describe('#onDayPickerBlur', () => {
+    it('sets state.isDayPickerFocused to false', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isDayPickerFocused: true,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().isDayPickerFocused).to.equal(false);
+    });
+
+    it('sets state.isInputFocused to true', () => {
+      const wrapper = shallow(
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      wrapper.setState({
+        isInputFocused: false,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().isInputFocused).to.equal(true);
     });
   });
 


### PR DESCRIPTION
This, as far as I can tell, should be a fix for https://github.com/airbnb/react-dates/issues/246.

I'm going to favor this PR over https://github.com/airbnb/react-dates/pull/409 because it paves the way better for https://github.com/airbnb/react-dates/pull/301.

@airbnb/webinfra @moonboots PTAL