### PR TITLE
SingleDatePicker now re-evaluates isOutsideRange on componentWillReceiveProps

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -218,6 +218,12 @@ export default class SingleDatePicker extends React.Component {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);
+          if (this.isBlocked(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
+          }
+
           if (isOutsideRange(momentObj)) {
             modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
           } else {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -218,6 +218,12 @@ export default class SingleDatePicker extends React.Component {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);
+          if (isOutsideRange(momentObj)) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+          }
+
           if (isDayBlocked(momentObj)) {
             modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
           } else {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -366,6 +366,70 @@ describe('SingleDatePicker', () => {
         });
       });
 
+      describe('blocked', () => {
+        describe('props.focused did not change', () => {
+          it('does not call isBlocked', () => {
+            const isBlockedStub = sinon.stub(SingleDatePicker.prototype, 'isBlocked');
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            isBlockedStub.reset();
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+            });
+            expect(isBlockedStub.callCount).to.equal(0);
+          });
+        });
+
+        describe('props.focused changed', () => {
+          const visibleDays = {
+            [toISOMonthString(today)]: {
+              [toISODateString(today)]: [],
+              [toISODateString(moment().add(1, 'day'))]: [],
+              [toISODateString(moment().add(2, 'day'))]: [],
+            },
+          };
+          const numVisibleDays = 3;
+
+          it('calls isBlocked for every visible day', () => {
+            const isBlockedStub = sinon.stub(SingleDatePicker.prototype, 'isBlocked');
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            isBlockedStub.reset();
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+            });
+            expect(isBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('if isBlocked(day) is true calls addModifier with `blocked` for each day', () => {
+            const addModifierSpy = sinon.spy(SingleDatePicker.prototype, 'addModifier');
+            sinon.stub(SingleDatePicker.prototype, 'isBlocked').returns(true);
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+            });
+            const blockedOutOfRangeCalls = getCallsByModifier(addModifierSpy, 'blocked');
+            expect(blockedOutOfRangeCalls.length).to.equal(numVisibleDays);
+          });
+
+          it('if isBlocked(day) is false calls deleteModifier with day and `blocked`', () => {
+            const deleteModifierSpy = sinon.spy(SingleDatePicker.prototype, 'deleteModifier');
+            sinon.stub(SingleDatePicker.prototype, 'isBlocked').returns(false);
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+            });
+            const blockedOutOfRangeCalls = getCallsByModifier(deleteModifierSpy, 'blocked');
+            expect(blockedOutOfRangeCalls.length).to.equal(numVisibleDays);
+          });
+        });
+      });
+
+
       describe('blocked-out-of-range', () => {
         describe('props.focused did not change', () => {
           it('does not call isOutsideRange', () => {
@@ -442,7 +506,6 @@ describe('SingleDatePicker', () => {
           });
         });
       });
-
 
       describe('blocked-calendar', () => {
         describe('props.focused did not change', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -366,6 +366,84 @@ describe('SingleDatePicker', () => {
         });
       });
 
+      describe('blocked-out-of-range', () => {
+        describe('props.focused did not change', () => {
+          it('does not call isOutsideRange', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(0);
+          });
+        });
+
+        describe('props.focused changed', () => {
+          const visibleDays = {
+            [toISOMonthString(today)]: {
+              [toISODateString(today)]: [],
+              [toISODateString(moment().add(1, 'day'))]: [],
+              [toISODateString(moment().add(2, 'day'))]: [],
+            },
+          };
+          const numVisibleDays = 3;
+
+          it('calls isOutsideRange for every visible day', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('if isOutsideRange(day) is true calls addModifier with `blocked-out-of-range` for each day', () => {
+            const addModifierSpy = sinon.spy(
+              SingleDatePicker.prototype,
+              'addModifier',
+            );
+            const isOutsideRangeStub = sinon.stub().returns(true);
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            const blockedOutOfRangeCalls = getCallsByModifier(
+              addModifierSpy,
+              'blocked-out-of-range',
+            );
+            expect(blockedOutOfRangeCalls.length).to.equal(numVisibleDays);
+          });
+
+          it('if isOutsideRange(day) is false calls deleteModifier with day and `blocked-out-of-range`', () => {
+            const deleteModifierSpy = sinon.spy(
+              SingleDatePicker.prototype,
+              'deleteModifier',
+            );
+            const isOutsideRangeStub = sinon.stub().returns(false);
+            const wrapper = shallow(<SingleDatePicker {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              focused: true,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            const blockedOutOfRangeCalls = getCallsByModifier(
+              deleteModifierSpy,
+              'blocked-out-of-range',
+            );
+            expect(blockedOutOfRangeCalls.length).to.equal(numVisibleDays);
+          });
+        });
+      });
+
+
       describe('blocked-calendar', () => {
         describe('props.focused did not change', () => {
           it('does not call isDayBlocked', () => {


### PR DESCRIPTION
Fixes #549 by adding a new call to `isOutsideRange` on `componentWillReceiveProps`, just like what is being done for `isDayBlocked` and `isDayHighlighted`.