### PR TITLE
Set tab index as -1 for default and custom date icons in SingleDatePicker

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -563,6 +563,7 @@ class DateRangePicker extends React.PureComponent {
             type="button"
             onClick={this.onOutsideClick}
             aria-label={phrases.closeDatePicker}
+            tabIndex="-1"
           >
             {closeIcon}
           </button>

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -153,6 +153,7 @@ function SingleDatePickerInput({
       disabled={disabled}
       aria-label={phrases.focusStartDate}
       onClick={onFocus}
+      tabIndex="-1"
     >
       {calendarIcon}
     </button>


### PR DESCRIPTION
Currently date icons are coming in the tab navigation, which is not of any use. So, setting its tab index to -1.