### PR TITLE
Only update phrases object when the focusedInput actually changes.

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -116,6 +116,7 @@ export default class DayPickerRangeController extends React.Component {
     super(props);
     this.state = {
       hoverDate: null,
+      phrases: props.phrases,
     };
 
     this.isTouchDevice = isTouchDevice();
@@ -125,6 +126,27 @@ export default class DayPickerRangeController extends React.Component {
     this.onDayMouseEnter = this.onDayMouseEnter.bind(this);
     this.onDayMouseLeave = this.onDayMouseLeave.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { focusedInput, phrases } = nextProps;
+
+    if (focusedInput !== this.props.focusedInput || phrases !== this.props.phrases) {
+      // set the appropriate CalendarDay phrase based on focusedInput
+      let chooseAvailableDate = phrases.chooseAvailableDate;
+      if (focusedInput === START_DATE) {
+        chooseAvailableDate = phrases.chooseAvailableStartDate;
+      } else if (focusedInput === END_DATE) {
+        chooseAvailableDate = phrases.chooseAvailableEndDate;
+      }
+
+      this.setState({
+        phrases: {
+          ...phrases,
+          chooseAvailableDate,
+        },
+      });
+    }
   }
 
   componentWillUpdate() {
@@ -302,8 +324,9 @@ export default class DayPickerRangeController extends React.Component {
       onBlur,
       isFocused,
       showKeyboardShortcuts,
-      phrases,
     } = this.props;
+
+    const { phrases } = this.state;
 
     const modifiers = {
       today: day => this.isToday(day),
@@ -336,19 +359,6 @@ export default class DayPickerRangeController extends React.Component {
       },
     };
 
-    // set the appropriate CalendarDay phrase based on focusedInput
-    let chooseAvailableDate = phrases.chooseAvailableDate;
-    if (focusedInput === START_DATE) {
-      chooseAvailableDate = phrases.chooseAvailableStartDate;
-    } else if (focusedInput === END_DATE) {
-      chooseAvailableDate = phrases.chooseAvailableEndDate;
-    }
-
-    const calendarDayPhrases = {
-      ...phrases,
-      chooseAvailableDate,
-    };
-
     return (
       <DayPicker
         ref={(ref) => { this.dayPicker = ref; }}
@@ -375,7 +385,7 @@ export default class DayPickerRangeController extends React.Component {
         getFirstFocusableDay={this.getFirstFocusableDay}
         onBlur={onBlur}
         showKeyboardShortcuts={showKeyboardShortcuts}
-        phrases={calendarDayPhrases}
+        phrases={phrases}
       />
     );
   }

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -28,6 +28,137 @@ describe('DayPickerRangeController', () => {
     });
   });
 
+  describe('#componentWillReceiveProps', () => {
+    const phrases = {
+      chooseAvailableDate: 'test1',
+      chooseAvailableStartDate: 'test2',
+      chooseAvailableEndDate: 'test3',
+    };
+
+    describe('neither props.focusedInput nor props.phrases have changed', () => {
+      it('state.phrases does not change', () => {
+        const phrasesObject = { hello: 'world' };
+        const wrapper = shallow(
+          <DayPickerRangeController
+            focusedInput={null}
+            onDatesChange={sinon.stub()}
+            onFocusChange={sinon.stub()}
+            phrases={phrases}
+          />,
+        );
+        wrapper.setState({ phrases: phrasesObject });
+        wrapper.instance().componentWillReceiveProps({ focusedInput: null, phrases });
+        expect(wrapper.state().phrases).to.equal(phrasesObject);
+      });
+    });
+
+    describe('props.focusedInput has changed', () => {
+      describe('new focusedInput is START_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableStartDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={null}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={phrases}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: START_DATE, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableStartDate);
+        });
+      });
+
+      describe('new focusedInput is END_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableEndDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={null}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={phrases}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: END_DATE, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableEndDate);
+        });
+      });
+
+      describe('new focusedInput is null', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={START_DATE}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={phrases}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: null, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableDate);
+        });
+      });
+    });
+
+    describe('props.phrases has changed', () => {
+      describe('focusedInput is START_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableStartDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={START_DATE}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={{}}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: START_DATE, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableStartDate);
+        });
+      });
+
+      describe('focusedInput is END_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableEndDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={END_DATE}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={{}}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: END_DATE, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableEndDate);
+        });
+      });
+
+      describe('focusedInput is null', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              focusedInput={null}
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              phrases={{}}
+            />,
+          );
+          wrapper.setState({ phrases: {} });
+          wrapper.instance().componentWillReceiveProps({ focusedInput: null, phrases });
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableDate);
+        });
+      });
+    });
+  });
+
   describe('#onDayClick', () => {
     describe('day argument is a blocked day', () => {
       it('props.onFocusChange is not called', () => {


### PR DESCRIPTION
Realized this when I was prototyping some perf changes... but basically the modifiers object is not the only one that is changing (unnecessarily) on every render.

to: @moonboots @ljharb @airbnb/webinfra 