### PR TITLE
Allow same day input when `minimumNights={0}`

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -400,6 +400,7 @@ export default class DateRangePicker extends React.Component {
       readOnly,
       phrases,
       isOutsideRange,
+      minimumNights,
       withPortal,
       withFullScreenPortal,
       displayFormat,
@@ -439,6 +440,7 @@ export default class DateRangePicker extends React.Component {
             reopenPickerOnClearDates={reopenPickerOnClearDates}
             keepOpenOnDateSelect={keepOpenOnDateSelect}
             isOutsideRange={isOutsideRange}
+            minimumNights={minimumNights}
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={this.onDateRangePickerInputFocus}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -16,6 +16,7 @@ import toISODateString from '../utils/toISODateString';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isInclusivelyBeforeDay from '../utils/isInclusivelyBeforeDay';
+import isSameDay from '../utils/isSameDay';
 
 import { START_DATE, END_DATE } from '../../constants';
 
@@ -41,6 +42,7 @@ const propTypes = forbidExtraProps({
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
+  minimumNights: PropTypes.number,
   isOutsideRange: PropTypes.func,
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
@@ -85,6 +87,7 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
   withFullScreenPortal: false,
+  minimumNights: 1,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   displayFormat: () => moment.localeData().longDateFormat('L'),
 
@@ -130,6 +133,7 @@ export default class DateRangePickerInputController extends React.Component {
     const {
       startDate,
       isOutsideRange,
+      minimumNights,
       keepOpenOnDateSelect,
       onDatesChange,
     } = this.props;
@@ -137,7 +141,8 @@ export default class DateRangePickerInputController extends React.Component {
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
 
     const isEndDateValid = endDate && !isOutsideRange(endDate) &&
-      !isInclusivelyBeforeDay(endDate, startDate);
+      (!isInclusivelyBeforeDay(endDate, startDate) ||
+      (minimumNights === 0 && isSameDay(endDate, startDate)));
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });
       if (!keepOpenOnDateSelect) this.onClearFocus();
@@ -166,10 +171,11 @@ export default class DateRangePickerInputController extends React.Component {
     const startDate = toMomentObject(startDateString, this.getDisplayFormat());
 
     let { endDate } = this.props;
-    const { isOutsideRange, onDatesChange, onFocusChange } = this.props;
+    const { isOutsideRange, minimumNights, onDatesChange, onFocusChange } = this.props;
     const isStartDateValid = startDate && !isOutsideRange(startDate);
     if (isStartDateValid) {
-      if (isInclusivelyBeforeDay(endDate, startDate)) {
+      if (isInclusivelyBeforeDay(endDate, startDate) &&
+        !(minimumNights === 0 && isSameDay(endDate, startDate))) {
         endDate = null;
       }
 

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -42,7 +42,7 @@ const propTypes = forbidExtraProps({
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
-  minimumNights: PropTypes.number,
+  minimumNights: nonNegativeInteger,
   isOutsideRange: PropTypes.func,
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -15,8 +15,7 @@ import toLocalizedDateString from '../utils/toLocalizedDateString';
 import toISODateString from '../utils/toISODateString';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
-import isInclusivelyBeforeDay from '../utils/isInclusivelyBeforeDay';
-import isSameDay from '../utils/isSameDay';
+import isBeforeDay from '../utils/isBeforeDay';
 
 import { START_DATE, END_DATE } from '../../constants';
 
@@ -141,8 +140,7 @@ export default class DateRangePickerInputController extends React.Component {
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
 
     const isEndDateValid = endDate && !isOutsideRange(endDate) &&
-      (!isInclusivelyBeforeDay(endDate, startDate) ||
-      (minimumNights === 0 && isSameDay(endDate, startDate)));
+      !(startDate && isBeforeDay(endDate, startDate.clone().add(minimumNights, 'days')));
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });
       if (!keepOpenOnDateSelect) this.onClearFocus();
@@ -174,8 +172,7 @@ export default class DateRangePickerInputController extends React.Component {
     const { isOutsideRange, minimumNights, onDatesChange, onFocusChange } = this.props;
     const isStartDateValid = startDate && !isOutsideRange(startDate);
     if (isStartDateValid) {
-      if (isInclusivelyBeforeDay(endDate, startDate) &&
-        !(minimumNights === 0 && isSameDay(endDate, startDate))) {
+      if (startDate && isBeforeDay(endDate, startDate.clone().add(minimumNights, 'days'))) {
         endDate = null;
       }
 

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -113,33 +113,168 @@ describe('DateRangePickerInputController', () => {
   describe('#onEndDateChange', () => {
     describe('is a valid end date', () => {
       const validFutureDateString = moment(today).add(10, 'days').format('YYYY-MM-DD');
-      it('calls props.onDatesChange with correct arguments', () => {
-        const onDatesChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
-        wrapper.instance().onEndDateChange(validFutureDateString);
-        expect(onDatesChangeStub.callCount).to.equal(1);
-
-        const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
-        expect(onDatesChangeArgs.startDate).to.equal(wrapper.props().startDate);
-        expect(isSameDay(onDatesChangeArgs.endDate, moment(validFutureDateString))).to.equal(true);
-      });
-
-      describe('props.onFocusChange', () => {
-        it('is called once', () => {
-          const onFocusChangeStub = sinon.stub();
+      describe('when props.startDate is not provided', () => {
+        it('calls props.onDatesChange with provided end date', () => {
+          const onDatesChangeStub = sinon.stub();
           const wrapper =
-            shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
           wrapper.instance().onEndDateChange(validFutureDateString);
-          expect(onFocusChangeStub.callCount).to.equal(1);
+          expect(onDatesChangeStub.callCount).to.equal(1);
+
+          const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+          expect(onDatesChangeArgs.startDate).to.equal(wrapper.props().startDate);
+          expect(
+            isSameDay(onDatesChangeArgs.endDate, moment(validFutureDateString))).to.equal(true);
         });
 
-        it('is called with null arg', () => {
-          const onFocusChangeStub = sinon.stub();
-          const wrapper =
-            shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+        describe('props.onFocusChange', () => {
+          it('is called once', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.callCount).to.equal(1);
+          });
+
+          it('is called with null arg', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+          });
+        });
+      });
+
+      describe('is before props.startDate', () => {
+        const startDate = moment(today).add(15, 'days');
+        it('calls props.onDatesChange with props.startDate and null end date', () => {
+          const onDatesChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePickerInputController
+              onDatesChange={onDatesChangeStub}
+              startDate={startDate}
+            />);
           wrapper.instance().onEndDateChange(validFutureDateString);
-          expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+          expect(onDatesChangeStub.callCount).to.equal(1);
+
+          const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+          expect(onDatesChangeArgs.startDate).to.equal(startDate);
+          expect(onDatesChangeArgs.endDate).to.equal(null);
+        });
+
+        describe('props.onFocusChange', () => {
+          it('is called once', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.callCount).to.equal(1);
+          });
+
+          it('is called with null arg', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+          });
+        });
+      });
+
+      describe('is after props.startDate', () => {
+        const startDate = moment(today);
+        it('calls props.onDatesChange with props.startDate and provided end date', () => {
+          const onDatesChangeStub = sinon.stub();
+          const wrapper = shallow(
+            <DateRangePickerInputController
+              onDatesChange={onDatesChangeStub}
+              startDate={startDate}
+            />);
+          wrapper.instance().onEndDateChange(validFutureDateString);
+          expect(onDatesChangeStub.callCount).to.equal(1);
+
+          const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+          const futureDate = moment(validFutureDateString);
+          expect(onDatesChangeArgs.startDate).to.equal(startDate);
+          expect(isSameDay(onDatesChangeArgs.endDate, futureDate)).to.equal(true);
+        });
+
+        describe('props.onFocusChange', () => {
+          it('is called once', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.callCount).to.equal(1);
+          });
+
+          it('is called with null arg', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+          });
+        });
+      });
+
+      describe('is the same day as props.startDate', () => {
+        const startDate = moment(today).add(10, 'days');
+
+        describe('props.minimumNights is 0', () => {
+          it('calls props.onDatesChange with props.startDate and provided end date', () => {
+            const onDatesChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onDatesChange={onDatesChangeStub}
+                startDate={startDate}
+                minimumNights={0}
+              />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onDatesChangeStub.callCount).to.equal(1);
+
+            const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+            const futureDate = moment(validFutureDateString);
+            expect(onDatesChangeArgs.startDate).to.equal(startDate);
+            expect(isSameDay(onDatesChangeArgs.endDate, futureDate)).to.equal(true);
+          });
+        });
+
+        describe('props.minimumNights is greater than 0', () => {
+          it('calls props.onDatesChange with props.startDate and null end date', () => {
+            const onDatesChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onDatesChange={onDatesChangeStub}
+                startDate={startDate}
+                minimumNights={1}
+              />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onDatesChangeStub.callCount).to.equal(1);
+
+            const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+            expect(onDatesChangeArgs.startDate).to.equal(startDate);
+            expect(onDatesChangeArgs.endDate).to.equal(null);
+          });
+        });
+
+        describe('props.onFocusChange', () => {
+          it('is called once', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.callCount).to.equal(1);
+          });
+
+          it('is called with null arg', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper =
+              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            wrapper.instance().onEndDateChange(validFutureDateString);
+            expect(onFocusChangeStub.calledWith(null)).to.equal(true);
+          });
         });
       });
     });
@@ -315,7 +450,7 @@ describe('DateRangePickerInputController', () => {
       const validFutureDateString = moment(today).add(5, 'days').format('YYYY-MM-DD');
       describe('is before props.endDate', () => {
         const endDate = moment(today).add(10, 'days');
-        it('calls props.onDatesChange with correct arguments', () => {
+        it('calls props.onDatesChange provided start date and props.endDate', () => {
           const onDatesChangeStub = sinon.stub();
           const wrapper = shallow(
             <DateRangePickerInputController onDatesChange={onDatesChangeStub} endDate={endDate} />,
@@ -358,7 +493,7 @@ describe('DateRangePickerInputController', () => {
 
       describe('is after props.endDate', () => {
         const endDate = moment(today);
-        it('calls props.onDatesChange with correct arguments', () => {
+        it('calls props.onDatesChange with provided start date and null end date', () => {
           const onDatesChangeStub = sinon.stub();
           const wrapper = shallow(
             <DateRangePickerInputController
@@ -373,6 +508,74 @@ describe('DateRangePickerInputController', () => {
           const futureDate = moment(validFutureDateString);
           expect(isSameDay(onDatesChangeArgs.startDate, futureDate)).to.equal(true);
           expect(onDatesChangeArgs.endDate).to.equal(null);
+        });
+
+        describe('props.onFocusChange', () => {
+          it('is called once', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onFocusChange={onFocusChangeStub}
+                endDate={endDate}
+              />,
+            );
+            wrapper.instance().onStartDateChange(validFutureDateString);
+            expect(onFocusChangeStub.callCount).to.equal(1);
+          });
+
+          it('is called with END_DATE arg', () => {
+            const onFocusChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onFocusChange={onFocusChangeStub}
+                endDate={endDate}
+              />,
+            );
+            wrapper.instance().onStartDateChange(validFutureDateString);
+            expect(onFocusChangeStub.calledWith(END_DATE)).to.equal(true);
+          });
+        });
+      });
+
+      describe('is the same day as props.endDate', () => {
+        const endDate = moment(today).add(5, 'days');
+
+        describe('props.minimumNights is 0', () => {
+          it('calls props.onDatesChange with provided start date and props.endDate', () => {
+            const onDatesChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onDatesChange={onDatesChangeStub}
+                endDate={endDate}
+                minimumNights={0}
+              />);
+            wrapper.instance().onStartDateChange(validFutureDateString);
+            expect(onDatesChangeStub.callCount).to.equal(1);
+
+            const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+            const futureDate = moment(validFutureDateString);
+            expect(isSameDay(onDatesChangeArgs.startDate, futureDate)).to.equal(true);
+            expect(onDatesChangeArgs.endDate).to.equal(endDate);
+          });
+        });
+
+        describe('props.minimumNights is greater than 0', () => {
+          it('calls props.onDatesChange with provided start date and null end date', () => {
+            const onDatesChangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DateRangePickerInputController
+                onDatesChange={onDatesChangeStub}
+                endDate={endDate}
+                minimumNights={1}
+              />);
+            wrapper.instance().onStartDateChange(validFutureDateString);
+            expect(onDatesChangeStub.callCount).to.equal(1);
+
+            const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
+            const futureDate = moment(validFutureDateString);
+            expect(isSameDay(onDatesChangeArgs.startDate, futureDate)).to.equal(true);
+            expect(onDatesChangeArgs.endDate).to.equal(null);
+          });
         });
 
         describe('props.onFocusChange', () => {

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -36,7 +36,8 @@ describe('DateRangePickerInputController', () => {
             <DateRangePickerInputController
               onFocusChange={onFocusChangeStub}
               reopenPickerOnClearDates
-            />);
+            />,
+          );
           wrapper.instance().clearDates();
           expect(onFocusChangeStub.callCount).to.equal(1);
         });
@@ -47,7 +48,8 @@ describe('DateRangePickerInputController', () => {
             <DateRangePickerInputController
               onFocusChange={onFocusChangeStub}
               reopenPickerOnClearDates
-            />);
+            />,
+          );
           wrapper.instance().clearDates();
           expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
         });
@@ -58,8 +60,9 @@ describe('DateRangePickerInputController', () => {
       describe('props.onFocusChange', () => {
         it('is not called', () => {
           const onFocusChangeStub = sinon.stub();
-          const wrapper =
-            shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+          const wrapper = shallow(
+            <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+          );
           wrapper.instance().clearDates();
           expect(onFocusChangeStub.callCount).to.equal(0);
         });
@@ -68,8 +71,9 @@ describe('DateRangePickerInputController', () => {
 
     it('calls props.onDatesChange with arg { startDate: null, endDate: null }', () => {
       const onDatesChangeStub = sinon.stub();
-      const wrapper =
-        shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
+      const wrapper = shallow(
+        <DateRangePickerInputController onDatesChange={onDatesChangeStub} />,
+      );
       wrapper.instance().clearDates();
       expect(onDatesChangeStub.callCount).to.equal(1);
     });
@@ -116,30 +120,33 @@ describe('DateRangePickerInputController', () => {
       describe('when props.startDate is not provided', () => {
         it('calls props.onDatesChange with provided end date', () => {
           const onDatesChangeStub = sinon.stub();
-          const wrapper =
-            shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
+          const wrapper = shallow(
+            <DateRangePickerInputController onDatesChange={onDatesChangeStub} />,
+          );
           wrapper.instance().onEndDateChange(validFutureDateString);
           expect(onDatesChangeStub.callCount).to.equal(1);
 
-          const onDatesChangeArgs = onDatesChangeStub.getCall(0).args[0];
-          expect(onDatesChangeArgs.startDate).to.equal(wrapper.props().startDate);
+          const [{ startDate, endDate }] = onDatesChangeStub.getCall(0).args;
+          expect(startDate).to.equal(wrapper.props().startDate);
           expect(
-            isSameDay(onDatesChangeArgs.endDate, moment(validFutureDateString))).to.equal(true);
+            isSameDay(endDate, moment(validFutureDateString))).to.equal(true);
         });
 
         describe('props.onFocusChange', () => {
           it('is called once', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.callCount).to.equal(1);
           });
 
           it('is called with null arg', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.calledWith(null)).to.equal(true);
           });
@@ -154,7 +161,8 @@ describe('DateRangePickerInputController', () => {
             <DateRangePickerInputController
               onDatesChange={onDatesChangeStub}
               startDate={startDate}
-            />);
+            />,
+          );
           wrapper.instance().onEndDateChange(validFutureDateString);
           expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -166,16 +174,18 @@ describe('DateRangePickerInputController', () => {
         describe('props.onFocusChange', () => {
           it('is called once', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.callCount).to.equal(1);
           });
 
           it('is called with null arg', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.calledWith(null)).to.equal(true);
           });
@@ -190,7 +200,8 @@ describe('DateRangePickerInputController', () => {
             <DateRangePickerInputController
               onDatesChange={onDatesChangeStub}
               startDate={startDate}
-            />);
+            />,
+          );
           wrapper.instance().onEndDateChange(validFutureDateString);
           expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -203,16 +214,18 @@ describe('DateRangePickerInputController', () => {
         describe('props.onFocusChange', () => {
           it('is called once', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.callCount).to.equal(1);
           });
 
           it('is called with null arg', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.calledWith(null)).to.equal(true);
           });
@@ -230,7 +243,8 @@ describe('DateRangePickerInputController', () => {
                 onDatesChange={onDatesChangeStub}
                 startDate={startDate}
                 minimumNights={0}
-              />);
+              />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -249,7 +263,8 @@ describe('DateRangePickerInputController', () => {
                 onDatesChange={onDatesChangeStub}
                 startDate={startDate}
                 minimumNights={1}
-              />);
+              />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -262,16 +277,18 @@ describe('DateRangePickerInputController', () => {
         describe('props.onFocusChange', () => {
           it('is called once', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.callCount).to.equal(1);
           });
 
           it('is called with null arg', () => {
             const onFocusChangeStub = sinon.stub();
-            const wrapper =
-              shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+            const wrapper = shallow(
+              <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+            );
             wrapper.instance().onEndDateChange(validFutureDateString);
             expect(onFocusChangeStub.calledWith(null)).to.equal(true);
           });
@@ -329,8 +346,9 @@ describe('DateRangePickerInputController', () => {
       const invalidDateString = 'foo';
       it('calls props.onDatesChange', () => {
         const onDatesChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
+        const wrapper = shallow(
+          <DateRangePickerInputController onDatesChange={onDatesChangeStub} />,
+        );
         wrapper.instance().onEndDateChange(invalidDateString);
         expect(onDatesChangeStub.callCount).to.equal(1);
       });
@@ -350,8 +368,9 @@ describe('DateRangePickerInputController', () => {
 
       it('calls props.onDatesChange with endDate === null', () => {
         const onDatesChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
+        const wrapper = shallow(
+          <DateRangePickerInputController onDatesChange={onDatesChangeStub} />,
+        );
         wrapper.instance().onEndDateChange(invalidDateString);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.endDate).to.equal(null);
@@ -548,7 +567,8 @@ describe('DateRangePickerInputController', () => {
                 onDatesChange={onDatesChangeStub}
                 endDate={endDate}
                 minimumNights={0}
-              />);
+              />,
+            );
             wrapper.instance().onStartDateChange(validFutureDateString);
             expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -567,7 +587,8 @@ describe('DateRangePickerInputController', () => {
                 onDatesChange={onDatesChangeStub}
                 endDate={endDate}
                 minimumNights={1}
-              />);
+              />,
+            );
             wrapper.instance().onStartDateChange(validFutureDateString);
             expect(onDatesChangeStub.callCount).to.equal(1);
 
@@ -656,8 +677,9 @@ describe('DateRangePickerInputController', () => {
       const invalidDateString = 'foo';
       it('calls props.onDatesChange', () => {
         const onDatesChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<DateRangePickerInputController onDatesChange={onDatesChangeStub} />);
+        const wrapper = shallow(
+          <DateRangePickerInputController onDatesChange={onDatesChangeStub} />,
+        );
         wrapper.instance().onStartDateChange(invalidDateString);
         expect(onDatesChangeStub.callCount).to.equal(1);
       });
@@ -735,16 +757,18 @@ describe('DateRangePickerInputController', () => {
   describe('#onStartDateFocus', () => {
     it('calls props.onFocusChange once', () => {
       const onFocusChangeStub = sinon.stub();
-      const wrapper =
-        shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+      const wrapper = shallow(
+        <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+      );
       wrapper.instance().onStartDateFocus();
       expect(onFocusChangeStub).to.have.property('callCount', 1);
     });
 
     it('calls props.onFocusChange with START_DATE as arg', () => {
       const onFocusChangeStub = sinon.stub();
-      const wrapper =
-        shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+      const wrapper = shallow(
+        <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+      );
       wrapper.instance().onStartDateFocus();
       expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
     });
@@ -752,8 +776,9 @@ describe('DateRangePickerInputController', () => {
     describe('props.disabled = true', () => {
       it('does not call props.onFocusChange', () => {
         const onFocusChangeStub = sinon.stub();
-        const wrapper =
-          shallow(<DateRangePickerInputController disabled onFocusChange={onFocusChangeStub} />);
+        const wrapper = shallow(
+          <DateRangePickerInputController disabled onFocusChange={onFocusChangeStub} />,
+        );
         wrapper.instance().onStartDateFocus();
         expect(onFocusChangeStub).to.have.property('callCount', 0);
       });
@@ -763,8 +788,9 @@ describe('DateRangePickerInputController', () => {
   describe('#onEndDateFocus', () => {
     it('calls props.onFocusChange once with arg END_DATE', () => {
       const onFocusChangeStub = sinon.stub();
-      const wrapper =
-        shallow(<DateRangePickerInputController onFocusChange={onFocusChangeStub} />);
+      const wrapper = shallow(
+        <DateRangePickerInputController onFocusChange={onFocusChangeStub} />,
+      );
       wrapper.instance().onEndDateFocus();
       expect(onFocusChangeStub).to.have.property('callCount', 1);
       expect(onFocusChangeStub.getCall(0).args[0]).to.equal(END_DATE);


### PR DESCRIPTION
Fixes #353.