### PR TITLE
Recomputes more modifiers when focusedInput changes

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -290,6 +290,19 @@ export default class DayPickerRangeController extends React.Component {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);
+
+          if (this.isBlocked(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
+          }
+
+          if (isOutsideRange(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+          }
+
           if (isDayBlocked(momentObj)) {
             modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
           } else {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -796,6 +796,140 @@ describe('DayPickerRangeController', () => {
         });
       });
 
+      describe('blocked', () => {
+        describe.skip('focusedInput did not change', () => {
+          it('does not call isBlocked', () => {
+            const isBlockedStub =
+              sinon.stub(DayPickerRangeController.prototype, 'isBlocked');
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+            });
+            expect(isBlockedStub.callCount).to.equal(0);
+          });
+        });
+
+        describe('focusedInput changed', () => {
+          const visibleDays = {
+            [toISOMonthString(today)]: {
+              [toISODateString(today)]: [],
+              [toISODateString(moment().add(1, 'day'))]: [],
+              [toISODateString(moment().add(2, 'day'))]: [],
+            },
+          };
+          const numVisibleDays = 3;
+
+          it.skip('calls isBlocked for every visible day', () => {
+            const isBlockedStub =
+              sinon.stub(DayPickerRangeController.prototype, 'isBlocked');
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: END_DATE,
+            });
+            expect(isBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('if isBlocked(day) is true calls addModifier with `blocked` for each day', () => {
+            const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
+            const isBlockedStub =
+              sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(true);
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: START_DATE,
+              isBlocked: isBlockedStub,
+            });
+            const blockedCalendarCalls = getCallsByModifier(addModifierSpy, 'blocked');
+            expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+          });
+
+          it('if isBlocked(day) is false calls deleteModifier with day and `blocked`', () => {
+            const deleteModifierSpy =
+              sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
+            const isBlockedStub =
+              sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(false);
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: END_DATE,
+              isBlocked: isBlockedStub,
+            });
+            const blockedCalendarCalls = getCallsByModifier(deleteModifierSpy, 'blocked');
+            expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+          });
+        });
+      });
+
+      describe('blocked-out-of-range', () => {
+        describe('focusedInput did not change', () => {
+          it('does not call isOutsideRange', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(0);
+          });
+        });
+
+        describe('focusedInput changed', () => {
+          const visibleDays = {
+            [toISOMonthString(today)]: {
+              [toISODateString(today)]: [],
+              [toISODateString(moment().add(1, 'day'))]: [],
+              [toISODateString(moment().add(2, 'day'))]: [],
+            },
+          };
+          const numVisibleDays = 3;
+
+          it('calls isOutsideRange for every visible day', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: END_DATE,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('if isOutsideRange(day) is true calls addModifier with `blocked-out-of-range` for each day', () => {
+            const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
+            const isOutsideRangeStub = sinon.stub().returns(true);
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: START_DATE,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            const blockedCalendarCalls = getCallsByModifier(addModifierSpy, 'blocked-out-of-range');
+            expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+          });
+
+          it('if isOutsideRange(day) is false calls deleteModifier with day and `blocked-out-of-range`', () => {
+            const deleteModifierSpy =
+              sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
+            const isOutsideRangeStub = sinon.stub().returns(false);
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focusedInput: END_DATE,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            const blockedCalendarCalls = getCallsByModifier(deleteModifierSpy, 'blocked-out-of-range');
+            expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+          });
+        });
+      });
+
       describe('blocked-calendar', () => {
         describe('focusedInput did not change', () => {
           it('does not call isDayBlocked', () => {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -797,11 +797,12 @@ describe('DayPickerRangeController', () => {
       });
 
       describe('blocked', () => {
-        describe.skip('focusedInput did not change', () => {
+        describe('focusedInput did not change', () => {
           it('does not call isBlocked', () => {
             const isBlockedStub =
               sinon.stub(DayPickerRangeController.prototype, 'isBlocked');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
+            isBlockedStub.reset();
             wrapper.instance().componentWillReceiveProps({
               ...props,
             });
@@ -819,11 +820,12 @@ describe('DayPickerRangeController', () => {
           };
           const numVisibleDays = 3;
 
-          it.skip('calls isBlocked for every visible day', () => {
+          it('calls isBlocked for every visible day', () => {
             const isBlockedStub =
               sinon.stub(DayPickerRangeController.prototype, 'isBlocked');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
+            isBlockedStub.reset();
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
@@ -840,10 +842,10 @@ describe('DayPickerRangeController', () => {
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
-              isBlocked: isBlockedStub,
             });
             const blockedCalendarCalls = getCallsByModifier(addModifierSpy, 'blocked');
             expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+            isBlockedStub.restore();
           });
 
           it('if isBlocked(day) is false calls deleteModifier with day and `blocked`', () => {
@@ -856,10 +858,10 @@ describe('DayPickerRangeController', () => {
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
-              isBlocked: isBlockedStub,
             });
             const blockedCalendarCalls = getCallsByModifier(deleteModifierSpy, 'blocked');
             expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
+            isBlockedStub.restore();
           });
         });
       });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -835,8 +835,7 @@ describe('DayPickerRangeController', () => {
 
           it('if isBlocked(day) is true calls addModifier with `blocked` for each day', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
-            const isBlockedStub =
-              sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(true);
+            sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(true);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
@@ -845,14 +844,12 @@ describe('DayPickerRangeController', () => {
             });
             const blockedCalendarCalls = getCallsByModifier(addModifierSpy, 'blocked');
             expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
-            isBlockedStub.restore();
           });
 
           it('if isBlocked(day) is false calls deleteModifier with day and `blocked`', () => {
             const deleteModifierSpy =
               sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
-            const isBlockedStub =
-              sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(false);
+            sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(false);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
@@ -861,7 +858,6 @@ describe('DayPickerRangeController', () => {
             });
             const blockedCalendarCalls = getCallsByModifier(deleteModifierSpy, 'blocked');
             expect(blockedCalendarCalls.length).to.equal(numVisibleDays);
-            isBlockedStub.restore();
           });
         });
       });


### PR DESCRIPTION
Previously, only `props.isDayBlocked()` and `props.isDayHighlighted()` are computed. However, in my use case, where there are different validations on the start and end date inputs, `'blocked'` and `'blocked-out-of-range'` persisted when the focused input changes. This PR adds recomputation of modifiers with `this.isBlocked()` and `props.isOutOfRange()`.

I've also added tests; however, it seems like `this.isBlocked()` is getting called for all visible dates instead of only the changed dates. I commented out the failing tests for now (returns 183 calls or something) -- more clarification on that would be appreciated!

Also, if there's any reason I missed that these checks shouldn't be done, please let me know. I tested my fork in my use case and the problem was fixed.

Thanks!