### PR TITLE
[Issue 25] Month and Year Dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDates: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+enableDropdowns: PropTypes.bool,
 hideKeyboardShortcutsPanel: PropTypes.bool,
 isRTL: PropTypes.bool,
 
@@ -172,6 +173,7 @@ numberOfMonths: PropTypes.number,
 keepOpenOnDateSelect: PropTypes.bool,
 reopenPickerOnClearDate: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
+enableDropdowns: PropTypes.bool,
 hideKeyboardShortcutsPanel: PropTypes.bool,
 isRTL: PropTypes.bool,
 
@@ -220,6 +222,7 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
+  enableDropdowns: PropTypes.bool,
   onOutsideClick: PropTypes.func,
   keepOpenOnDateSelect: PropTypes.bool,
 

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -71,6 +71,7 @@ const defaultProps = {
   renderDay: null,
   minimumNights: 1,
   enableOutsideDays: false,
+  enableDropdowns: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,

--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -28,6 +28,7 @@ const propTypes = forbidExtraProps({
 
   // DayPicker props
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
@@ -61,6 +62,7 @@ const defaultProps = {
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
   enableOutsideDays: false,
+  enableDropdowns: false,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -61,6 +61,7 @@ const defaultProps = {
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,
+  enableDropdowns: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => {},

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -12,6 +12,7 @@ import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
 import CalendarDay from './CalendarDay';
+import MonthSelector from './MonthSelector';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 import isSameDay from '../utils/isSameDay';
@@ -30,12 +31,15 @@ const propTypes = forbidExtraProps({
   month: momentPropTypes.momentObj,
   isVisible: PropTypes.bool,
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
   daySize: nonNegativeInteger,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  onMonthSelect: PropTypes.func,
+  onYearSelect: PropTypes.func,
   renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
 
@@ -51,12 +55,15 @@ const defaultProps = {
   month: moment(),
   isVisible: true,
   enableOutsideDays: false,
+  enableDropdowns: false,
   modifiers: {},
   orientation: HORIZONTAL_ORIENTATION,
   daySize: DAY_SIZE,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  onMonthSelect() {},
+  onYearSelect() {},
   renderMonth: null,
   renderDay: null,
 
@@ -91,6 +98,7 @@ export default class CalendarMonth extends React.Component {
 
   render() {
     const {
+      enableDropdowns,
       month,
       monthFormat,
       orientation,
@@ -99,6 +107,8 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      onMonthSelect,
+      onYearSelect,
       renderMonth,
       renderDay,
       daySize,
@@ -119,10 +129,21 @@ export default class CalendarMonth extends React.Component {
     return (
       <div className={calendarMonthClasses} data-visible={isVisible}>
         <table>
-          <caption className="CalendarMonth__caption js-CalendarMonth__caption">
-            <strong>{monthTitle}</strong>
-          </caption>
-
+          {enableDropdowns &&
+            <caption className="CalendarMonth__caption js-CalendarMonth__caption">
+              <MonthSelector
+                month={month}
+                onYearSelect={onYearSelect}
+                onMonthSelect={onMonthSelect}
+                phrases={phrases}
+              />
+            </caption>
+          }
+          {!enableDropdowns &&
+            <caption className="CalendarMonth__caption js-CalendarMonth__caption">
+              <strong>{monthTitle}</strong>
+            </caption>
+          }
           <tbody className="js-CalendarMonth__grid">
             {weeks.map((week, i) => (
               <tr key={i}>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -16,7 +16,8 @@ import isTransitionEndSupported from '../utils/isTransitionEndSupported';
 import getTransformStyles from '../utils/getTransformStyles';
 import getCalendarMonthWidth from '../utils/getCalendarMonthWidth';
 import toISOMonthString from '../utils/toISOMonthString';
-import isAfterDay from '../utils/isAfterDay';
+import isPrevMonth from '../utils/isPrevMonth';
+import isNextMonth from '../utils/isNextMonth';
 
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 
@@ -29,6 +30,7 @@ import {
 
 const propTypes = forbidExtraProps({
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   firstVisibleMonthIndex: PropTypes.number,
   initialMonth: momentPropTypes.momentObj,
   isAnimating: PropTypes.bool,
@@ -39,6 +41,8 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
+  onMonthChange: PropTypes.func,
+  onYearChange: PropTypes.func,
   renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
@@ -53,6 +57,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   enableOutsideDays: false,
+  enableDropdowns: false,
   firstVisibleMonthIndex: 0,
   initialMonth: moment(),
   isAnimating: false,
@@ -62,6 +67,8 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  onMonthChange() {},
+  onYearChange() {},
   onMonthTransitionEnd() {},
   renderMonth: null,
   renderDay: null,
@@ -98,6 +105,8 @@ export default class CalendarMonthGrid extends React.Component {
 
     this.isTransitionEndSupported = isTransitionEndSupported();
     this.onTransitionEnd = this.onTransitionEnd.bind(this);
+    this.onMonthSelect = this.onMonthSelect.bind(this);
+    this.onYearSelect = this.onYearSelect.bind(this);
   }
 
   componentDidMount() {
@@ -117,12 +126,15 @@ export default class CalendarMonthGrid extends React.Component {
     let newMonths = months;
 
     if (hasMonthChanged && !hasNumberOfMonthsChanged) {
-      if (isAfterDay(initialMonth, this.props.initialMonth)) {
+      if (isNextMonth(this.props.initialMonth, initialMonth)) {
         newMonths = months.slice(1);
         newMonths.push(months[months.length - 1].clone().add(1, 'month'));
-      } else {
+      } else if (isPrevMonth(this.props.initialMonth, initialMonth)) {
         newMonths = months.slice(0, months.length - 1);
         newMonths.unshift(months[0].clone().subtract(1, 'month'));
+      } else {
+        const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+        newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
       }
     }
 
@@ -158,9 +170,36 @@ export default class CalendarMonthGrid extends React.Component {
     this.props.onMonthTransitionEnd();
   }
 
+  onMonthSelect(currentMonth, newMonthVal) {
+    const newMonth = currentMonth.clone();
+    const { orientation } = this.props;
+    const { months } = this.state;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    let initialMonthSubtraction = months.indexOf(currentMonth);
+    if (!withoutTransitionMonths) {
+      initialMonthSubtraction -= 1;
+    }
+    newMonth.set('month', newMonthVal).subtract(initialMonthSubtraction, 'months');
+    this.props.onMonthChange(newMonth);
+  }
+
+  onYearSelect(currentMonth, newYearVal) {
+    const newMonth = currentMonth.clone();
+    const { orientation } = this.props;
+    const { months } = this.state;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    let initialMonthSubtraction = months.indexOf(currentMonth);
+    if (!withoutTransitionMonths) {
+      initialMonthSubtraction -= 1;
+    }
+    newMonth.set('year', newYearVal).subtract(initialMonthSubtraction, 'months');
+    this.props.onYearChange(newMonth);
+  }
+
   render() {
     const {
       enableOutsideDays,
+      enableDropdowns,
       firstVisibleMonthIndex,
       isAnimating,
       modifiers,
@@ -220,12 +259,15 @@ export default class CalendarMonthGrid extends React.Component {
               month={month}
               isVisible={isVisible}
               enableOutsideDays={enableOutsideDays}
+              enableDropdowns={enableDropdowns}
               modifiers={modifiers[monthString]}
               monthFormat={monthFormat}
               orientation={orientation}
               onDayMouseEnter={onDayMouseEnter}
               onDayMouseLeave={onDayMouseLeave}
               onDayClick={onDayClick}
+              onMonthSelect={this.onMonthSelect}
+              onYearSelect={this.onYearSelect}
               renderMonth={renderMonth}
               renderDay={renderDay}
               daySize={daySize}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -84,6 +84,7 @@ const defaultProps = {
   renderDay: null,
   minimumNights: 1,
   enableOutsideDays: false,
+  enableDropdowns: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
@@ -298,6 +299,7 @@ export default class DateRangePicker extends React.Component {
       withFullScreenPortal,
       daySize,
       enableOutsideDays,
+      enableDropdowns,
       focusedInput,
       startDate,
       endDate,
@@ -333,6 +335,7 @@ export default class DateRangePicker extends React.Component {
           ref={(ref) => { this.dayPicker = ref; }}
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
+          enableDropdowns={enableDropdowns}
           numberOfMonths={numberOfMonths}
           onPrevMonthClick={onPrevMonthClick}
           onNextMonthClick={onNextMonthClick}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -38,10 +38,13 @@ const MONTH_PADDING = 23;
 const DAY_PICKER_PADDING = 9;
 const PREV_TRANSITION = 'prev';
 const NEXT_TRANSITION = 'next';
+const MONTH_SELECTION_TRANSITION = 'month_selection';
+const YEAR_SELECTION_TRANSITION = 'year_selection';
 
 const propTypes = forbidExtraProps({
   // calendar presentation props
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
@@ -58,6 +61,8 @@ const propTypes = forbidExtraProps({
   navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onMonthChange: PropTypes.func,
+  onYearChange: PropTypes.func,
   onMultiplyScrollableMonths: PropTypes.func, // VERTICAL_SCROLLABLE daypickers only
 
   // month props
@@ -84,6 +89,7 @@ const propTypes = forbidExtraProps({
 export const defaultProps = {
   // calendar presentation props
   enableOutsideDays: false,
+  enableDropdowns: false,
   numberOfMonths: 2,
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
@@ -100,6 +106,8 @@ export const defaultProps = {
   navNext: null,
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  onMonthChange() {},
+  onYearChange() {},
   onMultiplyScrollableMonths() {},
 
   // month props
@@ -210,6 +218,8 @@ export default class DayPicker extends React.Component {
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.setCalendarMonthGridRef = this.setCalendarMonthGridRef.bind(this);
+    this.onMonthChange = this.onMonthChange.bind(this);
+    this.onYearChange = this.onYearChange.bind(this);
     this.multiplyScrollableMonths = this.multiplyScrollableMonths.bind(this);
     this.updateStateAfterMonthTransition = this.updateStateAfterMonthTransition.bind(this);
 
@@ -409,6 +419,30 @@ export default class DayPicker extends React.Component {
     });
   }
 
+  onMonthChange(currentMonth) {
+    // Translation value is a hack to force an invisible transition that
+    // properly rerenders the CalendarMonthGrid
+    this.setState({
+      monthTransition: MONTH_SELECTION_TRANSITION,
+      translationValue: 0.00001,
+      focusedDate: null,
+      nextFocusedDate: currentMonth,
+      currentMonth,
+    });
+  }
+
+  onYearChange(currentMonth) {
+    // Translation value is a hack to force an invisible transition that
+    // properly rerenders the CalendarMonthGrid
+    this.setState({
+      monthTransition: YEAR_SELECTION_TRANSITION,
+      translationValue: 0.0001,
+      focusedDate: null,
+      nextFocusedDate: currentMonth,
+      currentMonth,
+    });
+  }
+
   onNextMonthClick(nextFocusedDate, e) {
     const { isRTL } = this.props;
 
@@ -520,6 +554,8 @@ export default class DayPicker extends React.Component {
     const {
       onPrevMonthClick,
       onNextMonthClick,
+      onMonthChange,
+      onYearChange,
     } = this.props;
 
     const {
@@ -539,6 +575,10 @@ export default class DayPicker extends React.Component {
     } else if (monthTransition === NEXT_TRANSITION) {
       if (onNextMonthClick) onNextMonthClick();
       newMonth.add(1, 'month');
+    } else if (monthTransition === MONTH_SELECTION_TRANSITION) {
+      if (onMonthChange) onMonthChange(newMonth);
+    } else if (monthTransition === YEAR_SELECTION_TRANSITION) {
+      if (onYearChange) onYearChange(newMonth);
     }
 
     let newFocusedDate = null;
@@ -718,6 +758,7 @@ export default class DayPicker extends React.Component {
 
     const {
       enableOutsideDays,
+      enableDropdowns,
       numberOfMonths,
       orientation,
       modifiers,
@@ -828,6 +869,7 @@ export default class DayPicker extends React.Component {
                 ref={this.setCalendarMonthGridRef}
                 transformValue={transformValue}
                 enableOutsideDays={enableOutsideDays}
+                enableDropdowns={enableDropdowns}
                 firstVisibleMonthIndex={firstVisibleMonthIndex}
                 initialMonth={currentMonth}
                 isAnimating={isCalendarMonthGridAnimating}
@@ -837,6 +879,8 @@ export default class DayPicker extends React.Component {
                 onDayClick={onDayClick}
                 onDayMouseEnter={onDayMouseEnter}
                 onDayMouseLeave={onDayMouseLeave}
+                onMonthChange={this.onMonthChange}
+                onYearChange={this.onYearChange}
                 renderMonth={renderMonth}
                 renderDay={renderDay}
                 onMonthTransitionEnd={this.updateStateAfterMonthTransition}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -53,6 +53,7 @@ const propTypes = forbidExtraProps({
   // DayPicker props
   renderMonth: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   numberOfMonths: PropTypes.number,
   orientation: ScrollableOrientationShape,
   withPortal: PropTypes.bool,
@@ -65,6 +66,8 @@ const propTypes = forbidExtraProps({
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onMonthChange: PropTypes.func,
+  onYearChange: PropTypes.func,
   onOutsideClick: PropTypes.func,
   renderDay: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
@@ -99,6 +102,7 @@ const defaultProps = {
   // DayPicker props
   renderMonth: null,
   enableOutsideDays: false,
+  enableDropdowns: false,
   numberOfMonths: 1,
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
@@ -111,6 +115,8 @@ const defaultProps = {
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  onMonthChange() {},
+  onYearChange() {},
   onOutsideClick() {},
 
   renderDay: null,
@@ -165,6 +171,8 @@ export default class DayPickerRangeController extends React.Component {
     this.onDayMouseLeave = this.onDayMouseLeave.bind(this);
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
+    this.onMonthChange = this.onMonthChange.bind(this);
+    this.onYearChange = this.onYearChange.bind(this);
     this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
@@ -523,6 +531,30 @@ export default class DayPickerRangeController extends React.Component {
     onNextMonthClick();
   }
 
+  onMonthChange(newMonth) {
+    const { numberOfMonths, enableOutsideDays, orientation } = this.props;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    const newVisibleDays =
+      getVisibleDays(newMonth, numberOfMonths, enableOutsideDays, withoutTransitionMonths);
+
+    this.setState({
+      currentMonth: newMonth.clone(),
+      visibleDays: this.getModifiers(newVisibleDays),
+    });
+  }
+
+  onYearChange(newMonth) {
+    const { numberOfMonths, enableOutsideDays, orientation } = this.props;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    const newVisibleDays =
+      getVisibleDays(newMonth, numberOfMonths, enableOutsideDays, withoutTransitionMonths);
+
+    this.setState({
+      currentMonth: newMonth.clone(),
+      visibleDays: this.getModifiers(newVisibleDays),
+    });
+  }
+
   onMultiplyScrollableMonths() {
     const { numberOfMonths, enableOutsideDays } = this.props;
     const { currentMonth, visibleDays } = this.state;
@@ -766,6 +798,7 @@ export default class DayPickerRangeController extends React.Component {
       onOutsideClick,
       withPortal,
       enableOutsideDays,
+      enableDropdowns,
       initialVisibleMonth,
       hideKeyboardShortcutsPanel,
       daySize,
@@ -785,6 +818,7 @@ export default class DayPickerRangeController extends React.Component {
         ref={(ref) => { this.dayPicker = ref; }}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
+        enableDropdowns={enableDropdowns}
         modifiers={visibleDays}
         numberOfMonths={numberOfMonths}
         onDayClick={this.onDayClick}
@@ -792,6 +826,8 @@ export default class DayPickerRangeController extends React.Component {
         onDayMouseLeave={this.onDayMouseLeave}
         onPrevMonthClick={this.onPrevMonthClick}
         onNextMonthClick={this.onNextMonthClick}
+        onMonthChange={this.onMonthChange}
+        onYearChange={this.onYearChange}
         onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
         monthFormat={monthFormat}
         renderMonth={renderMonth}

--- a/src/components/MonthSelector.jsx
+++ b/src/components/MonthSelector.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import shallowCompare from 'react-addons-shallow-compare';
+import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
+import moment from 'moment';
+import cx from 'classnames';
+
+import { CalendarDayPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
+const propTypes = forbidExtraProps({
+  month: momentPropTypes.momentObj,
+  onMonthSelect: PropTypes.func,
+  onYearSelect: PropTypes.func,
+
+  // internationalization
+  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+});
+
+const defaultProps = {
+  month: moment(),
+  onMonthSelect() {},
+  onYearSelect() {},
+
+  // internationalization
+  phrases: CalendarDayPhrases,
+};
+
+export default class MonthSelector extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  render() {
+    const {
+      month,
+      onMonthSelect,
+      onYearSelect,
+    } = this.props;
+
+    const className = cx('MonthSelector');
+    const selectableYears = [];
+    const currentYear = month.get('year');
+    for (let i = 50; i >= 1; i -= 1) {
+      selectableYears.push(currentYear - i);
+    }
+    selectableYears.push(currentYear);
+    for (let i = 1; i <= 5; i += 1) {
+      selectableYears.push(currentYear + i);
+    }
+
+    return (
+      <div className={className}>
+        <select onChange={e => onMonthSelect(month, e.target.value)} value={month.get('month')} className="MonthSelector__month_select">
+          <option value={0}>January</option>
+          <option value={1}>February</option>
+          <option value={2}>March</option>
+          <option value={3}>April</option>
+          <option value={4}>May</option>
+          <option value={5}>June</option>
+          <option value={6}>July</option>
+          <option value={7}>August</option>
+          <option value={8}>September</option>
+          <option value={9}>October</option>
+          <option value={10}>November</option>
+          <option value={11}>December</option>
+        </select>
+        <select onChange={e => onYearSelect(month, e.target.value)} value={month.get('year')} className="MonthSelector__year_select">
+          {selectableYears.map(year => (
+            <option value={year} key={year}>{year}</option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+}
+
+MonthSelector.propTypes = propTypes;
+MonthSelector.defaultProps = defaultProps;

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -87,6 +87,7 @@ const defaultProps = {
   // day presentation and interaction related props
   renderDay: null,
   enableOutsideDays: false,
+  enableDropdowns: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => {},
@@ -658,6 +659,7 @@ export default class SingleDatePicker extends React.Component {
   renderDayPicker() {
     const {
       enableOutsideDays,
+      enableDropdowns,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -690,6 +692,7 @@ export default class SingleDatePicker extends React.Component {
         <DayPicker
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
+          enableDropdowns={enableDropdowns}
           modifiers={visibleDays}
           numberOfMonths={numberOfMonths}
           onDayClick={this.onDayClick}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -62,6 +62,7 @@ export default {
   renderDay: PropTypes.func,
   minimumNights: PropTypes.number,
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
   isDayHighlighted: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -55,6 +55,7 @@ export default {
   // day presentation and interaction related props
   renderDay: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
+  enableDropdowns: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
   isDayHighlighted: PropTypes.func,

--- a/src/utils/isNextMonth.js
+++ b/src/utils/isNextMonth.js
@@ -1,0 +1,6 @@
+import moment from 'moment';
+
+export default function isNextMonth(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+  return b.isSame(a.clone().add(1, 'month'), 'month');
+}

--- a/src/utils/isPrevMonth.js
+++ b/src/utils/isPrevMonth.js
@@ -1,0 +1,6 @@
+import moment from 'moment';
+
+export default function isPrevMonth(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+  return b.isSame(a.clone().subtract(1, 'month'), 'month');
+}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -109,6 +109,11 @@ storiesOf('DRP - Calendar Props', module)
       autoFocus
     />
   ))
+  .addWithInfo('with month selection dropdowns', () => (
+    <DateRangePickerWrapper
+      enableDropdowns
+    />
+  ))
   .addWithInfo('with outside days enabled', () => (
     <DateRangePickerWrapper
       numberOfMonths={1}

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -90,6 +90,11 @@ storiesOf('DayPicker', module)
       navNext={<TestNextIcon />}
     />
   ))
+  .addWithInfo('with month selection dropdowns', () => (
+    <DayPicker
+      enableDropdowns
+    />
+  ))
   .addWithInfo('with custom details', () => (
     <DayPicker
       renderDay={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -159,6 +159,14 @@ storiesOf('DayPickerRangeController', module)
       navNext={<TestNextIcon />}
     />
   ))
+  .addWithInfo('with month selection dropdowns', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      enableDropdowns
+    />
+  ))
   .addWithInfo('with outside days enabled', () => (
     <DayPickerRangeControllerWrapper
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -113,6 +113,12 @@ storiesOf('SDP - Calendar Props', module)
       autoFocus
     />
   ))
+  .addWithInfo('with month selection dropdowns', () => (
+    <SingleDatePickerWrapper
+      enableDropdowns
+      autoFocus
+    />
+  ))
   .addWithInfo('with info panel', () => (
     <SingleDatePickerWrapper
       renderCalendarInfo={() => (

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
 import CalendarMonth from '../../src/components/CalendarMonth';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
 
-import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
+import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE } from '../../constants';
 
 import getTransformStyles from '../../src/utils/getTransformStyles';
 
@@ -96,5 +97,97 @@ describe('CalendarMonthGrid', () => {
       ), {});
 
     expect(Object.keys(collisions).length).to.equal(months.length);
+  });
+
+  describe('#onMonthSelect', () => {
+    describe('has transitionMonths', () => {
+      it('calls onMonthChange with the month that should render first', () => {
+        const onMonthChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <CalendarMonthGrid
+            orientation={HORIZONTAL_ORIENTATION}
+            onMonthChange={onMonthChangeStub}
+          />,
+        );
+        const month1 = moment();
+        const month2 = moment().add(1, 'months');
+        const month3 = moment().add(2, 'months');
+        const months = [month1, month2, month3];
+        wrapper.setState({
+          months,
+        });
+        wrapper.instance().onMonthSelect(month3, 10);
+        const calledWithDate = month3.set('month', 10).subtract('1', 'months');
+        expect(onMonthChangeStub.calledWith(calledWithDate)).to.equal(true);
+      });
+    });
+
+    describe('doesnt have transitionMonths', () => {
+      it('calls onMonthChange with the month that should render first', () => {
+        const onMonthChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <CalendarMonthGrid
+            orientation={VERTICAL_SCROLLABLE}
+            onMonthChange={onMonthChangeStub}
+          />,
+        );
+        const month1 = moment();
+        const month2 = moment().add(1, 'months');
+        const month3 = moment().add(2, 'months');
+        const months = [month1, month2, month3];
+        wrapper.instance().setState({
+          months,
+        });
+        wrapper.instance().onMonthSelect(month3, 10);
+        const calledWithDate = month3.set('month', 10).subtract('2', 'months');
+        expect(onMonthChangeStub.calledWith(calledWithDate)).to.equal(true);
+      });
+    });
+  });
+
+  describe('#onYearSelect', () => {
+    describe('has transitionMonths', () => {
+      it('calls onYearChange with the month that should render first', () => {
+        const onYearChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <CalendarMonthGrid
+            orientation={HORIZONTAL_ORIENTATION}
+            onYearChange={onYearChangeStub}
+          />,
+        );
+        const month1 = moment();
+        const month2 = moment().add(1, 'months');
+        const month3 = moment().add(2, 'months');
+        const months = [month1, month2, month3];
+        wrapper.setState({
+          months,
+        });
+        wrapper.instance().onYearSelect(month3, '1999');
+        const calledWithDate = month3.set('year', '1999').subtract('1', 'months');
+        expect(onYearChangeStub.calledWith(calledWithDate)).to.equal(true);
+      });
+    });
+
+    describe('doesnt have transitionMonths', () => {
+      it('calls onMonthChange with the month that should render first', () => {
+        const onYearChangeStub = sinon.stub();
+        const wrapper = shallow(
+          <CalendarMonthGrid
+            orientation={VERTICAL_SCROLLABLE}
+            onYearChange={onYearChangeStub}
+          />,
+        );
+        const month1 = moment();
+        const month2 = moment().add(1, 'months');
+        const month3 = moment().add(2, 'months');
+        const months = [month1, month2, month3];
+        wrapper.setState({
+          months,
+        });
+        wrapper.instance().onYearSelect(month3, '1999');
+        const calledWithDate = month3.set('year', '1999').subtract('2', 'months');
+        expect(onYearChangeStub.calledWith(calledWithDate)).to.equal(true);
+      });
+    });
   });
 });

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -39,6 +39,18 @@ describe('CalendarMonth', () => {
       });
     });
 
+    describe('monthSelector', () => {
+      it('shows the month as a string by default', () => {
+        const wrapper = shallow(<CalendarMonth />);
+        expect(wrapper.find('MonthSelector')).to.have.lengthOf(0);
+      });
+
+      it('shows the month selector dropdowns when enabledDropdowns is true', () => {
+        const wrapper = shallow(<CalendarMonth enableDropdowns />);
+        expect(wrapper.find('MonthSelector')).to.have.lengthOf(1);
+      });
+    });
+
     describe('caption', () => {
       it('.CalendarMonth__caption class is present', () => {
         const caption = shallow(<CalendarMonth />).find('caption');

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1986,6 +1986,60 @@ describe('DayPickerRangeController', () => {
     });
   });
 
+  describe('#onMonthChange', () => {
+    it('updates state.currentMonth to be the passed month', () => {
+      const wrapper = shallow(
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      const date = moment().add('10', 'months');
+      wrapper.instance().onMonthChange(date);
+      expect(wrapper.state().currentMonth.isSame(date)).to.equal(true);
+    });
+
+    it('updates state.visibleDays to include the given date', () => {
+      const wrapper = shallow(
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      const date = moment().add('10', 'months');
+      wrapper.instance().onMonthChange(date);
+      const visibleDays = Object.keys(wrapper.state().visibleDays);
+      expect(visibleDays).to.include(toISOMonthString(date));
+    });
+  });
+
+  describe('#onYearChange', () => {
+    it('updates state.currentYear to be the passed date', () => {
+      const wrapper = shallow(
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      const date = moment().add('2', 'years');
+      wrapper.instance().onYearChange(date);
+      expect(wrapper.state().currentMonth.isSame(date)).to.equal(true);
+    });
+
+    it('updates state.visibleDays to include the given date', () => {
+      const wrapper = shallow(
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />,
+      );
+      const date = moment().add('2', 'years');
+      wrapper.instance().onYearChange(date);
+      const visibleDays = Object.keys(wrapper.state().visibleDays);
+      expect(visibleDays).to.include(toISOMonthString(date));
+    });
+  });
+
   describe('#onNextMonthClick', () => {
     it('updates state.currentMonth to add 1 month', () => {
       const wrapper = shallow(

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -453,6 +453,50 @@ describe('DayPicker', () => {
     });
   });
 
+  describe('#onMonthChange', () => {
+    it('sets state.monthTransition to "month_selection"', () => {
+      const wrapper = shallow(<DayPicker />);
+      wrapper.instance().onMonthChange();
+      expect(wrapper.state().monthTransition).to.equal('month_selection');
+    });
+
+    it('sets state.nextFocusedDate to passed in date', () => {
+      const wrapper = shallow(<DayPicker />);
+      const date = moment();
+      wrapper.instance().onMonthChange(date);
+      expect(wrapper.state().nextFocusedDate).to.equal(date);
+    });
+
+    it('sets state.currentMonth to passed in month', () => {
+      const wrapper = shallow(<DayPicker />);
+      const date = moment();
+      wrapper.instance().onMonthChange(date);
+      expect(wrapper.state().currentMonth).to.equal(date);
+    });
+  });
+
+  describe('#onYearChange', () => {
+    it('sets state.yearTransition to "year_selection"', () => {
+      const wrapper = shallow(<DayPicker />);
+      wrapper.instance().onYearChange();
+      expect(wrapper.state().monthTransition).to.equal('year_selection');
+    });
+
+    it('sets state.nextFocusedDate to passed in date', () => {
+      const wrapper = shallow(<DayPicker />);
+      const date = moment();
+      wrapper.instance().onYearChange(date);
+      expect(wrapper.state().nextFocusedDate).to.equal(date);
+    });
+
+    it('sets state.currentMonth to passed in year', () => {
+      const wrapper = shallow(<DayPicker />);
+      const date = moment();
+      wrapper.instance().onYearChange(date);
+      expect(wrapper.state().currentMonth).to.equal(date);
+    });
+  });
+
   describe('#onPrevMonthClick', () => {
     let translateFirstDayPickerForAnimationSpy;
     beforeEach(() => {

--- a/test/components/MonthSelector_spec.jsx
+++ b/test/components/MonthSelector_spec.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon-sandbox';
+import { shallow } from 'enzyme';
+import moment from 'moment';
+
+import MonthSelector from '../../src/components/MonthSelector';
+
+describe('MonthSelector', () => {
+  describe('#render', () => {
+    it('chooses the current month by default', () => {
+      const date = moment('2016-02-20');
+      const wrapper = shallow(
+        <MonthSelector month={date} />,
+      );
+      expect(wrapper.find('.MonthSelector__month_select').prop('value')).to.equal(1);
+    });
+
+    it('chooses the current year by default', () => {
+      const date = moment('2016-02-20');
+      const wrapper = shallow(
+        <MonthSelector month={date} />,
+      );
+      expect(wrapper.find('.MonthSelector__year_select').prop('value')).to.equal(2016);
+    });
+
+    describe('month select button', () => {
+      it('has .MonthSelector__month_select class', () => {
+        const wrapper = shallow(<MonthSelector />);
+        expect(wrapper.find('.MonthSelector__month_select')).to.have.lengthOf(1);
+      });
+
+      it('has options for all months', () => {
+        const wrapper = shallow(<MonthSelector />);
+        expect(wrapper.find('.MonthSelector__month_select option')).to.have.lengthOf(12);
+      });
+
+      it('has the proper month first', () => {
+        const wrapper = shallow(<MonthSelector />);
+        const option = wrapper.find('.MonthSelector__month_select option').first();
+        expect(option.prop('value')).to.equal(0);
+        expect(option.text()).to.equal('January');
+      });
+
+      it('has the proper month last', () => {
+        const wrapper = shallow(<MonthSelector />);
+        const option = wrapper.find('.MonthSelector__month_select option').last();
+        expect(option.prop('value')).to.equal(11);
+        expect(option.text()).to.equal('December');
+      });
+    });
+
+    describe('year select button', () => {
+      it('has .MonthSelector__year_select class', () => {
+        const wrapper = shallow(<MonthSelector />);
+        expect(wrapper.find('.MonthSelector__year_select')).to.have.lengthOf(1);
+      });
+
+      it('has options for 56 years', () => {
+        const wrapper = shallow(<MonthSelector />);
+        expect(wrapper.find('.MonthSelector__year_select option')).to.have.lengthOf(56);
+      });
+
+      it('has the proper year first', () => {
+        const date = moment('2016-02-20');
+        const wrapper = shallow(<MonthSelector month={date} />);
+        const option = wrapper.find('.MonthSelector__year_select option').first();
+        expect(option.prop('value')).to.equal(1966);
+        expect(option.text()).to.equal('1966');
+      });
+
+      it('has the proper year last', () => {
+        const date = moment('2016-02-20');
+        const wrapper = shallow(<MonthSelector month={date} />);
+        const option = wrapper.find('.MonthSelector__year_select option').last();
+        expect(option.prop('value')).to.equal(2021);
+        expect(option.text()).to.equal('2021');
+      });
+    });
+  });
+
+  describe('#onMonthSelect', () => {
+    it('is triggered by the selection of a month', () => {
+      const onMonthSelectStub = sinon.stub();
+      const date = moment('2016-02-20');
+      const monthSelect = shallow(
+        <MonthSelector onMonthSelect={onMonthSelectStub} month={date} />,
+      ).find('.MonthSelector__month_select');
+      monthSelect.simulate('change', { target: { value: 'month' } });
+      expect(onMonthSelectStub.calledWith(date, 'month')).to.equal(true);
+    });
+  });
+
+  describe('#onYearSelect', () => {
+    it('is triggered by the selection of a year', () => {
+      const onYearSelectStub = sinon.stub();
+      const date = moment('2016-02-20');
+      const yearSelect = shallow(
+        <MonthSelector onYearSelect={onYearSelectStub} month={date} />,
+      ).find('.MonthSelector__year_select');
+      yearSelect.simulate('change', { target: { value: 'year' } });
+      expect(onYearSelectStub.calledWith(date, 'year')).to.equal(true);
+    });
+  });
+});

--- a/test/utils/isNextMonth__spec.js
+++ b/test/utils/isNextMonth__spec.js
@@ -1,0 +1,32 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isNextMonth from '../../src/utils/isNextMonth';
+
+const today = moment();
+const nextMonth = moment().add(1, 'months');
+const twoMonths = moment().add(2, 'months');
+
+describe('isNextMonth', () => {
+  it('returns true if second argument is the next month after the first', () => {
+    expect(isNextMonth(today, nextMonth)).to.equal(true);
+  });
+
+  it('returns false if second argument is not the next month after the first', () => {
+    expect(isNextMonth(nextMonth, today)).to.equal(false);
+  });
+
+  it('returns false if second argument is more than one month after the first', () => {
+    expect(isNextMonth(today, twoMonths)).to.equal(false);
+  });
+
+  describe('non-moment arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isNextMonth(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isNextMonth(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isPrevMonth_spec.js
+++ b/test/utils/isPrevMonth_spec.js
@@ -1,0 +1,32 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isPrevMonth from '../../src/utils/isPrevMonth';
+
+const today = moment();
+const lastMonth = moment().subtract(1, 'months');
+const twoMonthsAgo = moment().subtract(2, 'months');
+
+describe('isPrevMonth', () => {
+  it('returns true if second argument is the month before the first', () => {
+    expect(isPrevMonth(today, lastMonth)).to.equal(true);
+  });
+
+  it('returns false if second argument is not the month before the first', () => {
+    expect(isPrevMonth(lastMonth, today)).to.equal(false);
+  });
+
+  it('returns false if second argument is more than one month before the first', () => {
+    expect(isPrevMonth(today, twoMonthsAgo)).to.equal(false);
+  });
+
+  describe('non-moment arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isPrevMonth(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isPrevMonth(today, 'foo')).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
This adds the feature requested in https://github.com/airbnb/react-dates/issues/25 with simple `<select>` boxes for month and year, which can be turned on with the `enableDropdowns` options. When enabled, this looks like:

<img width="702" alt="screen shot 2017-06-12 at 5 59 40 pm" src="https://user-images.githubusercontent.com/5505870/27058802-041b0456-4f99-11e7-85ac-2659655c5f4f.png">

This is my first PR to this package and the first thing I've ever really built in React, so I'm open to and appreciate all feedback
