### PR TITLE
Uses React's onClick handler instead of `OutsideClickHandler` with `withPortal` implementations

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -292,10 +292,11 @@ export default class DateRangePicker extends React.Component {
     const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
-      <div
+      <div // eslint-disable-line jsx-a11y/no-static-element-interactions
         ref={(ref) => { this.dayPickerContainer = ref; }}
         className={this.getDayPickerContainerClasses()}
         style={dayPickerContainerStyles}
+        onClick={onOutsideClick}
       >
         <DayPickerRangeController
           ref={(ref) => { this.dayPicker = ref; }}
@@ -313,7 +314,6 @@ export default class DateRangePicker extends React.Component {
           withPortal={withPortal || withFullScreenPortal}
           daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}
-          onOutsideClick={onOutsideClick}
           navPrev={navPrev}
           navNext={navNext}
           minimumNights={minimumNights}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -486,7 +486,10 @@ export default class DayPicker extends React.Component {
     const transformValue = `${transformType}(${translationValue}px)`;
 
     return (
-      <div className={dayPickerClassNames} style={dayPickerStyle} >
+      <div
+        className={dayPickerClassNames}
+        style={dayPickerStyle}
+      >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
           <div
             className="DayPicker__week-headers"
@@ -496,9 +499,10 @@ export default class DayPicker extends React.Component {
             {weekHeaders}
           </div>
 
-          <div
+          <div // eslint-disable-line jsx-a11y/no-static-element-interactions
             className="DayPicker__focus-region"
             ref={(ref) => { this.container = ref; }}
+            onClick={(e) => { e.stopPropagation(); }}
             role="region"
             tabIndex={-1}
           >

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -366,10 +366,11 @@ export default class SingleDatePicker extends React.Component {
     const closeIcon = customCloseIcon || (<CloseButton />);
 
     return (
-      <div
+      <div // eslint-disable-line jsx-a11y/no-static-element-interactions
         ref={(ref) => { this.dayPickerContainer = ref; }}
         className={this.getDayPickerContainerClasses()}
         style={dayPickerContainerStyles}
+        onClick={onOutsideClick}
       >
         <DayPicker
           orientation={orientation}
@@ -385,7 +386,6 @@ export default class SingleDatePicker extends React.Component {
           withPortal={withPortal || withFullScreenPortal}
           hidden={!focused}
           initialVisibleMonth={initialVisibleMonthThunk}
-          onOutsideClick={onOutsideClick}
           navPrev={navPrev}
           navNext={navNext}
           renderDay={renderDay}


### PR DESCRIPTION
Fix for https://github.com/airbnb/react-dates/issues/340

This fixes an issue with Firefox specifically where the order of operations of the events caused the `withPortal` DayPicker to immediately close upon opening.

to: @lencioni 
fyi: @phamcharles