### PR TITLE
Fix moment peer dependency to allow 2.18.x patch releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-portal": "^3.0.0"
   },
   "peerDependencies": {
-    "moment": "(2.10 - 2.14 || ^2.15.1) && < 2.18.0",
+    "moment": "(2.10 - 2.14 || ^2.15.1) && < 2.18.0 || ~2.18.0",
     "react": ">=0.14",
     "react-dom": ">=0.14",
     "react-addons-shallow-compare": ">=0.14"


### PR DESCRIPTION
Fix the `peerDependencies` for the `moment` package to prevent warnings from being emitted by package managers.