### PR TITLE
Support changing withPortal/withFullScreenPortal

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -229,6 +229,10 @@ export default class DateRangePicker extends React.Component {
   }
 
   responsivizePickerPosition() {
+    // It's possible the portal props have been changed in response to window resizes
+    // So let's ensure we reset this back to the base state each time
+    this.setState({ dayPickerContainerStyles: {} });
+
     if (!this.isOpened()) {
       return;
     }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -246,6 +246,10 @@ export default class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   responsivizePickerPosition() {
+    // It's possible the portal props have been changed in response to window resizes
+    // So let's ensure we reset this back to the base state each time
+    this.setState({ dayPickerContainerStyles: {} });
+
     const {
       anchorDirection,
       horizontalMargin,


### PR DESCRIPTION
I am attempting to set `withFullScreenPortal` in response to the window size (so it only applies on narrow screens). Unfortunately, if `responsivizePickerPosition` is ever called in widescreen (non portal) mode, and the user shrinks the window width....it will now refrain from ever updating/clearing the `dayPickerContainerStyles` (since its a portal!). This bug causes the portal to be displayed with an offset, partially offscreen.