### PR TITLE
fix(DayPickerRangeController): del hovered-span modifier for new end date

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -246,7 +246,7 @@ export default class DayPickerRangeController extends React.Component {
         modifiers = this.deleteModifierFromRange(
           modifiers,
           startDate,
-          endDate,
+          endDate.clone().add(1, 'day'),
           'hovered-span',
         );
 

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -455,17 +455,18 @@ describe('DayPickerRangeController', () => {
           });
 
           describe('new startDate and new endDate both exist', () => {
-            it('deleteModifierFromRange gets called with startDate, endDate, and `hovered-span`', () => {
+            it('deleteModifierFromRange gets called with startDate, endDate + 1 day, and `hovered-span`', () => {
               const deleteModifierFromRangeSpy =
                 sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
               const startDate = today;
               const endDate = today.clone().add(10, 'days');
+              const dayAfterEndDate = endDate.clone().add(1, 'day');
               const wrapper = shallow(<DayPickerRangeController {...props} />);
               wrapper.instance().componentWillReceiveProps({ ...props, startDate, endDate });
               const hoverSpanCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'hovered-span');
               expect(hoverSpanCalls.length).to.equal(1);
               expect(hoverSpanCalls[0].args[1]).to.equal(startDate);
-              expect(hoverSpanCalls[0].args[2]).to.equal(endDate);
+              expect(isSameDay(hoverSpanCalls[0].args[2], dayAfterEndDate)).to.equal(true);
             });
           });
         });


### PR DESCRIPTION
If not deleted, then when selecting a new range with an end date before the previous one, it will still keep the hovered-span modifier.

![react_dates_bug](https://cloud.githubusercontent.com/assets/1235917/26228960/d15eaef0-3bf2-11e7-9f68-955f88900091.gif)

Steps to reproduce:

* Select a range.
* Select the same start date again.
* Select an end date before the previous end date.
* The end date keeps the `CalendarDay--hovered-span` when it shouldn't.

Fixes #520.