### PR TITLE
updating propType usage to nonNegativeInteger()

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -14,7 +14,7 @@ import { BLOCKED_MODIFIER, DAY_SIZE } from '../../constants';
 
 const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   isOutsideDay: PropTypes.bool,
   modifiers: PropTypes.instanceOf(Set),
   isFocused: PropTypes.bool,

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -33,7 +33,7 @@ const propTypes = forbidExtraProps({
   enableOutsideDays: PropTypes.bool,
   modifiers: PropTypes.object,
   orientation: ScrollableOrientationShape,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -43,7 +43,7 @@ const propTypes = forbidExtraProps({
   renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
   transformValue: PropTypes.string,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
   isFocused: PropTypes.bool, // indicates whether or not to move focus to focusable day
   firstDayOfWeek: DayOfWeekShape,

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -41,7 +41,7 @@ const propTypes = forbidExtraProps({
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
-  minimumNights: nonNegativeInteger,
+  minimumNights: nonNegativeInteger(),
   isOutsideRange: PropTypes.func,
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -52,7 +52,7 @@ const propTypes = forbidExtraProps({
   firstDayOfWeek: DayOfWeekShape,
   renderCalendarInfo: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   isRTL: PropTypes.bool,
 
   // navigation props

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -58,7 +58,7 @@ const propTypes = forbidExtraProps({
   withPortal: PropTypes.bool,
   initialVisibleMonth: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -43,7 +43,7 @@ export default {
   horizontalMargin: PropTypes.number,
   withPortal: PropTypes.bool,
   withFullScreenPortal: PropTypes.bool,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   isRTL: PropTypes.bool,
   firstDayOfWeek: DayOfWeekShape,
   initialVisibleMonth: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -43,7 +43,7 @@ export default {
   reopenPickerOnClearDate: PropTypes.bool,
   renderCalendarInfo: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
-  daySize: nonNegativeInteger,
+  daySize: nonNegativeInteger(),
   isRTL: PropTypes.bool,
 
   // navigation related props


### PR DESCRIPTION
– fixes proptype warnings

see [this comment](https://github.com/airbnb/react-dates/pull/406#discussion_r131527804) 

example:
```sh
Warning: CalendarDay: type specification of prop `daySize` is invalid; the type checker function must return `null` or an `Error` but returned a function. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).
```