### PR TITLE
Fix a couple of nits as a result of the a11y PR

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -102,8 +102,7 @@ export default class CalendarDay extends React.Component {
     const formattedDate = `${day.format('dddd')}, ${day.format('LL')}`;
 
     let ariaLabel = getPhrase(chooseAvailableDate, {
-      checkin_date: formattedDate,
-      checkout_date: formattedDate,
+      date: formattedDate,
     });
 
     if (BLOCKED_MODIFIER in modifiers && modifiers[BLOCKED_MODIFIER](day)) {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -331,10 +331,12 @@ export default class DayPickerRangeController extends React.Component {
     };
 
     // set the appropriate CalendarDay phrase based on focusedInput
-    const chooseAvailableDate =
-      focusedInput === START_DATE
-      ? phrases.chooseAvailableStartDate
-      : phrases.chooseAvailableEndDate;
+    let chooseAvailableDate = phrases.chooseAvailableDate;
+    if (focusedInput === START_DATE) {
+      chooseAvailableDate = phrases.chooseAvailableStartDate;
+    } else if (focusedInput === END_DATE) {
+      chooseAvailableDate = phrases.chooseAvailableEndDate;
+    }
 
     const calendarDayPhrases = {
       ...phrases,

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -25,12 +25,12 @@ const keyboardNavigationInstructions = `Press the down arrow key to interact wit
   select a date. Press the question mark key to get the keyboard shortcuts for changing dates.`;
 
 // eslint-disable-next-line camelcase
-const chooseAvailableStartDate = ({ checkin_date }) => `Choose ${checkin_date} as your check-in date. It's available.`;
+const chooseAvailableStartDate = ({ date }) => `Choose ${date} as your check-in date. It's available.`;
 
 // eslint-disable-next-line camelcase
-const chooseAvailableEndDate = ({ checkout_date }) => `Choose ${checkout_date} as your check-out date. It's available.`;
+const chooseAvailableEndDate = ({ date }) => `Choose ${date} as your check-out date. It's available.`;
+const chooseAvailableDate = ({ date }) => date;
 const dateIsUnavailable = ({ date }) => `Not available. ${date}`;
-
 
 export default {
   closeDatePicker,
@@ -121,8 +121,7 @@ export const SingleDatePickerPhrases = {
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
   keyboardNavigationInstructions,
-  chooseAvailableStartDate,
-  chooseAvailableEndDate,
+  chooseAvailableDate,
   dateIsUnavailable,
 };
 
@@ -151,7 +150,9 @@ export const DayPickerPhrases = {
   moveFocusByOneMonth,
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
-  chooseAvailableDate: chooseAvailableStartDate,
+  chooseAvailableStartDate,
+  chooseAvailableEndDate,
+  chooseAvailableDate,
   dateIsUnavailable,
 };
 
@@ -181,6 +182,6 @@ export const DayPickerNavigationPhrases = {
 };
 
 export const CalendarDayPhrases = {
-  chooseAvailableDate: chooseAvailableStartDate,
+  chooseAvailableDate,
   dateIsUnavailable,
 };

--- a/src/utils/getActiveElement.js
+++ b/src/utils/getActiveElement.js
@@ -1,0 +1,3 @@
+export default function getActiveElement() {
+  return typeof document !== 'undefined' && document.activeElement;
+}

--- a/src/utils/getPhrase.jsx
+++ b/src/utils/getPhrase.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
-
 export default function getPhrase(phrase, args) {
   if (typeof phrase === 'string') return phrase;
 
-  if (typeof phrase === 'function') return phrase(args);
+  if (typeof phrase === 'function') {
+    return phrase(args);
+  }
 
-  return <phrase {...args} />;
+  return '';
 }

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -175,6 +175,15 @@ describe('DayPicker', () => {
         sinon.stub(DayPicker.prototype, 'translateFirstDayPickerForAnimation');
       });
 
+      it('sets state.withMouseInteractions to false', () => {
+        const wrapper = shallow(<DayPicker />);
+        wrapper.setState({
+          withMouseInteractions: true,
+        });
+        wrapper.instance().onKeyDown({ ...event });
+        expect(wrapper.state().withMouseInteractions).to.equal(false);
+      });
+
       describe('ArrowUp', () => {
         it('calls maybeTransitionPrevMonth', () => {
           const maybeTransitionPrevMonthSpy = sinon.spy(DayPicker.prototype, 'maybeTransitionPrevMonth');

--- a/test/utils/getActiveElement_spec.jsx
+++ b/test/utils/getActiveElement_spec.jsx
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import wrap from 'mocha-wrap';
+
+import getActiveElement from '../../src/utils/getActiveElement';
+
+const describeIfNoWindow = typeof document === 'undefined' ? describe : describe.skip;
+const test = 'FOOBARBAZ';
+
+describeIfNoWindow('getActiveElement', () => {
+  describe('without `document`', () => {
+    it('returns false', () => {
+      expect(typeof document).to.equal('undefined');
+      expect(getActiveElement()).to.equal(false);
+    });
+  });
+
+  wrap()
+  .withGlobal('document', () => ({}))
+  .describe('with `document`', () => {
+    it('returns undefined without `document.activeElement`', () => {
+      expect(getActiveElement()).to.be.an('undefined');
+    });
+
+    wrap()
+    .withOverride(() => document, 'activeElement', () => test)
+    .it('returns activeElement value with `document.activeElement', () => {
+      expect(getActiveElement()).to.equal(test);
+    });
+  });
+});

--- a/test/utils/getPhrase_spec.jsx
+++ b/test/utils/getPhrase_spec.jsx
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
+import getPhrase from '../../src/utils/getPhrase';
+
+describe('getPhrase', () => {
+  it('returns empty string when arg is falsey', () => {
+    expect(getPhrase()).to.equal('');
+  });
+
+  it('returns arg if arg is a string', () => {
+    const test = 'foobarbaz';
+    expect(getPhrase(test)).to.equal(test);
+  });
+
+  describe('arg is a function', () => {
+    it('returns invoked arg', () => {
+      const test = 'this is a new test string';
+      const phraseFunc = sinon.stub().returns(test);
+      const phrase = getPhrase(phraseFunc);
+      expect(phraseFunc.callCount).to.equal(1);
+      expect(phrase).to.equal(test);
+    });
+
+    it('passes second arg into the invoked function', () => {
+      const testObj = { hello: 'world' };
+      const phraseFunc = sinon.stub();
+      getPhrase(phraseFunc, testObj);
+      expect(phraseFunc.getCall(0).args[0]).to.equal(testObj);
+    });
+  });
+});


### PR DESCRIPTION
- blur the CalendarDay is month navigation was done with the mouse
- prevent home/end/pagedown/pageup from scrolling the page
- fixed some weirdness with the aria-label text on Calendar Day components when not using the DRP explicitly

to: @airbnb/webinfra @moonboots 