### PR TITLE
Perf rearchitecting

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,7 @@
 module.exports = {
   DISPLAY_FORMAT: 'L',
   ISO_FORMAT: 'YYYY-MM-DD',
+  ISO_MONTH_FORMAT: 'YYYY-MM',
 
   START_DATE: 'startDate',
   END_DATE: 'endDate',

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   },
   "dependencies": {
     "airbnb-prop-types": "^2.4.1",
-    "array-includes": "^3.0.2",
     "classnames": "^2.2.5",
     "consolidated-events": "^1.0.1",
     "lodash.throttle": "^4.1.1",

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -16,7 +16,7 @@ const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
   daySize: nonNegativeInteger,
   isOutsideDay: PropTypes.bool,
-  modifiers: PropTypes.object,
+  modifiers: PropTypes.instanceOf(Set),
   isFocused: PropTypes.bool,
   tabIndex: PropTypes.oneOf([0, -1]),
   onDayClick: PropTypes.func,
@@ -32,7 +32,7 @@ const defaultProps = {
   day: moment(),
   daySize: DAY_SIZE,
   isOutsideDay: false,
-  modifiers: {},
+  modifiers: new Set(),
   isFocused: false,
   tabIndex: -1,
   onDayClick() {},
@@ -43,10 +43,6 @@ const defaultProps = {
   // internationalization
   phrases: CalendarDayPhrases,
 };
-
-export function getModifiersForDay(modifiers, day) {
-  return day ? Object.keys(modifiers).filter(key => modifiers[key](day)) : [];
-}
 
 export default class CalendarDay extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
@@ -93,12 +89,9 @@ export default class CalendarDay extends React.Component {
 
     if (!day) return <td />;
 
-    const modifiersForDay = getModifiersForDay(modifiers, day);
-
     const className = cx('CalendarDay', {
       'CalendarDay--outside': isOutsideDay,
-    }, modifiersForDay.map(mod => `CalendarDay--${mod}`));
-
+    }, Array.from(modifiers, mod => `CalendarDay--${mod}`));
 
     const formattedDate = `${day.format('dddd')}, ${day.format('LL')}`;
 

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -15,6 +15,7 @@ import CalendarDay from './CalendarDay';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 import isSameDay from '../utils/isSameDay';
+import toISODateString from '../utils/toISODateString';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -132,13 +133,13 @@ export default class CalendarMonth extends React.Component {
                     isOutsideDay={!day || day.month() !== month.month()}
                     tabIndex={isVisible && isSameDay(day, focusedDate) ? 0 : -1}
                     isFocused={isFocused}
-                    modifiers={modifiers}
                     key={dayOfWeek}
                     onDayMouseEnter={onDayMouseEnter}
                     onDayMouseLeave={onDayMouseLeave}
                     onDayClick={onDayClick}
                     renderDay={renderDay}
                     phrases={phrases}
+                    modifiers={modifiers[toISODateString(day)]}
                   />
                 ))}
               </tr>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -15,6 +15,8 @@ import CalendarMonth from './CalendarMonth';
 import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
+import toISOMonthString from '../utils/toISOMonthString';
+import isAfterDay from '../utils/isAfterDay';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -113,7 +115,7 @@ export default class CalendarMonthGrid extends React.Component {
     let newMonths = months;
 
     if (hasMonthChanged && !hasNumberOfMonthsChanged) {
-      if (initialMonth.isAfter(this.props.initialMonth)) {
+      if (isAfterDay(initialMonth, this.props.initialMonth)) {
         newMonths = months.slice(1);
         newMonths.push(months[months.length - 1].clone().add(1, 'month'));
       } else {
@@ -208,13 +210,14 @@ export default class CalendarMonthGrid extends React.Component {
         {months.map((month, i) => {
           const isVisible =
             (i >= firstVisibleMonthIndex) && (i < firstVisibleMonthIndex + numberOfMonths);
+          const monthString = toISOMonthString(month);
           return (
             <CalendarMonth
-              key={month.format('YYYY-MM')}
+              key={monthString}
               month={month}
               isVisible={isVisible}
               enableOutsideDays={enableOutsideDays}
-              modifiers={modifiers}
+              modifiers={modifiers[monthString]}
               monthFormat={monthFormat}
               orientation={orientation}
               onDayMouseEnter={onDayMouseEnter}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -12,6 +12,14 @@ import isTouchDevice from '../utils/isTouchDevice';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isNextDay from '../utils/isNextDay';
 import isSameDay from '../utils/isSameDay';
+import isAfterDay from '../utils/isAfterDay';
+import isBeforeDay from '../utils/isBeforeDay';
+
+import getVisibleDays from '../utils/getVisibleDays';
+import isDayVisible from '../utils/isDayVisible';
+
+import toISODateString from '../utils/toISODateString';
+import toISOMonthString from '../utils/toISOMonthString';
 
 import FocusedInputShape from '../shapes/FocusedInputShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
@@ -121,24 +129,184 @@ const defaultProps = {
 export default class DayPickerRangeController extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      hoverDate: null,
-      phrases: props.phrases,
-    };
 
     this.isTouchDevice = isTouchDevice();
     this.today = moment();
+    this.modifiers = {
+      today: day => this.isToday(day),
+      blocked: day => this.isBlocked(day),
+      'blocked-calendar': day => props.isDayBlocked(day),
+      'blocked-out-of-range': day => props.isOutsideRange(day),
+      'highlighted-calendar': day => props.isDayHighlighted(day),
+      valid: day => !this.isBlocked(day),
+      'selected-start': day => this.isStartDate(day),
+      'selected-end': day => this.isEndDate(day),
+      'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
+      'selected-span': day => this.isInSelectedSpan(day),
+      'last-in-range': day => this.isLastInRange(day),
+      hovered: day => this.isHovered(day),
+      'hovered-span': day => this.isInHoveredSpan(day),
+      'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
+    };
+
+    const { currentMonth, visibleDays } = this.getStateForNewMonth(props);
+
+    this.state = {
+      hoverDate: null,
+      currentMonth,
+      phrases: props.phrases,
+      visibleDays,
+    };
 
     this.onDayClick = this.onDayClick.bind(this);
     this.onDayMouseEnter = this.onDayMouseEnter.bind(this);
     this.onDayMouseLeave = this.onDayMouseLeave.bind(this);
+    this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
+    this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    const { focusedInput, phrases } = nextProps;
+    const {
+      startDate,
+      endDate,
+      focusedInput,
+      minimumNights,
+      isOutsideRange,
+      isDayBlocked,
+      isDayHighlighted,
+      phrases,
+      initialVisibleMonth,
+      numberOfMonths,
+      enableOutsideDays,
+    } = nextProps;
+    let { visibleDays } = this.state;
 
-    if (focusedInput !== this.props.focusedInput || phrases !== this.props.phrases) {
+    if (isOutsideRange !== this.props.isOutsideRange) {
+      this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
+    }
+
+    if (isDayBlocked !== this.props.isDayBlocked) {
+      this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
+    }
+
+    if (isDayHighlighted !== this.props.isDayHighlighted) {
+      this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
+    }
+
+    if (
+      initialVisibleMonth !== this.props.initialVisibleMonth ||
+      numberOfMonths !== this.props.numberOfMonths ||
+      enableOutsideDays !== this.props.enableOutsideDays
+    ) {
+      const newMonthState = this.getStateForNewMonth(nextProps);
+      const currentMonth = newMonthState.currentMonth;
+      visibleDays = newMonthState.visibleDays;
+      this.setState({
+        currentMonth,
+        visibleDays,
+      });
+    }
+
+    const didStartDateChange = startDate !== this.props.startDate;
+    const didEndDateChange = endDate !== this.props.endDate;
+    const didFocusChange = focusedInput !== this.props.focusedInput;
+
+    let modifiers = {};
+
+    if (didStartDateChange) {
+      modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
+      modifiers = this.addModifier(modifiers, startDate, 'selected-start');
+    }
+
+    if (didEndDateChange) {
+      modifiers = this.deleteModifier(modifiers, this.props.endDate, 'selected-end');
+      modifiers = this.addModifier(modifiers, endDate, 'selected-end');
+    }
+
+    if (didStartDateChange || didEndDateChange) {
+      if (this.props.startDate && this.props.endDate) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          this.props.startDate.clone().add(1, 'day'),
+          this.props.endDate,
+          'selected-span',
+        );
+      }
+
+      if (startDate && endDate) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          startDate,
+          endDate,
+          'hovered-span',
+        );
+
+        modifiers = this.addModifierToRange(
+          modifiers,
+          startDate.clone().add(1, 'day'),
+          endDate,
+          'selected-span',
+        );
+      }
+    }
+
+    if (minimumNights > 0 || minimumNights !== this.props.minimumNights) {
+      if (this.props.startDate && (didFocusChange || didStartDateChange)) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          this.props.startDate,
+          this.props.startDate.clone().add(minimumNights, 'days'),
+          'blocked-minimum-nights',
+        );
+      }
+
+      if (startDate && focusedInput === END_DATE) {
+        modifiers = this.addModifierToRange(
+          modifiers,
+          startDate,
+          startDate.clone().add(minimumNights, 'days'),
+          'blocked-minimum-nights',
+        );
+      }
+    }
+
+    if (didFocusChange) {
+      Object.values(visibleDays).forEach((days) => {
+        Object.keys(days).forEach((day) => {
+          const momentObj = moment(day);
+          if (isDayBlocked(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+          }
+
+          if (isDayHighlighted(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+          }
+        });
+      });
+    }
+
+    const today = moment();
+    if (!isSameDay(this.today, today)) {
+      modifiers = this.deleteModifier(modifiers, this.today, 'today');
+      modifiers = this.addModifier(modifiers, today, 'today');
+      this.today = today;
+    }
+
+    if (Object.keys(modifiers).length > 0) {
+      this.setState({
+        visibleDays: {
+          ...visibleDays,
+          ...modifiers,
+        },
+      });
+    }
+
+    if (didFocusChange || phrases !== this.props.phrases) {
       // set the appropriate CalendarDay phrase based on focusedInput
       let chooseAvailableDate = phrases.chooseAvailableDate;
       if (focusedInput === START_DATE) {
@@ -154,10 +322,6 @@ export default class DayPickerRangeController extends React.Component {
         },
       });
     }
-  }
-
-  componentWillUpdate() {
-    this.today = moment();
   }
 
   onDayClick(day, e) {
@@ -200,18 +364,111 @@ export default class DayPickerRangeController extends React.Component {
 
   onDayMouseEnter(day) {
     if (this.isTouchDevice) return;
+    const { startDate, endDate, focusedInput } = this.props;
+    const { hoverDate, visibleDays } = this.state;
+
+    let modifiers = {};
+    modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
+    modifiers = this.addModifier(modifiers, day, 'hovered');
+
+    if (startDate && !endDate && focusedInput === END_DATE) {
+      if (isAfterDay(hoverDate, startDate)) {
+        modifiers = this.deleteModifierFromRange(modifiers, startDate, hoverDate, 'hovered-span');
+      }
+
+      if (!this.isBlocked(day) && isAfterDay(day, startDate)) {
+        modifiers = this.addModifierToRange(modifiers, startDate, day, 'hovered-span');
+      }
+    }
+
+    if (!startDate && endDate && focusedInput === START_DATE) {
+      if (isBeforeDay(hoverDate, endDate)) {
+        modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
+      }
+
+      if (!this.isBlocked(day) && isBeforeDay(day, endDate)) {
+        modifiers = this.addModifierToRange(modifiers, day, endDate, 'hovered-span');
+      }
+    }
 
     this.setState({
       hoverDate: day,
+      visibleDays: {
+        ...visibleDays,
+        ...modifiers,
+      },
     });
   }
 
   onDayMouseLeave() {
-    if (this.isTouchDevice) return;
+    const { startDate, endDate } = this.props;
+    const { hoverDate, visibleDays } = this.state;
+    if (this.isTouchDevice || !hoverDate) return;
+
+    let modifiers = {};
+    modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
+
+    if (startDate && !endDate && isAfterDay(hoverDate, startDate)) {
+      modifiers = this.deleteModifierFromRange(modifiers, startDate, hoverDate, 'hovered-span');
+    }
+
+    if (!startDate && endDate && isAfterDay(endDate, hoverDate)) {
+      modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
+    }
 
     this.setState({
       hoverDate: null,
+      visibleDays: {
+        ...visibleDays,
+        ...modifiers,
+      },
     });
+  }
+
+  onPrevMonthClick() {
+    const { onPrevMonthClick, numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const newVisibleDays = {};
+    Object.keys(visibleDays).sort().slice(0, numberOfMonths + 1).forEach((month) => {
+      newVisibleDays[month] = visibleDays[month];
+    });
+
+    const prevMonth = currentMonth.clone().subtract(1, 'months');
+    const prevMonthVisibleDays = getVisibleDays(prevMonth, 1, enableOutsideDays);
+
+    this.setState({
+      currentMonth: prevMonth,
+      visibleDays: {
+        ...newVisibleDays,
+        ...this.getModifiers(prevMonthVisibleDays),
+      },
+    });
+
+    onPrevMonthClick();
+  }
+
+  onNextMonthClick() {
+    const { onNextMonthClick, numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const newVisibleDays = {};
+    Object.keys(visibleDays).sort().slice(1).forEach((month) => {
+      newVisibleDays[month] = visibleDays[month];
+    });
+
+    const nextMonth = currentMonth.clone().add(numberOfMonths, 'month');
+    const nextMonthVisibleDays = getVisibleDays(nextMonth, 1, enableOutsideDays);
+
+    this.setState({
+      currentMonth: currentMonth.clone().add(1, 'month'),
+      visibleDays: {
+        ...newVisibleDays,
+        ...this.getModifiers(nextMonthVisibleDays),
+      },
+    });
+
+    onNextMonthClick();
   }
 
   getFirstFocusableDay(newMonth) {
@@ -230,16 +487,135 @@ export default class DayPickerRangeController extends React.Component {
       const days = [];
       const lastVisibleDay = newMonth.clone().add(numberOfMonths - 1, 'months').endOf('month');
       let currentDay = focusedDate.clone();
-      while (!currentDay.isAfter(lastVisibleDay)) {
+      while (!isAfterDay(currentDay, lastVisibleDay)) {
         currentDay = currentDay.clone().add(1, 'day');
         days.push(currentDay);
       }
 
-      const viableDays = days.filter(day => !this.isBlocked(day) && day.isAfter(focusedDate));
+      const viableDays = days.filter(day => !this.isBlocked(day));
+
       if (viableDays.length > 0) focusedDate = viableDays[0];
     }
 
     return focusedDate;
+  }
+
+  getModifiers(visibleDays) {
+    const modifiers = {};
+    Object.keys(visibleDays).forEach((month) => {
+      modifiers[month] = {};
+      visibleDays[month].forEach((day) => {
+        modifiers[month][toISODateString(day)] = this.getModifiersForDay(day);
+      });
+    });
+
+    return modifiers;
+  }
+
+  getModifiersForDay(day) {
+    return new Set(Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day)));
+  }
+
+  getStateForNewMonth(nextProps) {
+    const { initialVisibleMonth, numberOfMonths, enableOutsideDays } = nextProps;
+    const currentMonth = initialVisibleMonth();
+    const visibleDays =
+      this.getModifiers(getVisibleDays(currentMonth, numberOfMonths, enableOutsideDays));
+    return { currentMonth, visibleDays };
+  }
+
+  addModifier(updatedDays, day, modifier) {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+    if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
+      return updatedDays;
+    }
+
+    let monthIso = toISOMonthString(day);
+    let month = updatedDays[monthIso] || visibleDays[monthIso];
+    const iso = toISODateString(day);
+    if (enableOutsideDays) {
+      const startOfMonth = day.clone().startOf('month');
+      const endOfMonth = day.clone().endOf('month');
+      if (
+        isBeforeDay(startOfMonth, currentMonth.clone().startOf('month')) ||
+        isAfterDay(endOfMonth, currentMonth.clone().endOf('month'))
+      ) {
+        monthIso = Object.keys(visibleDays).filter(monthKey => (
+          monthKey !== monthIso && Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
+        ))[0];
+        month = updatedDays[monthIso] || visibleDays[monthIso];
+      }
+    }
+
+    const modifiers = new Set(month[iso]);
+    modifiers.add(modifier);
+    return {
+      ...updatedDays,
+      [monthIso]: {
+        ...month,
+        [iso]: modifiers,
+      },
+    };
+  }
+
+  addModifierToRange(updatedDays, start, end, modifier) {
+    let days = updatedDays;
+
+    let spanStart = start.clone();
+    while (isBeforeDay(spanStart, end)) {
+      days = this.addModifier(days, spanStart, modifier);
+      spanStart = spanStart.clone().add(1, 'day');
+    }
+
+    return days;
+  }
+
+  deleteModifier(updatedDays, day, modifier) {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+    if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
+      return updatedDays;
+    }
+
+    let monthIso = toISOMonthString(day);
+    let month = updatedDays[monthIso] || visibleDays[monthIso];
+    const iso = toISODateString(day);
+    if (enableOutsideDays) {
+      const startOfMonth = day.clone().startOf('month');
+      const endOfMonth = day.clone().endOf('month');
+      if (
+        isBeforeDay(startOfMonth, currentMonth.clone().startOf('month')) ||
+        isAfterDay(endOfMonth, currentMonth.clone().endOf('month'))
+      ) {
+        monthIso = Object.keys(visibleDays).filter(monthKey => (
+          monthKey !== monthIso && Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
+        ))[0];
+        month = updatedDays[monthIso] || visibleDays[monthIso];
+      }
+    }
+
+    const modifiers = new Set(month[iso]);
+    modifiers.delete(modifier);
+    return {
+      ...updatedDays,
+      [monthIso]: {
+        ...month,
+        [iso]: modifiers,
+      },
+    };
+  }
+
+  deleteModifierFromRange(updatedDays, start, end, modifier) {
+    let days = updatedDays;
+
+    let spanStart = start.clone();
+    while (isBeforeDay(spanStart, end)) {
+      days = this.deleteModifier(days, spanStart, modifier);
+      spanStart = spanStart.clone().add(1, 'day');
+    }
+
+    return days;
   }
 
   doesNotMeetMinimumNights(day) {
@@ -255,7 +631,7 @@ export default class DayPickerRangeController extends React.Component {
 
   isDayAfterHoveredStartDate(day) {
     const { startDate, endDate, minimumNights } = this.props;
-    const { hoverDate } = this.state;
+    const { hoverDate } = this.state || {};
     return !!startDate && !endDate && !this.isBlocked(day) && isNextDay(hoverDate, day) &&
       minimumNights > 0 && isSameDay(hoverDate, startDate);
   }
@@ -265,12 +641,13 @@ export default class DayPickerRangeController extends React.Component {
   }
 
   isHovered(day) {
-    return isSameDay(day, this.state.hoverDate);
+    const { hoverDate } = this.state || {};
+    return isSameDay(day, hoverDate);
   }
 
   isInHoveredSpan(day) {
     const { startDate, endDate } = this.props;
-    const { hoverDate } = this.state;
+    const { hoverDate } = this.state || {};
 
     const isForwardRange = !!startDate && !endDate &&
       (day.isBetween(startDate, hoverDate) ||
@@ -308,9 +685,6 @@ export default class DayPickerRangeController extends React.Component {
 
   render() {
     const {
-      isDayBlocked,
-      isDayHighlighted,
-      isOutsideRange,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -318,8 +692,6 @@ export default class DayPickerRangeController extends React.Component {
       navPrev,
       navNext,
       onOutsideClick,
-      onPrevMonthClick,
-      onNextMonthClick,
       withPortal,
       enableOutsideDays,
       initialVisibleMonth,
@@ -328,59 +700,26 @@ export default class DayPickerRangeController extends React.Component {
       focusedInput,
       renderDay,
       renderCalendarInfo,
-      startDate,
-      endDate,
       onBlur,
       isFocused,
       showKeyboardShortcuts,
       isRTL,
     } = this.props;
 
-    const { phrases } = this.state;
-
-    const modifiers = {
-      today: day => this.isToday(day),
-      blocked: day => this.isBlocked(day),
-      'blocked-calendar': day => isDayBlocked(day),
-      'blocked-out-of-range': day => isOutsideRange(day),
-      'highlighted-calendar': day => isDayHighlighted(day),
-      valid: day => !this.isBlocked(day),
-
-      // Modifiers are computed for every CalendarDay, so we omit where
-      // logically possible.
-      ...startDate && {
-        'selected-start': day => this.isStartDate(day),
-      },
-      ...endDate && {
-        'selected-end': day => this.isEndDate(day),
-        'blocked-minimum-nights': day => this.doesNotMeetMinimumNights(day),
-      },
-      ...(startDate && endDate) && {
-        'selected-span': day => this.isInSelectedSpan(day),
-        'last-in-range': day => this.isLastInRange(day),
-      },
-      ...!this.isTouchDevice && {
-        // before anything has been set or after both are set
-        hovered: day => this.isHovered(day),
-
-        // while start date has been set, but end date has not been
-        'hovered-span': day => this.isInHoveredSpan(day),
-        'after-hovered-start': day => this.isDayAfterHoveredStartDate(day),
-      },
-    };
+    const { phrases, visibleDays } = this.state;
 
     return (
       <DayPicker
         ref={(ref) => { this.dayPicker = ref; }}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
-        modifiers={modifiers}
+        modifiers={visibleDays}
         numberOfMonths={numberOfMonths}
         onDayClick={this.onDayClick}
         onDayMouseEnter={this.onDayMouseEnter}
         onDayMouseLeave={this.onDayMouseLeave}
-        onPrevMonthClick={onPrevMonthClick}
-        onNextMonthClick={onNextMonthClick}
+        onPrevMonthClick={this.onPrevMonthClick}
+        onNextMonthClick={this.onNextMonthClick}
         monthFormat={monthFormat}
         renderMonth={renderMonth}
         withPortal={withPortal}

--- a/src/utils/getVisibleDays.js
+++ b/src/utils/getVisibleDays.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+import toISOMonthString from './toISOMonthString';
+
+export default function getVisibleDays(month, numberOfMonths, enableOutsideDays) {
+  if (!moment.isMoment(month)) return {};
+
+  const visibleDaysByMonth = {};
+  let currentMonth = month.clone().subtract(1, 'month');
+  for (let i = 0; i < numberOfMonths + 2; i += 1) { // account for transition months
+    const visibleDays = [];
+
+    // set utc offset to get correct dates in future (when timezone changes)
+    const baseDate = currentMonth.clone();
+    const firstOfMonth = baseDate.clone().startOf('month').hour(12);
+    const lastOfMonth = baseDate.clone().endOf('month').hour(12);
+
+    const currentDay = firstOfMonth.clone();
+
+    // days belonging to the previous month
+    if (enableOutsideDays) {
+      for (let j = 0; j < currentDay.weekday(); j += 1) {
+        const prevDay = currentDay.clone().subtract(j + 1, 'day');
+        visibleDays.unshift(prevDay);
+      }
+    }
+
+    while (currentDay < lastOfMonth) {
+      visibleDays.push(currentDay.clone());
+      currentDay.add(1, 'day');
+    }
+
+    if (enableOutsideDays) {
+      // weekday() returns the index of the day of the week according to the locale
+      // this means if the week starts on Monday, weekday() will return 0 for a Monday date, not 1
+      if (currentDay.weekday() !== 0) {
+        // days belonging to the next month
+        for (let k = currentDay.weekday(), count = 0; k < 7; k += 1, count += 1) {
+          const nextDay = currentDay.clone().add(count, 'day');
+          visibleDays.push(nextDay);
+        }
+      }
+    }
+
+    visibleDaysByMonth[toISOMonthString(currentMonth)] = visibleDays;
+    currentMonth = currentMonth.clone().add(1, 'month');
+  }
+
+  return visibleDaysByMonth;
+}

--- a/src/utils/isAfterDay.js
+++ b/src/utils/isAfterDay.js
@@ -1,8 +1,9 @@
 import moment from 'moment';
 
 import isBeforeDay from './isBeforeDay';
+import isSameDay from './isSameDay';
 
-export default function isInclusivelyAfterDay(a, b) {
+export default function isAfterDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return !isBeforeDay(a, b);
+  return !isBeforeDay(a, b) && !isSameDay(a, b);
 }

--- a/src/utils/isBeforeDay.js
+++ b/src/utils/isBeforeDay.js
@@ -1,0 +1,18 @@
+import moment from 'moment';
+
+export default function isBeforeDay(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+
+  const aYear = a.year();
+  const aMonth = a.month();
+
+  const bYear = b.year();
+  const bMonth = b.month();
+
+  const isSameYear = aYear === bYear;
+  const isSameMonth = aMonth === bMonth;
+
+  if (isSameYear && isSameMonth) return a.date() < b.date();
+  if (isSameYear) return aMonth < bMonth;
+  return aYear < bYear;
+}

--- a/src/utils/isDayVisible.js
+++ b/src/utils/isDayVisible.js
@@ -1,0 +1,12 @@
+import isBeforeDay from './isBeforeDay';
+import isAfterDay from './isAfterDay';
+
+export default function isDayVisible(day, month, numberOfMonths, enableOutsideDays) {
+  let firstDayOfFirstMonth = month.clone().startOf('month');
+  if (enableOutsideDays) firstDayOfFirstMonth = firstDayOfFirstMonth.startOf('week');
+  if (isBeforeDay(day, firstDayOfFirstMonth)) return false;
+
+  let lastDayOfLastMonth = month.clone().add(numberOfMonths - 1, 'months').endOf('month');
+  if (enableOutsideDays) lastDayOfLastMonth = lastDayOfLastMonth.endOf('week');
+  return !isAfterDay(day, lastDayOfLastMonth);
+}

--- a/src/utils/isInclusivelyBeforeDay.js
+++ b/src/utils/isInclusivelyBeforeDay.js
@@ -1,8 +1,8 @@
 import moment from 'moment';
 
-import isSameDay from './isSameDay';
+import isAfterDay from './isAfterDay';
 
 export default function isInclusivelyBeforeDay(a, b) {
   if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
-  return a.isBefore(b) || isSameDay(a, b);
+  return !isAfterDay(a, b);
 }

--- a/src/utils/toISOMonthString.js
+++ b/src/utils/toISOMonthString.js
@@ -1,0 +1,12 @@
+import moment from 'moment';
+
+import toMomentObject from './toMomentObject';
+
+import { ISO_MONTH_FORMAT } from '../../constants';
+
+export default function toISOMonthString(date, currentFormat) {
+  const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
+  if (!dateObj) return null;
+
+  return dateObj.format(ISO_MONTH_FORMAT);
+}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -118,7 +118,7 @@ storiesOf('DRP - Calendar Props', module)
   ))
   .addWithInfo('with month specified on open', () => (
     <DateRangePickerWrapper
-      initialVisibleMonth={() => moment('04 2017', 'MM YYYY')}
+      initialVisibleMonth={() => moment().add(10, 'months')}
       autoFocus
     />
   ))

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -95,7 +95,7 @@ storiesOf('SDP - Calendar Props', module)
   ))
   .addWithInfo('with month specified on open', () => (
     <SingleDatePickerWrapper
-      initialVisibleMonth={() => moment('01 2017', 'MM YYYY')}
+      initialVisibleMonth={() => moment().add(10, 'months')}
       autoFocus
     />
   ))

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
-import CalendarDay, { getModifiersForDay } from '../../src/components/CalendarDay';
+import CalendarDay from '../../src/components/CalendarDay';
 
 describe('CalendarDay', () => {
   describe('#render', () => {
@@ -120,35 +120,6 @@ describe('CalendarDay', () => {
       const wrapper = shallow(<CalendarDay onDayMouseLeave={onMouseLeaveStub} />);
       wrapper.instance().onDayMouseLeave();
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
-    });
-  });
-
-  describe('#getModifiersForDay', () => {
-    it('returns empty array if day is not passed in', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => true;
-
-      const filteredModifiers = getModifiersForDay(modifiers);
-      expect(filteredModifiers).to.have.lengthOf(0);
-    });
-
-    it('returns key for true modifier', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => true;
-
-      const filteredModifiers = getModifiersForDay(modifiers, moment());
-      expect(filteredModifiers).to.include(modifierKey);
-    });
-
-    it('does not return key for false modifier', () => {
-      const modifierKey = 'foo';
-      const modifiers = {};
-      modifiers[modifierKey] = () => false;
-
-      const filteredModifiers = getModifiersForDay(modifiers, moment());
-      expect(filteredModifiers).not.to.include(modifierKey);
     });
   });
 });

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -6,6 +6,8 @@ import sinon from 'sinon-sandbox';
 import { mount, shallow } from 'enzyme';
 import wrap from 'mocha-wrap';
 
+import * as isDayVisible from '../../src/utils/isDayVisible';
+
 import DayPicker, { calculateDimension } from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
 import DayPickerNavigation from '../../src/components/DayPickerNavigation';
@@ -457,13 +459,6 @@ describe('DayPicker', () => {
       translateFirstDayPickerForAnimationSpy = sinon.stub(DayPicker.prototype, 'translateFirstDayPickerForAnimation');
     });
 
-    it('calls props.onPrevMonthClick', () => {
-      const onPrevMonthClickSpy = sinon.stub();
-      const wrapper = shallow(<DayPicker onPrevMonthClick={onPrevMonthClickSpy} />);
-      wrapper.instance().onPrevMonthClick(event);
-      expect(onPrevMonthClickSpy).to.have.property('callCount', 1);
-    });
-
     it('calls translateFirstDayPickerForAnimation', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().onPrevMonthClick(event);
@@ -485,13 +480,6 @@ describe('DayPicker', () => {
   });
 
   describe('#onNextMonthClick', () => {
-    it('calls props.onNextMonthClick', () => {
-      const onNextMonthClickSpy = sinon.stub();
-      const wrapper = shallow(<DayPicker onNextMonthClick={onNextMonthClickSpy} />);
-      wrapper.instance().onNextMonthClick(event);
-      expect(onNextMonthClickSpy).to.have.property('callCount', 1);
-    });
-
     it('sets state.monthTransition to "next"', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().onNextMonthClick();
@@ -535,7 +523,7 @@ describe('DayPicker', () => {
       it('returns first day of arg if getFirstFocusableDay returns invisible day', () => {
         const test = moment().add(3, 'months');
         const getFirstFocusableDayStub = sinon.stub().returns(today);
-        sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+        sinon.stub(isDayVisible, 'default').returns(false);
         const wrapper = shallow(<DayPicker getFirstFocusableDay={getFirstFocusableDayStub} />);
         expect(wrapper.instance().getFocusedDay(test).isSame(test.startOf('month'), 'day')).to.equal(true);
       });
@@ -578,7 +566,7 @@ describe('DayPicker', () => {
       describe('arg is visible', () => {
         it('does not call `onNextMonthClick`', () => {
           const onNextMonthClickSpy = sinon.spy(DayPicker.prototype, 'onNextMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -587,7 +575,7 @@ describe('DayPicker', () => {
         });
 
         it('returns false', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -598,7 +586,7 @@ describe('DayPicker', () => {
       describe('arg is not visible', () => {
         it('calls `onNextMonthClick`', () => {
           const onNextMonthClickSpy = sinon.spy(DayPicker.prototype, 'onNextMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -607,7 +595,7 @@ describe('DayPicker', () => {
         });
 
         it('returns true', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -640,7 +628,7 @@ describe('DayPicker', () => {
       describe('arg is visible', () => {
         it('does not call `onPrevMonthClick`', () => {
           const onPrevMonthClickSpy = sinon.spy(DayPicker.prototype, 'onPrevMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -649,7 +637,7 @@ describe('DayPicker', () => {
         });
 
         it('returns false', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(true);
+          sinon.stub(isDayVisible, 'default').returns(true);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -664,7 +652,7 @@ describe('DayPicker', () => {
 
         it('calls `onPrevMonthClick`', () => {
           const onPrevMonthClickSpy = sinon.spy(DayPicker.prototype, 'onPrevMonthClick');
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -673,7 +661,7 @@ describe('DayPicker', () => {
         });
 
         it('returns true', () => {
-          sinon.stub(DayPicker.prototype, 'isDayVisible').returns(false);
+          sinon.stub(isDayVisible, 'default').returns(false);
           const nextMonth = moment().add(1, 'month');
           const wrapper = shallow(<DayPicker />);
           wrapper.state().focusedDate = nextMonth;
@@ -694,37 +682,6 @@ describe('DayPicker', () => {
       const wrapper = shallow(<DayPicker />);
       wrapper.instance().multiplyScrollableMonths();
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
-    });
-  });
-
-  describe('#isDayVisible', () => {
-    it('returns true if arg is in visible months', () => {
-      const test = moment().add(3, 'months');
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(test)).to.equal(true);
-    });
-
-    it('returns false if arg is before first month', () => {
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(today)).to.equal(false);
-    });
-
-    it('returns false if arg is after last month', () => {
-      const test = moment().add(4, 'months');
-      const wrapper = shallow(<DayPicker numberOfMonths={1} />);
-      wrapper.setState({
-        currentMonth: moment().add(3, 'months'),
-      });
-
-      expect(wrapper.instance().isDayVisible(test)).to.equal(false);
     });
   });
 

--- a/test/utils/getVisibleDays_spec.js
+++ b/test/utils/getVisibleDays_spec.js
@@ -1,0 +1,34 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isSameDay from '../../src/utils/isSameDay';
+import getVisibleDays from '../../src/utils/getVisibleDays';
+
+const today = moment();
+
+describe('getVisibleDays', () => {
+  it('has numberOfMonths entries', () => {
+    const numberOfMonths = 3;
+    const visibleDays = getVisibleDays(today, numberOfMonths, false);
+    expect(Object.keys(visibleDays).length).to.equal(numberOfMonths + 2);
+  });
+
+  it('values are all arrays of moment objects', () => {
+    const visibleDays = getVisibleDays(today, 3, false);
+    Object.values(visibleDays).forEach((days) => {
+      expect(Array.isArray(days)).to.equal(true);
+      days.forEach((day) => {
+        expect(moment.isMoment(day)).to.equal(true);
+      });
+    });
+  });
+
+  it('contains first arg day', () => {
+    const visibleDays = getVisibleDays(today, 3, false);
+    const containsToday = Object.values(visibleDays).filter(
+      days => days.filter(day => isSameDay(day, today)).length > 0,
+    );
+    expect(containsToday.length > 0).to.equal(true);
+  });
+});
+

--- a/test/utils/isAfterDay_spec.js
+++ b/test/utils/isAfterDay_spec.js
@@ -1,0 +1,39 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isAfterDay from '../../src/utils/isAfterDay';
+
+const today = moment();
+const tomorrow = moment().add(1, 'days');
+
+describe('isAfterDay', () => {
+  it('returns true if first arg is after the second but have same month and year', () => {
+    expect(isAfterDay(tomorrow, today)).to.equal(true);
+  });
+
+  it('returns true if first arg is after the second but have same day and year', () => {
+    expect(isAfterDay(moment().clone().add(1, 'month'), today)).to.equal(true);
+  });
+
+  it('returns true if first arg is after the second but have same day and month', () => {
+    expect(isAfterDay(moment().clone().add(1, 'year'), today)).to.equal(true);
+  });
+
+  it('returns false if args are the same day', () => {
+    expect(isAfterDay(today, today)).to.equal(false);
+  });
+
+  it('returns false if first arg is after the second', () => {
+    expect(isAfterDay(today, tomorrow)).to.equal(false);
+  });
+
+  describe('non-moment object arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isAfterDay(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isAfterDay(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isBeforeDay_spec.js
+++ b/test/utils/isBeforeDay_spec.js
@@ -1,0 +1,39 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isBeforeDay from '../../src/utils/isBeforeDay';
+
+const today = moment();
+const tomorrow = moment().add(1, 'days');
+
+describe('isBeforeDay', () => {
+  it('returns true if first arg is before the second but have same month and year', () => {
+    expect(isBeforeDay(today, tomorrow)).to.equal(true);
+  });
+
+  it('returns true if first arg is before the second but have same day and year', () => {
+    expect(isBeforeDay(today, moment().clone().add(1, 'month'))).to.equal(true);
+  });
+
+  it('returns true if first arg is before the second but have same day and month', () => {
+    expect(isBeforeDay(today, moment().clone().add(1, 'year'))).to.equal(true);
+  });
+
+  it('returns false if args are the same day', () => {
+    expect(isBeforeDay(today, today)).to.equal(false);
+  });
+
+  it('returns false if first arg is after the second', () => {
+    expect(isBeforeDay(tomorrow, today)).to.equal(false);
+  });
+
+  describe('non-moment object arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isBeforeDay(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isBeforeDay(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isDayVisible_spec.js
+++ b/test/utils/isDayVisible_spec.js
@@ -1,0 +1,24 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isDayVisible from '../../src/utils/isDayVisible';
+
+describe('#isDayVisible', () => {
+  it('returns true if arg is in visible months', () => {
+    const test = moment().add(3, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(true);
+  });
+
+  it('returns false if arg is before first month', () => {
+    const test = moment().add(1, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+  });
+
+  it('returns false if arg is after last month', () => {
+    const test = moment().add(4, 'months');
+    const currentMonth = moment().add(2, 'months');
+    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+  });
+});

--- a/test/utils/toISOMonthString_spec.js
+++ b/test/utils/toISOMonthString_spec.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import { ISO_FORMAT, ISO_MONTH_FORMAT } from '../../constants';
+import toISOMonthString from '../../src/utils/toISOMonthString';
+
+describe('#toISOMonthString', () => {
+  describe('arg is a moment object', () => {
+    it('returns month in ISO_MONTH_FORMAT format', () => {
+      const today = moment();
+      expect(toISOMonthString(today)).to.equal(today.format(ISO_MONTH_FORMAT));
+    });
+  });
+
+  describe('arg is a string', () => {
+    describe('arg is in ISO format', () => {
+      it('returns month in ISO_MONTH_FORMAT format', () => {
+        const today = moment();
+        const todayISO = today.format(ISO_FORMAT);
+        expect(toISOMonthString(todayISO)).to.equal(today.format(ISO_MONTH_FORMAT));
+      });
+    });
+
+    describe('arg matches the second arg date format provided', () => {
+      it('returns month in ISO_MONTH_FORMAT format', () => {
+        const today = moment();
+        const dateFormat = 'MM_DD_YYYY';
+        const formattedDate = today.format(dateFormat);
+        const monthString = toISOMonthString(formattedDate, dateFormat);
+        expect(monthString).to.equal(today.format(ISO_MONTH_FORMAT));
+      });
+    });
+
+    describe('arg is neither in iso format or in the provided format', () => {
+      it('returns null', () => {
+        const today = moment();
+        const dateFormat = 'MM_DD_YYYY';
+        const formattedDate = today.format('MM-DD-YYYY');
+        expect(toISOMonthString(formattedDate, dateFormat)).to.equal(null);
+      });
+    });
+
+    describe('arg is not a valid date string', () => {
+      it('returns null', () => {
+        expect(toISOMonthString('This is not a date')).to.equal(null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR is a dramatic rearchitecture of the way that we handle modifiers in `react-dates` on the whole.

Instead of passing down an object of modifier string => modifiers functions to each CalendarDay component (one that gets rebuilt on every render call) and expecting the CalendarDay component to take care of updating itself, we now put the burden on the top of the tree instead of on the leaves. The previous model meant that whenever an interaction happened on an individual day, even a hover interaction, every single CalendarDay would have to recalculate its modifiers and rerender as a result. The idea was that an interaction on one day might have effects elsewhere in the calendar (like the `hovered-span`). The effect unfortunately was that react-dates was [really god damn slow](https://github.com/airbnb/react-dates/issues/272).

In this new model, the DayPickerRangeController maintains a map with the following structure:
```
{
  MONTH_ISO_1: {
    DAY_ISO_1: Set(['modifier_1', 'modifier_2', ...]),
    DAY_ISO_2: Set(['modifier_1', 'modifier_2', ...]),
    ...
  },
  ...
}
```
It passes this down the tree such that each `CalendarMonth` and each `CalendarDay` only gets the information that pertains to it. This means that the updating of these modifiers is also handled at the top-level and is done in the `componentWillReceiveProps`, `onDayMouseEnter`, and `onDayMouseLeave` methods of the `DayPickerRangeController`. Fortunately, this allows us to more finely tune which days get updated and speeds up the rerendering/updating process dramatically.

I did some preliminary testing and saw the following improvements:
*Before:*
<img width="1100" alt="screen shot 2017-04-13 at 10 35 39 pm" src="https://cloud.githubusercontent.com/assets/1383861/25154213/9d8ba8aa-2444-11e7-847a-1762f164ac6e.png">

*After:*
<img width="1382" alt="screen shot 2017-04-13 at 10 55 41 pm" src="https://cloud.githubusercontent.com/assets/1383861/25154217/a688b0c4-2444-11e7-8214-58b2904eccc3.png">

I will update those graphs when everything is in place.

I still need to finish writing some tests, clean up some other tests, and also get this working with `enableOutsideDays` and the `SingleDatePicker`.  The bulk of the work is in `DayPickerRangeController` right now, but I've been musing on ways to pull that in an HOC or something. SUGGESTIONS ARE WELCOME.

In any case, I would appreciate a first review pass while I finish up the above points! <3
@lencioni @ljharb @moonboots @backwardok 

UPDATE: Here are the final perf measurements!
**Before:**
<img width="1270" alt="screen shot 2017-05-01 at 3 19 09 pm" src="https://cloud.githubusercontent.com/assets/1383861/25598878/97062454-2e8c-11e7-81d6-45555caa6652.png">

**After:**
![screen shot 2017-05-01 at 4 38 44 pm](https://cloud.githubusercontent.com/assets/1383861/25598893/accb5728-2e8c-11e7-94fe-dd52b5507e3f.png)

Here are the findings:
 - The overhead on initial mount remains about the same (~400-500ms)
 - Any calendar interaction (hover, click, etc.) consistently caused a 65ms update in the old version and now only takes about 10ms - 15ms.
 - Transitions are now a bit slower (likely due to a bug in the code and therefore an opportunity) at about 120ms as opposed to 95ms previously. There does seem to be an unnecessary update occurring that I'll investigate in a follow up PR.
