### PR TITLE
Pass onNextMonthClick and onPrevMonthClick handlers down to SDP ctrl

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -308,6 +308,8 @@ export default class SingleDatePicker extends React.Component {
       monthFormat,
       navPrev,
       navNext,
+      onPrevMonthClick,
+      onNextMonthClick,
       withPortal,
       withFullScreenPortal,
       keepOpenOnDateSelect,
@@ -352,6 +354,8 @@ export default class SingleDatePicker extends React.Component {
           initialVisibleMonth={initialVisibleMonth}
           navPrev={navPrev}
           navNext={navNext}
+          onPrevMonthClick={onPrevMonthClick}
+          onNextMonthClick={onNextMonthClick}
           renderMonth={renderMonth}
           renderDay={renderDay}
           renderCalendarInfo={renderCalendarInfo}


### PR DESCRIPTION
Passing the  props: `onNextMonthClick` and `onPrevMonthClick` down to the `DayPickerSingleDateController`  to reflect the functionality of  `DateRangePicker` which passes them down to `DayPickerRangeController`

Resolves #631 

