### PR TITLE
Improve touch tap performance

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -247,6 +247,8 @@ export default class DayPickerRangeController extends React.Component {
       focusedInput,
       renderDay,
       renderCalendarInfo,
+      startDate,
+      endDate,
     } = this.props;
 
     const modifiers = {
@@ -254,17 +256,22 @@ export default class DayPickerRangeController extends React.Component {
       blocked: day => this.isBlocked(day),
       'blocked-calendar': day => isDayBlocked(day),
       'blocked-out-of-range': day => isOutsideRange(day),
-      'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
       'highlighted-calendar': day => isDayHighlighted(day),
       valid: day => !this.isBlocked(day),
 
-      // once a start date and end date have been set
-      'selected-start': day => this.isStartDate(day),
-      'selected-end': day => this.isEndDate(day),
-      'selected-span': day => this.isInSelectedSpan(day),
-      'last-in-range': day => this.isLastInRange(day),
-
-      // Avoid computing hover modifiers for touch devices
+      // Modifiers are computed for every CalendarDay, so we omit where
+      // logically possible.
+      ...startDate && {
+        'selected-start': day => this.isStartDate(day),
+      },
+      ...endDate && {
+        'selected-end': day => this.isEndDate(day),
+        'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
+      },
+      ...(startDate && endDate) && {
+        'selected-span': day => this.isInSelectedSpan(day),
+        'last-in-range': day => this.isLastInRange(day),
+      },
       ...!this.isTouchDevice && {
         // before anything has been set or after both are set
         hovered: day => this.isHovered(day),

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -257,18 +257,22 @@ export default class DayPickerRangeController extends React.Component {
       'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
       'highlighted-calendar': day => isDayHighlighted(day),
       valid: day => !this.isBlocked(day),
-      // before anything has been set or after both are set
-      hovered: day => this.isHovered(day),
-
-      // while start date has been set, but end date has not been
-      'hovered-span': day => this.isInHoveredSpan(day),
-      'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
-      'last-in-range': day => this.isLastInRange(day),
 
       // once a start date and end date have been set
       'selected-start': day => this.isStartDate(day),
       'selected-end': day => this.isEndDate(day),
       'selected-span': day => this.isInSelectedSpan(day),
+      'last-in-range': day => this.isLastInRange(day),
+
+      // Avoid computing hover modifiers for touch devices
+      ...!this.isTouchDevice && {
+        // before anything has been set or after both are set
+        hovered: day => this.isHovered(day),
+
+        // while start date has been set, but end date has not been
+        'hovered-span': day => this.isInHoveredSpan(day),
+        'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
+      },
     };
 
     return (

--- a/src/utils/isSameDay.js
+++ b/src/utils/isSameDay.js
@@ -2,5 +2,8 @@ import moment from 'moment';
 
 export default function isSameDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return a.isSame(b, 'day');
+  // Speeding up by comparing most likely to differ unit first
+  return a.day() === b.day() &&
+    a.month() === b.month() &&
+    a.year() === b.year();
 }


### PR DESCRIPTION
to: @majapw @lencioni 

This PR skips expensive modifier calculations that slow down render performance. These modifiers are computed for every calendar day, which becomes problematic on mobile if we're showing more months.

I instrumented the time spent in each modifier and tested on my Pixel. The total time is ~400ms. 70ms were spent for the `today` check, and 60ms were spent in the hover checks. I've disabled hover for mobile and added the optional to skip the `today` check.

The `calculateToday` prop isn't the cleanest approach, but I think the perf problem is serious enough to address immediately as we work on a more general fix. On this note, I've discussed an approach with Maja of computing these modifiers strictly at the top level instead of lazily at the leaves. This will allow optimizations like only computing today once and only recomputing affected date ranges.