### PR TITLE
[Feature] add "renderMonth" support + add Persian locale story

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -49,6 +49,7 @@ const defaultProps = {
   customCloseIcon: null,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -38,6 +38,7 @@ const defaultProps = {
   showClearDate: false,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
@@ -53,9 +54,6 @@ const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
-
-  // month presentation and interaction related props
-  renderMonth: null,
 
   // day presentation and interaction related props
   renderDay: null,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -54,6 +54,9 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
 
+  // month presentation and interaction related props
+  renderMonth: null,
+
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "mocha": "^3.2.0",
     "mocha-wrap": "^2.1.0",
     "moment": "^2.17.1 && < 2.18.0",
+    "moment-jalaali": "^0.6.1",
     "node-sass": "^4.4.0",
     "nyc": "^10.1.2",
     "raw-loader": "^0.5.1",

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -35,6 +35,7 @@ const propTypes = forbidExtraProps({
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
 
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
@@ -55,6 +56,7 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  renderMonth: null,
   renderDay: null,
 
   focusedDate: null,
@@ -96,6 +98,7 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderMonth,
       renderDay,
       daySize,
       focusedDate,
@@ -104,7 +107,7 @@ export default class CalendarMonth extends React.Component {
     } = this.props;
 
     const { weeks } = this.state;
-    const monthTitle = month.format(monthFormat);
+    const monthTitle = renderMonth ? renderMonth(month) : month.format(monthFormat);
 
     const calendarMonthClasses = cx('CalendarMonth', {
       'CalendarMonth--horizontal': orientation === HORIZONTAL_ORIENTATION,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -37,6 +37,7 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
+  renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
   daySize: nonNegativeInteger,
@@ -60,6 +61,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
+  renderMonth: null,
   renderDay: null,
   transformValue: 'none',
   daySize: DAY_SIZE,
@@ -165,6 +167,7 @@ export default class CalendarMonthGrid extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       onDayClick,
+      renderMonth,
       renderDay,
       onMonthTransitionEnd,
       focusedDate,
@@ -217,6 +220,7 @@ export default class CalendarMonthGrid extends React.Component {
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
+              renderMonth={renderMonth}
               renderDay={renderDay}
               daySize={daySize}
               focusedDate={isVisible ? focusedDate : null}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -55,6 +55,7 @@ const defaultProps = {
   customCloseIcon: null,
 
   // calendar presentation and interaction related props
+  renderMonth: null,
   orientation: HORIZONTAL_ORIENTATION,
   anchorDirection: ANCHOR_LEFT,
   horizontalMargin: 0,
@@ -281,6 +282,7 @@ export default class DateRangePicker extends React.Component {
       numberOfMonths,
       orientation,
       monthFormat,
+      renderMonth,
       navPrev,
       navNext,
       onPrevMonthClick,
@@ -335,6 +337,7 @@ export default class DateRangePicker extends React.Component {
           startDate={startDate}
           endDate={endDate}
           monthFormat={monthFormat}
+          renderMonth={renderMonth}
           withPortal={withPortal || withFullScreenPortal}
           daySize={daySize}
           initialVisibleMonth={initialVisibleMonthThunk}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -57,6 +57,9 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
 
+  // month props
+  renderMonth: PropTypes.func,
+
   // day props
   modifiers: PropTypes.object,
   renderDay: PropTypes.func,
@@ -93,6 +96,9 @@ export const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
+
+  // month props
+  renderMonth: null,
 
   // day props
   modifiers: {},
@@ -682,6 +688,7 @@ export default class DayPicker extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      renderMonth,
       renderDay,
       renderCalendarInfo,
       hideKeyboardShortcutsPanel,
@@ -792,6 +799,7 @@ export default class DayPicker extends React.Component {
                 onDayClick={onDayClick}
                 onDayMouseEnter={onDayMouseEnter}
                 onDayMouseLeave={onDayMouseLeave}
+                renderMonth={renderMonth}
                 renderDay={renderDay}
                 onMonthTransitionEnd={this.updateStateAfterMonthTransition}
                 monthFormat={monthFormat}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -41,6 +41,7 @@ const propTypes = forbidExtraProps({
   isDayHighlighted: PropTypes.func,
 
   // DayPicker props
+  renderMonth: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
@@ -84,6 +85,7 @@ const defaultProps = {
   isDayHighlighted() {},
 
   // DayPicker props
+  renderMonth: null,
   enableOutsideDays: false,
   numberOfMonths: 1,
   orientation: HORIZONTAL_ORIENTATION,
@@ -308,6 +310,7 @@ export default class DayPickerRangeController extends React.Component {
       numberOfMonths,
       orientation,
       monthFormat,
+      renderMonth,
       navPrev,
       navNext,
       onOutsideClick,
@@ -374,6 +377,7 @@ export default class DayPickerRangeController extends React.Component {
         onPrevMonthClick={onPrevMonthClick}
         onNextMonthClick={onNextMonthClick}
         monthFormat={monthFormat}
+        renderMonth={renderMonth}
         withPortal={withPortal}
         hidden={!focusedInput}
         initialVisibleMonth={initialVisibleMonth}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -69,6 +69,9 @@ const defaultProps = {
   onNextMonthClick() {},
   onClose() {},
 
+  // month presentation and interaction related props
+  renderMonth: null,
+
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,
@@ -389,6 +392,7 @@ export default class SingleDatePicker extends React.Component {
       withPortal,
       withFullScreenPortal,
       focused,
+      renderMonth,
       renderDay,
       renderCalendarInfo,
       date,
@@ -439,6 +443,7 @@ export default class SingleDatePicker extends React.Component {
           hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
           navPrev={navPrev}
           navNext={navNext}
+          renderMonth={renderMonth}
           renderDay={renderDay}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -35,6 +35,7 @@ export default {
   customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
+  renderMonth: PropTypes.func,
   orientation: OrientationShape,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -26,6 +26,7 @@ export default {
   customCloseIcon: PropTypes.node,
 
   // calendar presentation and interaction related props
+  renderMonth: PropTypes.func,
   orientation: OrientationShape,
   anchorDirection: anchorDirectionShape,
   horizontalMargin: PropTypes.number,
@@ -46,9 +47,6 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onClose: PropTypes.func,
-
-  // month presentation and interaction related props
-  renderMonth: PropTypes.func,
 
   // day presentation and interaction related props
   renderDay: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -47,6 +47,9 @@ export default {
   onNextMonthClick: PropTypes.func,
   onClose: PropTypes.func,
 
+  // month presentation and interaction related props
+  renderMonth: PropTypes.func,
+
   // day presentation and interaction related props
   renderDay: PropTypes.func,
   enableOutsideDays: PropTypes.bool,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@kadira/storybook';
 
 import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
@@ -75,6 +76,16 @@ storiesOf('DateRangePicker (DRP)', module)
           closeDatePicker: '关闭',
           clearDates: '清除日期',
         }}
+      />
+    );
+  })
+  .addWithInfo('non-english locale (Persian)', () => {
+    moment.locale('fa');
+    return (
+      <DateRangePickerWrapper
+        placeholder="تقویم فارسی"
+        renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
+        renderDay={day => momentJalaali(day).format('jD')}
       />
     );
   });

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -46,14 +46,13 @@ storiesOf('SingleDatePicker (SDP)', module)
       />
     );
   })
-    .addWithInfo('non-english locale (Persian)', () => {
-        moment.locale('fa');
-        // if (moment.locale().toString() === "fa") momentJalaali.loadPersian();
-        return (
-            <SingleDatePickerWrapper
-                placeholder="تقویم فارسی"
-                renderMonth = {(month) => momentJalaali(month).format("jMMMM jYYYY")}
-                renderDay= {(day) => momentJalaali(day).format("jD")}
-            />
-        );
-    });
+  .addWithInfo('non-english locale (Persian)', () => {
+    moment.locale('fa');
+    return (
+      <SingleDatePickerWrapper
+        placeholder="تقویم فارسی"
+        renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
+        renderDay={day => momentJalaali(day).format('jD')}
+      />
+    );
+  });

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@kadira/storybook';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
@@ -44,4 +45,15 @@ storiesOf('SingleDatePicker (SDP)', module)
         }}
       />
     );
-  });
+  })
+    .addWithInfo('non-english locale (Persian)', () => {
+        moment.locale('fa');
+        // if (moment.locale().toString() === "fa") momentJalaali.loadPersian();
+        return (
+            <SingleDatePickerWrapper
+                placeholder="تقویم فارسی"
+                renderMonth = {(month) => momentJalaali(month).format("jMMMM jYYYY")}
+                renderDay= {(day) => momentJalaali(day).format("jD")}
+            />
+        );
+    });


### PR DESCRIPTION
This PR add `renderMonth` to react-dates and help to add custom calendar like Jalali (Persian) calendar in future.
It's needed for #447 

This is a simple screenshot from story page:
![jalali_5](https://cloud.githubusercontent.com/assets/8266479/25054154/ccf77e10-2170-11e7-8313-4bd528df6d92.png)
