### PR TITLE
Remove unused scss variables from variables.scss and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ react-dates comes with a set of SCSS variables that can be overridden to add you
 ```scss
 //overriding default sass variables with my project's colors
 $react-dates-color-primary: $some-color-specific-to-my-project;
-$react-dates-color-primary-dark: $some-other-color-specific-to-my-project;
+$react-dates-color-secondary: $some-other-color-specific-to-my-project;
 @import '~react-dates/css/variables.scss';
 @import '~react-dates/css/styles.scss';
 ```

--- a/css/variables.scss
+++ b/css/variables.scss
@@ -4,8 +4,6 @@ $react-dates-width-tooltip-arrow: 20px !default;
 $react-dates-spacing-vertical-picker: 72px !default;
 
 $react-dates-color-primary: #00a699 !default;
-$react-dates-color-primary-dark: #00514a !default;
-$react-date-color-primary-dark-1: #008489 !default;
 $react-dates-color-primary-shade-1: #33dacd !default;
 $react-dates-color-primary-shade-2: #66e2da !default;
 $react-dates-color-primary-shade-3: #80e8e0 !default;


### PR DESCRIPTION
The unused variables confused me when I was theming react-dates and I assumed they would do the same for others.

No changes to functionality at all.