### PR TITLE
Pass currentMonth into onPrevMonthClick and onNextMonthClick

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -500,7 +500,7 @@ export default class DayPickerRangeController extends React.Component {
       },
     });
 
-    onPrevMonthClick(newCurrentMonth);
+    onPrevMonthClick(newCurrentMonth.clone());
   }
 
   onNextMonthClick() {
@@ -524,7 +524,7 @@ export default class DayPickerRangeController extends React.Component {
       },
     });
 
-    onNextMonthClick(newCurrentMonth);
+    onNextMonthClick(newCurrentMonth.clone());
   }
 
   onMultiplyScrollableMonths() {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -499,7 +499,7 @@ export default class DayPickerRangeController extends React.Component {
       },
     });
 
-    onPrevMonthClick();
+    onPrevMonthClick(this.state.currentMonth.clone());
   }
 
   onNextMonthClick() {
@@ -522,7 +522,7 @@ export default class DayPickerRangeController extends React.Component {
       },
     });
 
-    onNextMonthClick();
+    onNextMonthClick(this.state.currentMonth.clone());
   }
 
   onMultiplyScrollableMonths() {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -491,15 +491,16 @@ export default class DayPickerRangeController extends React.Component {
     const prevMonth = currentMonth.clone().subtract(2, 'months');
     const prevMonthVisibleDays = getVisibleDays(prevMonth, 1, enableOutsideDays, true);
 
+    const newCurrentMonth = currentMonth.clone().subtract(1, 'month');
     this.setState({
-      currentMonth: currentMonth.clone().subtract(1, 'month'),
+      currentMonth: newCurrentMonth,
       visibleDays: {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
     });
 
-    onPrevMonthClick(this.state.currentMonth.clone());
+    onPrevMonthClick(newCurrentMonth);
   }
 
   onNextMonthClick() {
@@ -514,15 +515,16 @@ export default class DayPickerRangeController extends React.Component {
     const nextMonth = currentMonth.clone().add(numberOfMonths + 1, 'month');
     const nextMonthVisibleDays = getVisibleDays(nextMonth, 1, enableOutsideDays, true);
 
+    const newCurrentMonth = currentMonth.clone().add(1, 'month');
     this.setState({
-      currentMonth: currentMonth.clone().add(1, 'month'),
+      currentMonth: newCurrentMonth,
       visibleDays: {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
     });
 
-    onNextMonthClick(this.state.currentMonth.clone());
+    onNextMonthClick(newCurrentMonth);
   }
 
   onMultiplyScrollableMonths() {

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -331,7 +331,7 @@ export default class DayPickerSingleDateController extends React.Component {
       },
     });
 
-    onPrevMonthClick();
+    onPrevMonthClick(this.state.currentMonth.clone());
   }
 
   onNextMonthClick() {
@@ -354,7 +354,7 @@ export default class DayPickerSingleDateController extends React.Component {
       },
     });
 
-    onNextMonthClick();
+    onNextMonthClick(this.state.currentMonth.clone());
   }
 
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -331,7 +331,7 @@ export default class DayPickerSingleDateController extends React.Component {
       },
     });
 
-    onPrevMonthClick(prevMonth);
+    onPrevMonthClick(prevMonth.clone());
   }
 
   onNextMonthClick() {
@@ -355,7 +355,7 @@ export default class DayPickerSingleDateController extends React.Component {
       },
     });
 
-    onNextMonthClick(newCurrentMonth);
+    onNextMonthClick(newCurrentMonth.clone());
   }
 
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -331,7 +331,7 @@ export default class DayPickerSingleDateController extends React.Component {
       },
     });
 
-    onPrevMonthClick(this.state.currentMonth.clone());
+    onPrevMonthClick(prevMonth);
   }
 
   onNextMonthClick() {
@@ -346,15 +346,16 @@ export default class DayPickerSingleDateController extends React.Component {
     const nextMonth = currentMonth.clone().add(numberOfMonths, 'month');
     const nextMonthVisibleDays = getVisibleDays(nextMonth, 1, enableOutsideDays);
 
+    const newCurrentMonth = currentMonth.clone().add(1, 'month');
     this.setState({
-      currentMonth: currentMonth.clone().add(1, 'month'),
+      currentMonth: newCurrentMonth,
       visibleDays: {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
     });
 
-    onNextMonthClick(this.state.currentMonth.clone());
+    onNextMonthClick(newCurrentMonth);
   }
 
 

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1988,7 +1988,7 @@ describe('DayPickerRangeController', () => {
       expect(getModifiersSpy.callCount).to.equal(1);
     });
 
-    it('calls props.onPrevMonthClick', () => {
+    it('calls props.onPrevMonthClick with new month', () => {
       const onPrevMonthClickStub = sinon.stub();
       const wrapper = shallow(
         <DayPickerRangeController
@@ -1997,8 +1997,14 @@ describe('DayPickerRangeController', () => {
           onPrevMonthClick={onPrevMonthClickStub}
         />,
       );
+      wrapper.setState({
+        currentMonth: today,
+      });
+      const newMonth = moment().subtract(1, 'month');
       wrapper.instance().onPrevMonthClick();
       expect(onPrevMonthClickStub.callCount).to.equal(1);
+      expect(onPrevMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
+      expect(onPrevMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
     });
   });
 
@@ -2064,7 +2070,7 @@ describe('DayPickerRangeController', () => {
       expect(getModifiersSpy.callCount).to.equal(1);
     });
 
-    it('calls props.onNextMonthClick', () => {
+    it('calls props.onNextMonthClick with new month', () => {
       const onNextMonthClickStub = sinon.stub();
       const wrapper = shallow(
         <DayPickerRangeController
@@ -2073,8 +2079,14 @@ describe('DayPickerRangeController', () => {
           onNextMonthClick={onNextMonthClickStub}
         />,
       );
+      wrapper.setState({
+        currentMonth: today,
+      });
+      const newMonth = moment().add(1, 'month');
       wrapper.instance().onNextMonthClick();
       expect(onNextMonthClickStub.callCount).to.equal(1);
+      expect(onNextMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
+      expect(onNextMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
     });
   });
 

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -705,7 +705,7 @@ describe('DayPickerSingleDateController', () => {
       expect(getModifiersSpy.callCount).to.equal(1);
     });
 
-    it('calls props.onPrevMonthClick', () => {
+    it('calls props.onPrevMonthClick with new month', () => {
       const onPrevMonthClickStub = sinon.stub();
       const wrapper = shallow(
         <DayPickerSingleDateController
@@ -714,8 +714,14 @@ describe('DayPickerSingleDateController', () => {
           onPrevMonthClick={onPrevMonthClickStub}
         />,
       );
+      wrapper.setState({
+        currentMonth: today,
+      });
+      const newMonth = moment().subtract(1, 'month');
       wrapper.instance().onPrevMonthClick();
       expect(onPrevMonthClickStub.callCount).to.equal(1);
+      expect(onPrevMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
+      expect(onPrevMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
     });
   });
 
@@ -781,7 +787,7 @@ describe('DayPickerSingleDateController', () => {
       expect(getModifiersSpy.callCount).to.equal(1);
     });
 
-    it('calls props.onNextMonthClick', () => {
+    it('calls props.onNextMonthClick with new month', () => {
       const onNextMonthClickStub = sinon.stub();
       const wrapper = shallow(
         <DayPickerSingleDateController
@@ -790,8 +796,14 @@ describe('DayPickerSingleDateController', () => {
           onNextMonthClick={onNextMonthClickStub}
         />,
       );
+      wrapper.setState({
+        currentMonth: today,
+      });
+      const newMonth = moment().add(1, 'month');
       wrapper.instance().onNextMonthClick();
       expect(onNextMonthClickStub.callCount).to.equal(1);
+      expect(onNextMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
+      expect(onNextMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
     });
   });
 


### PR DESCRIPTION
Sometimes it's helpful to know what month is currently showing on the calendar (for instance, to fetch data on blocked or highlighted dates for upcoming months). This change adds the current month as an argument to the `onPrevMonthClick` and `onNextMonthClick` callbacks, allowing parent components to know the currently-displayed month.

This change also adds Mocha specs, which pass (I hope).

Alex Meed