### PR TITLE
Bugfix - clear modifiers on invisible dates hidden from the view

### DIFF
--- a/src/utils/isDayVisible.js
+++ b/src/utils/isDayVisible.js
@@ -2,11 +2,11 @@ import isBeforeDay from './isBeforeDay';
 import isAfterDay from './isAfterDay';
 
 export default function isDayVisible(day, month, numberOfMonths, enableOutsideDays) {
-  let firstDayOfFirstMonth = month.clone().startOf('month');
+  let firstDayOfFirstMonth = month.clone().subtract(1, 'month').startOf('month');
   if (enableOutsideDays) firstDayOfFirstMonth = firstDayOfFirstMonth.startOf('week');
   if (isBeforeDay(day, firstDayOfFirstMonth)) return false;
 
-  let lastDayOfLastMonth = month.clone().add(numberOfMonths - 1, 'months').endOf('month');
+  let lastDayOfLastMonth = month.clone().add(numberOfMonths, 'months').endOf('month');
   if (enableOutsideDays) lastDayOfLastMonth = lastDayOfLastMonth.endOf('week');
   return !isAfterDay(day, lastDayOfLastMonth);
 }

--- a/test/utils/isDayVisible_spec.js
+++ b/test/utils/isDayVisible_spec.js
@@ -10,15 +10,17 @@ describe('#isDayVisible', () => {
     expect(isDayVisible(test, currentMonth, 2)).to.equal(true);
   });
 
-  it('returns false if arg is before first month', () => {
+  it('returns false if arg is before the visible months', () => {
+    const numberOfMonths = 2;
     const test = moment().add(1, 'months');
-    const currentMonth = moment().add(2, 'months');
-    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+    const currentMonth = moment().add(1 + numberOfMonths, 'months');
+    expect(isDayVisible(test, currentMonth, numberOfMonths)).to.equal(false);
   });
 
-  it('returns false if arg is after last month', () => {
+  it('returns false if arg is after the visible months', () => {
+    const numberOfMonths = 2;
     const test = moment().add(4, 'months');
-    const currentMonth = moment().add(2, 'months');
-    expect(isDayVisible(test, currentMonth, 2)).to.equal(false);
+    const currentMonth = moment().add(4 - (numberOfMonths + 1), 'months');
+    expect(isDayVisible(test, currentMonth, numberOfMonths)).to.equal(false);
   });
 });


### PR DESCRIPTION
Fix for https://github.com/airbnb/react-dates/issues/567

Summary:
I noticed if I had made a selection, then moved the calendar over (future or past, didn't mater) one month, so that the selection was still in the DOM, it was just invisible, (We're keeping track of one month in the future and past) it wouldn't actually clear those selections if I made a new one.

This change properly accounts for those 'hidden' months, and ensures that we update any modifiers accordingly.

Here's a good GIF that should help explain:
![](https://user-images.githubusercontent.com/1081965/27149206-cf248460-5110-11e7-8306-79012288da0a.gif)

