### PR TITLE
Disable hover when DatePicker does not have focus

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -382,52 +382,54 @@ export default class DayPickerRangeController extends React.Component {
     const { startDate, endDate, focusedInput, minimumNights } = this.props;
     const { hoverDate, visibleDays } = this.state;
 
-    let modifiers = {};
-    modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
-    modifiers = this.addModifier(modifiers, day, 'hovered');
+    if (focusedInput) {
+      let modifiers = {};
+      modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
+      modifiers = this.addModifier(modifiers, day, 'hovered');
 
-    if (startDate && !endDate && focusedInput === END_DATE) {
-      if (isAfterDay(hoverDate, startDate)) {
-        const endSpan = hoverDate.clone().add(1, 'day');
-        modifiers = this.deleteModifierFromRange(modifiers, startDate, endSpan, 'hovered-span');
+      if (startDate && !endDate && focusedInput === END_DATE) {
+        if (isAfterDay(hoverDate, startDate)) {
+          const endSpan = hoverDate.clone().add(1, 'day');
+          modifiers = this.deleteModifierFromRange(modifiers, startDate, endSpan, 'hovered-span');
+        }
+
+        if (!this.isBlocked(day) && isAfterDay(day, startDate)) {
+          const endSpan = day.clone().add(1, 'day');
+          modifiers = this.addModifierToRange(modifiers, startDate, endSpan, 'hovered-span');
+        }
       }
 
-      if (!this.isBlocked(day) && isAfterDay(day, startDate)) {
-        const endSpan = day.clone().add(1, 'day');
-        modifiers = this.addModifierToRange(modifiers, startDate, endSpan, 'hovered-span');
+      if (!startDate && endDate && focusedInput === START_DATE) {
+        if (isBeforeDay(hoverDate, endDate)) {
+          modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
+        }
+
+        if (!this.isBlocked(day) && isBeforeDay(day, endDate)) {
+          modifiers = this.addModifierToRange(modifiers, day, endDate, 'hovered-span');
+        }
       }
+
+      if (startDate) {
+        const startSpan = startDate.clone().add(1, 'day');
+        const endSpan = startDate.clone().add(minimumNights + 1, 'days');
+        modifiers = this.deleteModifierFromRange(modifiers, startSpan, endSpan, 'after-hovered-start');
+
+        if (isSameDay(day, startDate)) {
+          const newStartSpan = startDate.clone().add(1, 'day');
+          const newEndSpan = startDate.clone().add(minimumNights + 1, 'days');
+          modifiers =
+            this.addModifierToRange(modifiers, newStartSpan, newEndSpan, 'after-hovered-start');
+        }
+      }
+
+      this.setState({
+        hoverDate: day,
+        visibleDays: {
+          ...visibleDays,
+          ...modifiers,
+        },
+      });
     }
-
-    if (!startDate && endDate && focusedInput === START_DATE) {
-      if (isBeforeDay(hoverDate, endDate)) {
-        modifiers = this.deleteModifierFromRange(modifiers, hoverDate, endDate, 'hovered-span');
-      }
-
-      if (!this.isBlocked(day) && isBeforeDay(day, endDate)) {
-        modifiers = this.addModifierToRange(modifiers, day, endDate, 'hovered-span');
-      }
-    }
-
-    if (startDate) {
-      const startSpan = startDate.clone().add(1, 'day');
-      const endSpan = startDate.clone().add(minimumNights + 1, 'days');
-      modifiers = this.deleteModifierFromRange(modifiers, startSpan, endSpan, 'after-hovered-start');
-
-      if (isSameDay(day, startDate)) {
-        const newStartSpan = startDate.clone().add(1, 'day');
-        const newEndSpan = startDate.clone().add(minimumNights + 1, 'days');
-        modifiers =
-          this.addModifierToRange(modifiers, newStartSpan, newEndSpan, 'after-hovered-start');
-      }
-    }
-
-    this.setState({
-      hoverDate: day,
-      visibleDays: {
-        ...visibleDays,
-        ...modifiers,
-      },
-    });
   }
 
   onDayMouseLeave(day) {
@@ -699,7 +701,7 @@ export default class DayPickerRangeController extends React.Component {
   isHovered(day) {
     const { hoverDate } = this.state || {};
     const { focusedInput } = this.props;
-    return focusedInput && isSameDay(day, hoverDate);
+    return !!focusedInput && isSameDay(day, hoverDate);
   }
 
   isInHoveredSpan(day) {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -698,7 +698,8 @@ export default class DayPickerRangeController extends React.Component {
 
   isHovered(day) {
     const { hoverDate } = this.state || {};
-    return isSameDay(day, hoverDate);
+    const { focusedInput } = this.props;
+    return focusedInput && isSameDay(day, hoverDate);
   }
 
   isInHoveredSpan(day) {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1370,7 +1370,7 @@ describe('DayPickerRangeController', () => {
 
   describe('#onDayMouseEnter', () => {
     it('sets state.hoverDate to the day arg', () => {
-      const wrapper = shallow(<DayPickerRangeController />);
+      const wrapper = shallow(<DayPickerRangeController focusedInput={START_DATE} />);
       wrapper.instance().onDayMouseEnter(today);
       expect(wrapper.state().hoverDate).to.equal(today);
     });
@@ -1380,6 +1380,7 @@ describe('DayPickerRangeController', () => {
         const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
         const wrapper = shallow(
           <DayPickerRangeController
+            focusedInput={START_DATE}
             onDatesChange={sinon.stub()}
             onFocusChange={sinon.stub()}
           />,
@@ -1398,6 +1399,7 @@ describe('DayPickerRangeController', () => {
         const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
         const wrapper = shallow(
           <DayPickerRangeController
+            focusedInput={START_DATE}
             onDatesChange={sinon.stub()}
             onFocusChange={sinon.stub()}
           />,
@@ -1528,6 +1530,7 @@ describe('DayPickerRangeController', () => {
               <DayPickerRangeController
                 onDatesChange={sinon.stub()}
                 onFocusChange={sinon.stub()}
+                focusedInput={START_DATE}
                 minimumNights={minimumNights}
               />,
             );
@@ -1552,6 +1555,7 @@ describe('DayPickerRangeController', () => {
                 onDatesChange={sinon.stub()}
                 onFocusChange={sinon.stub()}
                 startDate={startDate}
+                focusedInput={START_DATE}
                 minimumNights={minimumNights}
               />,
             );
@@ -1577,6 +1581,7 @@ describe('DayPickerRangeController', () => {
                   onDatesChange={sinon.stub()}
                   onFocusChange={sinon.stub()}
                   startDate={startDate}
+                  focusedInput={START_DATE}
                   minimumNights={minimumNights}
                 />,
               );
@@ -1601,6 +1606,7 @@ describe('DayPickerRangeController', () => {
                   onDatesChange={sinon.stub()}
                   onFocusChange={sinon.stub()}
                   startDate={startDate}
+                  focusedInput={START_DATE}
                   minimumNights={minimumNights}
                 />,
               );
@@ -2718,8 +2724,17 @@ describe('DayPickerRangeController', () => {
     });
 
     describe('#isHovered', () => {
+      it('returns false if focusedInput is falsey', () => {
+        const wrapper = shallow(<DayPickerRangeController focusedInput={null} />);
+        wrapper.setState({
+          hoverDate: today,
+        });
+
+        expect(wrapper.instance().isHovered(today)).to.equal(false);
+      });
+
       it('returns true if arg === state.hoverDate', () => {
-        const wrapper = shallow(<DayPickerRangeController />);
+        const wrapper = shallow(<DayPickerRangeController focusedInput={START_DATE} />);
         wrapper.setState({
           hoverDate: today,
         });
@@ -2728,7 +2743,7 @@ describe('DayPickerRangeController', () => {
       });
 
       it('returns false if arg !== state.hoverDate', () => {
-        const wrapper = shallow(<DayPickerRangeController />);
+        const wrapper = shallow(<DayPickerRangeController focusedInput={START_DATE} />);
         wrapper.setState({
           hoverDate: moment(today).add(1, 'days'),
         });


### PR DESCRIPTION
Adresses #479.

Usefull for DatePicker "resetting" focusedInput when clicking outside of the component.
It avoids DatePicker from showing hover style on day when hovered if the DayPicker does not have
focus.