### PR TITLE
update DayPicker story to show single month

### DIFF
--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -55,8 +55,12 @@ storiesOf('DayPicker', module)
   .addWithInfo('single month', () => (
     <DayPicker numberOfMonths={1} />
   ))
+  .addWithInfo('3 months', () => (
+    <DayPicker numberOfMonths={3} />
+  ))
   .addWithInfo('vertical', () => (
     <DayPicker
+      numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
     />
   ))
@@ -75,6 +79,7 @@ storiesOf('DayPicker', module)
   ))
   .addWithInfo('vertical with custom day size', () => (
     <DayPicker
+      numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
       daySize={50}
     />
@@ -93,6 +98,7 @@ storiesOf('DayPicker', module)
   .addWithInfo('vertical with fixed-width container', () => (
     <div style={{ width: '400px' }}>
       <DayPicker
+        numberOfMonths={2}
         orientation={VERTICAL_ORIENTATION}
       />
     </div>

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -52,12 +52,11 @@ storiesOf('DayPicker', module)
   .addWithInfo('with custom day size', () => (
     <DayPicker daySize={50} />
   ))
-  .addWithInfo('more than one month', () => (
-    <DayPicker numberOfMonths={2} />
+  .addWithInfo('single month', () => (
+    <DayPicker numberOfMonths={1} />
   ))
   .addWithInfo('vertical', () => (
     <DayPicker
-      numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
     />
   ))
@@ -76,7 +75,6 @@ storiesOf('DayPicker', module)
   ))
   .addWithInfo('vertical with custom day size', () => (
     <DayPicker
-      numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
       daySize={50}
     />
@@ -95,7 +93,6 @@ storiesOf('DayPicker', module)
   .addWithInfo('vertical with fixed-width container', () => (
     <div style={{ width: '400px' }}>
       <DayPicker
-        numberOfMonths={2}
         orientation={VERTICAL_ORIENTATION}
       />
     </div>


### PR DESCRIPTION
Looks like at one point the default was changed to two months while the story was representing a default of one