### PR TITLE
Reset modifiers for neighboring months

### DIFF
--- a/src/utils/isDayVisible.js
+++ b/src/utils/isDayVisible.js
@@ -2,11 +2,11 @@ import isBeforeDay from './isBeforeDay';
 import isAfterDay from './isAfterDay';
 
 export default function isDayVisible(day, month, numberOfMonths, enableOutsideDays) {
-  let firstDayOfFirstMonth = month.clone().startOf('month');
+  let firstDayOfFirstMonth = month.clone().subtract(1, "month").startOf('month');
   if (enableOutsideDays) firstDayOfFirstMonth = firstDayOfFirstMonth.startOf('week');
   if (isBeforeDay(day, firstDayOfFirstMonth)) return false;
 
-  let lastDayOfLastMonth = month.clone().add(numberOfMonths - 1, 'months').endOf('month');
+  let lastDayOfLastMonth = month.clone().add(numberOfMonths, 'months').endOf('month');
   if (enableOutsideDays) lastDayOfLastMonth = lastDayOfLastMonth.endOf('week');
   return !isAfterDay(day, lastDayOfLastMonth);
 }


### PR DESCRIPTION
Hi.

This references to the https://github.com/airbnb/react-dates/issues/589. Right now I did not find a better solution for me and fix it through workaround in `isDayVisible` — capture there ±1 neighboring invisible month.

It failing tests right now. I'm sure there is a better solution and I opened this request to start a discussion.