### PR TITLE
Update conditions when adjustDayPickerHeight is called (new, with tests)

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -315,8 +315,15 @@ class DayPicker extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isFocused } = this.props;
+    const { orientation, daySize, isFocused } = this.props;
     const { focusedDate } = this.state;
+
+    if (
+      this.isHorizontal()
+      && (orientation !== prevProps.orientation || daySize !== prevProps.daySize)
+    ) {
+      this.adjustDayPickerHeight();
+    }
 
     if (!prevProps.isFocused && isFocused && !focusedDate) {
       this.container.focus();

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -796,6 +796,23 @@ describe('DayPicker', () => {
           expect(adjustDayPickerHeightSpy.calledTwice).to.equal(false);
         });
 
+        it('calls adjustDayPickerHeight if orientation has changed from HORIZONTAL_ORIENTATION to VERTICAL_ORIENTATION', () => {
+          const wrapper = mount(<DayPicker orientation={HORIZONTAL_ORIENTATION} />);
+          wrapper.setState({
+            orientation: VERTICAL_ORIENTATION,
+          });
+          expect(adjustDayPickerHeightSpy).to.have.property('callCount', 2);
+        });
+
+        it('calls adjustDayPickerHeight if daySize has changed', () => {
+          const wrapper = mount(<DayPicker daySize={39} orientation={HORIZONTAL_ORIENTATION} />);
+          wrapper.setState({
+            daySize: 40,
+            orientation: HORIZONTAL_ORIENTATION,
+          });
+          expect(adjustDayPickerHeightSpy).to.have.property('callCount', 2);
+        });
+
         it('calls updateStateAfterMonthTransition if state.monthTransition is truthy', () => {
           const wrapper = mount(<DayPicker orientation={HORIZONTAL_ORIENTATION} />);
           wrapper.setState({
@@ -828,6 +845,23 @@ describe('DayPicker', () => {
             monthTransition: null,
           });
           expect(adjustDayPickerHeightSpy.called).to.equal(false);
+        });
+
+        it('calls adjustDayPickerHeight if orientation has changed from VERTICAL_ORIENTATION to HORIZONTAL_ORIENTATION', () => {
+          const wrapper = mount(<DayPicker orientation={VERTICAL_ORIENTATION} />);
+          wrapper.setState({
+            orientation: HORIZONTAL_ORIENTATION,
+          });
+          expect(adjustDayPickerHeightSpy).to.have.property('callCount', 2);
+        });
+
+        it('calls adjustDayPickerHeight if daySize has changed', () => {
+          const wrapper = mount(<DayPicker daySize={39} orientation={VERTICAL_ORIENTATION} />);
+          wrapper.setState({
+            daySize: 40,
+            orientation: VERTICAL_ORIENTATION,
+          });
+          expect(adjustDayPickerHeightSpy).to.have.property('callCount', 2);
         });
 
         it('calls updateStateAfterMonthTransition if state.monthTransition is truthy', () => {


### PR DESCRIPTION
I've attempted to complete #446 - I figured it was easier to make a new fork, rather than continue on the old one in #446 - I'm also still getting used to Github, so apologies if this isn't the right approach.

* Added checks for daySize and orientation in DayPicker.componentDidUpdate() so that DayPicker height is recalculated if either of these change between renders
* Added new tests for DayPicker.componentDidUpdate

I'm happy to keep this up to date and do whatever is needed to get it merged. I need this functionality as I need to switch the orientation from horizontal to vertical on XS breakpoint changes and back again when leaving XS. Currently this results in a 0 height DayPicker when going back to horizontal.