### PR TITLE
remove shallow compare in favor of PureComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "nyc": "^10.3.2",
     "raw-loader": "^0.5.1",
     "react": "^15.5.4",
-    "react-addons-shallow-compare": "^15.5.2",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
     "react-svg-loader": "^1.1.1",
@@ -114,9 +113,8 @@
   },
   "peerDependencies": {
     "moment": "^2.18.1",
-    "react": ">=0.14",
-    "react-dom": ">=0.14",
-    "react-addons-shallow-compare": ">=0.14"
+    "react": ">=15.3.0",
+    "react-dom": ">=15.3.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
@@ -44,10 +43,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-export default class CalendarDay extends React.Component {
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
+export default class CalendarDay extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
@@ -68,7 +67,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-export default class CalendarMonth extends React.Component {
+export default class CalendarMonth extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -83,10 +82,6 @@ export default class CalendarMonth extends React.Component {
         weeks: getCalendarMonthWeeks(month, enableOutsideDays),
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   render() {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
@@ -88,7 +87,7 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
   return months;
 }
 
-export default class CalendarMonthGrid extends React.Component {
+export default class CalendarMonthGrid extends React.PureComponent {
   constructor(props) {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
@@ -134,10 +133,6 @@ export default class CalendarMonthGrid extends React.Component {
     this.setState({
       months: newMonths,
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate() {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import cx from 'classnames';
 import Portal from 'react-portal';
@@ -94,7 +93,7 @@ const defaultProps = {
   phrases: DateRangePickerPhrases,
 };
 
-export default class DateRangePicker extends React.Component {
+export default class DateRangePicker extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -131,10 +130,6 @@ export default class DateRangePicker extends React.Component {
     }
 
     this.isTouchDevice = isTouchDevice();
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import ReactDOM from 'react-dom';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import moment from 'moment';
@@ -177,7 +176,7 @@ function getMonthHeight(el) {
   );
 }
 
-export default class DayPicker extends React.Component {
+export default class DayPicker extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -270,10 +269,6 @@ export default class DayPicker extends React.Component {
         this.setState({ focusedDate: null });
       }
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
React 15.3 introduces PureComponent making shallowCompare a legacy add-on if favor of React.PureComponent.
https://facebook.github.io/react/docs/shallow-compare.html

This removes that dependency and uses PureComponent where shallow compare was used.