### PR TITLE
Add custom week day format

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ isDayHighlighted: PropTypes.func,
 // internationalization props
 displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 monthFormat: PropTypes.string,
+weekDayFormat: PropTypes.string,
 phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),
 ```
 
@@ -198,6 +199,7 @@ isDayHighlighted: PropTypes.func,
 // internationalization props
 displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 monthFormat: PropTypes.string,
+weekDayFormat: PropTypes.string,
 phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerPhrases)),
 ```
 
@@ -244,6 +246,7 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
 
   // internationalization props
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
 />
 ```

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -94,6 +94,7 @@ const defaultProps = {
   // internationalization
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
   phrases: DateRangePickerPhrases,
 };
 
@@ -330,6 +331,7 @@ export default class DateRangePicker extends React.Component {
       onClose,
       phrases,
       isRTL,
+      weekDayFormat,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -382,6 +384,7 @@ export default class DateRangePicker extends React.Component {
           phrases={phrases}
           isRTL={isRTL}
           firstDayOfWeek={firstDayOfWeek}
+          weekDayFormat={weekDayFormat}
         />
 
         {withFullScreenPortal && (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -80,6 +80,7 @@ const propTypes = forbidExtraProps({
 
   // internationalization
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
 });
 
@@ -123,6 +124,7 @@ export const defaultProps = {
 
   // internationalization
   monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
   phrases: DayPickerPhrases,
 };
 
@@ -679,7 +681,7 @@ export default class DayPicker extends React.Component {
   }
 
   renderWeekHeader(index) {
-    const { daySize, orientation } = this.props;
+    const { daySize, orientation, weekDayFormat } = this.props;
     const { calendarMonthWidth } = this.state;
     const verticalScrollable = orientation === VERTICAL_SCROLLABLE;
     const horizontalStyle = {
@@ -705,7 +707,7 @@ export default class DayPicker extends React.Component {
     for (let i = 0; i < 7; i += 1) {
       header.push(
         <li key={i} style={{ width: daySize }}>
-          <small>{moment().day((i + firstDayOfWeek) % 7).format('dd')}</small>
+          <small>{moment().day((i + firstDayOfWeek) % 7).format(weekDayFormat)}</small>
         </li>,
       );
     }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -77,6 +77,7 @@ const propTypes = forbidExtraProps({
 
   // i18n
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
 
   isRTL: PropTypes.bool,
@@ -125,6 +126,7 @@ const defaultProps = {
 
   // i18n
   monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
   phrases: DayPickerPhrases,
 
   isRTL: false,
@@ -842,6 +844,7 @@ export default class DayPickerRangeController extends React.Component {
       isFocused,
       showKeyboardShortcuts,
       isRTL,
+      weekDayFormat,
     } = this.props;
 
     const { currentMonth, phrases, visibleDays } = this.state;
@@ -878,6 +881,7 @@ export default class DayPickerRangeController extends React.Component {
         showKeyboardShortcuts={showKeyboardShortcuts}
         phrases={phrases}
         isRTL={isRTL}
+        weekDayFormat={weekDayFormat}
       />
     );
   }

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -70,6 +70,7 @@ const propTypes = forbidExtraProps({
 
   // i18n
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
 
   isRTL: PropTypes.bool,
@@ -116,6 +117,7 @@ const defaultProps = {
 
   // i18n
   monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
   phrases: DayPickerPhrases,
 
   isRTL: false,
@@ -567,6 +569,7 @@ export default class DayPickerSingleDateController extends React.Component {
       onOutsideClick,
       onBlur,
       showKeyboardShortcuts,
+      weekDayFormat,
     } = this.props;
 
     const { currentMonth, visibleDays } = this.state;
@@ -600,6 +603,7 @@ export default class DayPickerSingleDateController extends React.Component {
         daySize={daySize}
         isRTL={isRTL}
         showKeyboardShortcuts={showKeyboardShortcuts}
+        weekDayFormat={weekDayFormat}
       />
     );
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -89,6 +89,7 @@ const defaultProps = {
   // internationalization props
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
   phrases: SingleDatePickerPhrases,
 };
 
@@ -338,6 +339,7 @@ export default class SingleDatePicker extends React.Component {
       isOutsideRange,
       isDayBlocked,
       isDayHighlighted,
+      weekDayFormat,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
 
@@ -379,6 +381,7 @@ export default class SingleDatePicker extends React.Component {
           isDayBlocked={isDayBlocked}
           isDayHighlighted={isDayHighlighted}
           firstDayOfWeek={firstDayOfWeek}
+          weekDayFormat={weekDayFormat}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -72,5 +72,6 @@ export default {
   // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),
 };

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -66,5 +66,6 @@ export default {
   // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   monthFormat: PropTypes.string,
+  weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerPhrases)),
 };

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -109,4 +109,9 @@ storiesOf('DayPicker', module)
         <TestCustomInfoPanel />
       )}
     />
+  ))
+  .addWithInfo('with custom week day format', () => (
+    <DayPicker
+      weekDayFormat='ddd'
+    />
   ));


### PR DESCRIPTION
Add a prop to customize the day format in the header.

Resolves #453  and #132 