### PR TITLE
Optimize isSameDay

### DIFF
--- a/src/utils/isSameDay.js
+++ b/src/utils/isSameDay.js
@@ -2,5 +2,9 @@ import moment from 'moment';
 
 export default function isSameDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return a.isSame(b, 'day');
+  // Compare least significant, most likely to change units first
+  // Moment's isSame clones moment inputs and is a tad slow
+  return a.date() === b.date() &&
+    a.month() === b.month() &&
+    a.year() === b.year();
 }

--- a/test/utils/isSameDay_spec.js
+++ b/test/utils/isSameDay_spec.js
@@ -15,6 +15,15 @@ describe('isSameDay', () => {
     expect(isSameDay(today, tomorrow)).to.equal(false);
   });
 
+  it('returns false for same days of week', () => {
+    // Flags accidentally use of moment's day() function, which returns index
+    // within the week.
+    expect(isSameDay(
+      moment('2000-01-01'),
+      moment('2000-01-08'),
+    )).to.equal(false);
+  });
+
   describe('non-moment object arguments', () => {
     it('is false if first argument is not a moment object', () => {
       expect(isSameDay(null, today)).to.equal(false);


### PR DESCRIPTION
to: @majapw @lencioni 

Implements the `isSameDay` optimizations @lencioni recommended by comparing the most likely to change units first. When I checked that benchmark script this morning, the old version spent 140ms checking `isSameDay(..., today)`, new version 30ms.

The today checks were more expensive than start/end date (even though they both use `isSameDay`) because the latter two can shortcircuit when null (today is never null). Moment's `isSame` is [expensive because it clones the input dates](https://github.com/moment/moment/blob/develop/src/lib/moment/compare.js#L49).