### PR TITLE
Fix for initialVisibleMonth in DayPickerRangeController (#613)

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -7,7 +7,6 @@ import moment from 'moment';
 import omit from 'lodash/omit';
 
 import DayPickerRangeController from '../src/components/DayPickerRangeController';
-import { defaultProps as DayPickerDefaultProps } from '../src/components/DayPicker';
 
 import ScrollableOrientationShape from '../src/shapes/ScrollableOrientationShape';
 
@@ -65,7 +64,7 @@ const defaultProps = {
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
-  initialVisibleMonth: DayPickerDefaultProps.initialVisibleMonth,
+  initialVisibleMonth: null,
   numberOfMonths: 2,
   onOutsideClick() {},
   keepOpenOnDateSelect: false,

--- a/examples/DayPickerSingleDateControllerWrapper.jsx
+++ b/examples/DayPickerSingleDateControllerWrapper.jsx
@@ -7,7 +7,6 @@ import moment from 'moment';
 import omit from 'lodash/omit';
 
 import DayPickerSingleDateController from '../src/components/DayPickerSingleDateController';
-import { defaultProps as DayPickerDefaultProps } from '../src/components/DayPicker';
 
 import ScrollableOrientationShape from '../src/shapes/ScrollableOrientationShape';
 
@@ -65,7 +64,7 @@ const defaultProps = {
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
   withPortal: false,
-  initialVisibleMonth: DayPickerDefaultProps.initialVisibleMonth,
+  initialVisibleMonth: null,
   numberOfMonths: 2,
   onOutsideClick() {},
   keepOpenOnDateSelect: false,

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -806,8 +806,6 @@ export default class DayPickerRangeController extends React.Component {
       onOutsideClick,
       withPortal,
       enableOutsideDays,
-      startDate,
-      initialVisibleMonth,
       hideKeyboardShortcutsPanel,
       daySize,
       focusedInput,
@@ -819,9 +817,7 @@ export default class DayPickerRangeController extends React.Component {
       isRTL,
     } = this.props;
 
-    const { phrases, visibleDays } = this.state;
-    const initialVisibleMonthThunk =
-      initialVisibleMonth || (startDate ? () => startDate : () => moment());
+    const { currentMonth, phrases, visibleDays } = this.state;
 
     return (
       <DayPicker
@@ -840,7 +836,7 @@ export default class DayPickerRangeController extends React.Component {
         renderMonth={renderMonth}
         withPortal={withPortal}
         hidden={!focusedInput}
-        initialVisibleMonth={initialVisibleMonthThunk}
+        initialVisibleMonth={() => currentMonth}
         daySize={daySize}
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -806,6 +806,7 @@ export default class DayPickerRangeController extends React.Component {
       onOutsideClick,
       withPortal,
       enableOutsideDays,
+      startDate,
       initialVisibleMonth,
       hideKeyboardShortcutsPanel,
       daySize,
@@ -819,6 +820,8 @@ export default class DayPickerRangeController extends React.Component {
     } = this.props;
 
     const { phrases, visibleDays } = this.state;
+    const initialVisibleMonthThunk =
+      initialVisibleMonth || (startDate ? () => startDate : () => moment());
 
     return (
       <DayPicker
@@ -837,7 +840,7 @@ export default class DayPickerRangeController extends React.Component {
         renderMonth={renderMonth}
         withPortal={withPortal}
         hidden={!focusedInput}
-        initialVisibleMonth={initialVisibleMonth}
+        initialVisibleMonth={initialVisibleMonthThunk}
         daySize={daySize}
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}


### PR DESCRIPTION
Original issue:
[is initialVisibleMonth now required for DayPickerRangeController](https://github.com/airbnb/react-dates/issues/613)

Looking at the commit logs I think this [commit](https://github.com/airbnb/react-dates/commit/48dfbd1b12bfd4a3658bf639630ea74ff073fe25#diff-a5cfcc83315d3bea09a9b06437d7ee80) broke the component when initialVisibleMonth is not set on DayPickerRangeController

By changing the default prop from:
```initialVisibleMonth: DayPickerDefaultProps.initialVisibleMonth```
to
```initialVisibleMonth: null,```
as it will pass ```null``` down to the DayPicker component on render

So made the prop a function as in [DateRangePicker](https://github.com/airbnb/react-dates/blob/master/src/components/DateRangePicker.jsx#L320)