### PR TITLE
Patch issues with the perf architecture

### DIFF
--- a/css/CalendarMonth.scss
+++ b/css/CalendarMonth.scss
@@ -5,13 +5,6 @@
   padding: 0 13px;
   vertical-align: top;
 
-  &:first-of-type {
-    position: absolute;
-    z-index: $react-dates-z-index - 1;
-    opacity: 0;
-    pointer-events: none;
-  }
-
   table {
     border-collapse: collapse;
     border-spacing: 0;
@@ -24,6 +17,16 @@
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.CalendarMonth--horizontal,
+.CalendarMonth--vertical {
+  &:first-of-type {
+    position: absolute;
+    z-index: $react-dates-z-index - 1;
+    opacity: 0;
+    pointer-events: none;
+  }
 }
 
 .CalendarMonth--horizontal {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -75,11 +75,12 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-function getMonths(initialMonth, numberOfMonths) {
-  let month = initialMonth.clone().subtract(1, 'month');
+function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
+  let month = initialMonth.clone();
+  if (!withoutTransitionMonths) month = month.subtract(1, 'month');
 
   const months = [];
-  for (let i = 0; i < numberOfMonths + 2; i += 1) {
+  for (let i = 0; i < (withoutTransitionMonths ? numberOfMonths : numberOfMonths + 2); i += 1) {
     months.push(month);
     month = month.clone().add(1, 'month');
   }
@@ -90,8 +91,9 @@ function getMonths(initialMonth, numberOfMonths) {
 export default class CalendarMonthGrid extends React.Component {
   constructor(props) {
     super(props);
+    const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
     this.state = {
-      months: getMonths(props.initialMonth, props.numberOfMonths),
+      months: getMonths(props.initialMonth, props.numberOfMonths, withoutTransitionMonths),
     };
 
     this.isTransitionEndSupported = isTransitionEndSupported();
@@ -107,7 +109,7 @@ export default class CalendarMonthGrid extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { initialMonth, numberOfMonths } = nextProps;
+    const { initialMonth, numberOfMonths, orientation } = nextProps;
     const { months } = this.state;
 
     const hasMonthChanged = !this.props.initialMonth.isSame(initialMonth, 'month');
@@ -125,7 +127,8 @@ export default class CalendarMonthGrid extends React.Component {
     }
 
     if (hasNumberOfMonthsChanged) {
-      newMonths = getMonths(initialMonth, numberOfMonths);
+      const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+      newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
     }
 
     this.setState({

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -58,6 +58,7 @@ const propTypes = forbidExtraProps({
   navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onMultiplyScrollableMonths: PropTypes.func, // VERTICAL_SCROLLABLE daypickers only
 
   // month props
   renderMonth: PropTypes.func,
@@ -99,6 +100,7 @@ export const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  onMultiplyScrollableMonths() {},
 
   // month props
   renderMonth: null,
@@ -476,7 +478,10 @@ export default class DayPicker extends React.Component {
   }
 
   multiplyScrollableMonths(e) {
+    const { onMultiplyScrollableMonths } = this.props;
     if (e) e.preventDefault();
+
+    if (onMultiplyScrollableMonths) onMultiplyScrollableMonths(e);
 
     this.setState({
       scrollableMonthMultiple: this.state.scrollableMonthMultiple + 1,
@@ -730,6 +735,7 @@ export default class DayPicker extends React.Component {
     }
 
     const verticalScrollable = this.props.orientation === VERTICAL_SCROLLABLE;
+    if (verticalScrollable) firstVisibleMonthIndex = 0;
 
     const dayPickerClassNames = cx('DayPicker', {
       'DayPicker--horizontal': this.isHorizontal(),

--- a/src/utils/getVisibleDays.js
+++ b/src/utils/getVisibleDays.js
@@ -1,12 +1,17 @@
 import moment from 'moment';
 import toISOMonthString from './toISOMonthString';
 
-export default function getVisibleDays(month, numberOfMonths, enableOutsideDays) {
+export default function getVisibleDays(
+  month,
+  numberOfMonths,
+  enableOutsideDays,
+  withoutTransitionMonths,
+) {
   if (!moment.isMoment(month)) return {};
 
   const visibleDaysByMonth = {};
-  let currentMonth = month.clone().subtract(1, 'month');
-  for (let i = 0; i < numberOfMonths + 2; i += 1) { // account for transition months
+  let currentMonth = withoutTransitionMonths ? month.clone() : month.clone().subtract(1, 'month');
+  for (let i = 0; i < (withoutTransitionMonths ? numberOfMonths : numberOfMonths + 2); i += 1) {
     const visibleDays = [];
 
     // set utc offset to get correct dates in future (when timezone changes)


### PR DESCRIPTION
- after-hovered-start is no longer applied on touch devices
- transitioning months no longer grabs extra hidden months
- vertical scrollable daypickers update modifier state accordingly

This should fix some issues I was seeing in prod

to: @moonboots @airbnb/webinfra 