### PR TITLE
Recalculate blocked days when day-blocking function prop changes

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -309,7 +309,7 @@ export default class DayPickerRangeController extends React.Component {
             modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
           }
 
-          if (recomputeOutsideRange) {
+          if (didFocusChange || recomputeOutsideRange) {
             if (isOutsideRange(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
             } else {
@@ -317,7 +317,7 @@ export default class DayPickerRangeController extends React.Component {
             }
           }
 
-          if (recomputeDayBlocked) {
+          if (didFocusChange || recomputeDayBlocked) {
             if (isDayBlocked(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
             } else {
@@ -325,7 +325,7 @@ export default class DayPickerRangeController extends React.Component {
             }
           }
 
-          if (recomputeDayHighlighted) {
+          if (didFocusChange || recomputeDayHighlighted) {
             if (isDayHighlighted(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
             } else {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -187,22 +187,27 @@ export default class DayPickerRangeController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
-    let recomputePropModifiers = false;
+    let recomputeOutsideRange = false;
+    let recomputeDayBlocked = false;
+    let recomputeDayHighlighted = false;
 
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
-      recomputePropModifiers = true;
+      recomputeOutsideRange = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
-      recomputePropModifiers = true;
+      recomputeDayBlocked = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
-      recomputePropModifiers = true;
+      recomputeDayHighlighted = true;
     }
+
+    const recomputePropModifiers =
+      recomputeOutsideRange || recomputeDayBlocked || recomputeDayHighlighted;
 
     const didStartDateChange = startDate !== this.props.startDate;
     const didEndDateChange = endDate !== this.props.endDate;
@@ -304,22 +309,28 @@ export default class DayPickerRangeController extends React.Component {
             modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
           }
 
-          if (isOutsideRange(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+          if (recomputeOutsideRange) {
+            if (isOutsideRange(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+            }
           }
 
-          if (isDayBlocked(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+          if (recomputeDayBlocked) {
+            if (isDayBlocked(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+            }
           }
 
-          if (isDayHighlighted(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+          if (recomputeDayHighlighted) {
+            if (isDayHighlighted(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+            }
           }
         });
       });

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -187,21 +187,21 @@ export default class DayPickerRangeController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
-    let recomputeBlockedDays = false;
+    let recomputePropModifiers = false;
 
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     const didStartDateChange = startDate !== this.props.startDate;
@@ -293,7 +293,7 @@ export default class DayPickerRangeController extends React.Component {
       }
     }
 
-    if (didFocusChange || recomputeBlockedDays) {
+    if (didFocusChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -187,16 +187,21 @@ export default class DayPickerRangeController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
+    let recomputeBlockedDays = false;
+
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
+      recomputeBlockedDays = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
+      recomputeBlockedDays = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
+      recomputeBlockedDays = true;
     }
 
     const didStartDateChange = startDate !== this.props.startDate;
@@ -288,7 +293,7 @@ export default class DayPickerRangeController extends React.Component {
       }
     }
 
-    if (didFocusChange) {
+    if (didFocusChange || recomputeBlockedDays) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -175,21 +175,21 @@ export default class DayPickerSingleDateController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
-    let recomputeBlockedDays = false;
+    let recomputePropModifiers = false;
 
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
-      recomputeBlockedDays = true;
+      recomputePropModifiers = true;
     }
 
     if (
@@ -216,7 +216,7 @@ export default class DayPickerSingleDateController extends React.Component {
       modifiers = this.addModifier(modifiers, date, 'selected');
     }
 
-    if (didFocusChange || recomputeBlockedDays) {
+    if (didFocusChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -231,7 +231,7 @@ export default class DayPickerSingleDateController extends React.Component {
             modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
           }
 
-          if (recomputeOutsideRange) {
+          if (didFocusChange || recomputeOutsideRange) {
             if (isOutsideRange(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
             } else {
@@ -239,7 +239,7 @@ export default class DayPickerSingleDateController extends React.Component {
             }
           }
 
-          if (recomputeDayBlocked) {
+          if (didFocusChange || recomputeDayBlocked) {
             if (isDayBlocked(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
             } else {
@@ -247,7 +247,7 @@ export default class DayPickerSingleDateController extends React.Component {
             }
           }
 
-          if (recomputeDayHighlighted) {
+          if (didFocusChange || recomputeDayHighlighted) {
             if (isDayHighlighted(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
             } else {

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -175,16 +175,21 @@ export default class DayPickerSingleDateController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
+    let recomputeBlockedDays = false;
+
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
+      recomputeBlockedDays = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
+      recomputeBlockedDays = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
+      recomputeBlockedDays = true;
     }
 
     if (
@@ -211,7 +216,7 @@ export default class DayPickerSingleDateController extends React.Component {
       modifiers = this.addModifier(modifiers, date, 'selected');
     }
 
-    if (didFocusChange) {
+    if (didFocusChange || recomputeBlockedDays) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -175,22 +175,27 @@ export default class DayPickerSingleDateController extends React.Component {
     } = nextProps;
     let { visibleDays } = this.state;
 
-    let recomputePropModifiers = false;
+    let recomputeOutsideRange = false;
+    let recomputeDayBlocked = false;
+    let recomputeDayHighlighted = false;
 
     if (isOutsideRange !== this.props.isOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
-      recomputePropModifiers = true;
+      recomputeOutsideRange = true;
     }
 
     if (isDayBlocked !== this.props.isDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
-      recomputePropModifiers = true;
+      recomputeDayBlocked = true;
     }
 
     if (isDayHighlighted !== this.props.isDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
-      recomputePropModifiers = true;
+      recomputeDayHighlighted = true;
     }
+
+    const recomputePropModifiers =
+      recomputeOutsideRange || recomputeDayBlocked || recomputeDayHighlighted;
 
     if (
       initialVisibleMonth !== this.props.initialVisibleMonth ||
@@ -226,22 +231,28 @@ export default class DayPickerSingleDateController extends React.Component {
             modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
           }
 
-          if (isOutsideRange(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+          if (recomputeOutsideRange) {
+            if (isOutsideRange(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
+            }
           }
 
-          if (isDayBlocked(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+          if (recomputeDayBlocked) {
+            if (isDayBlocked(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
+            }
           }
 
-          if (isDayHighlighted(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+          if (recomputeDayHighlighted) {
+            if (isDayHighlighted(momentObj)) {
+              modifiers = this.addModifier(modifiers, momentObj, 'highlighted-calendar');
+            } else {
+              modifiers = this.deleteModifier(modifiers, momentObj, 'highlighted-calendar');
+            }
           }
         });
       });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -869,14 +869,28 @@ describe('DayPickerRangeController', () => {
 
       describe('blocked-out-of-range', () => {
         describe('focusedInput did not change', () => {
-          it('does not call isOutsideRange', () => {
+          it('does not call isOutsideRange if unchanged', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController
+              {...props}
+              isOutsideRange={isOutsideRangeStub}
+            />);
+            const prevCallCount = isOutsideRangeStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isOutsideRange if changed', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
-            expect(isOutsideRangeStub.callCount).to.equal(0);
+            expect(isOutsideRangeStub.callCount).to.not.equal(0);
           });
         });
 
@@ -939,14 +953,28 @@ describe('DayPickerRangeController', () => {
 
       describe('blocked-calendar', () => {
         describe('focusedInput did not change', () => {
-          it('does not call isDayBlocked', () => {
+          it('does not call isDayBlocked if unchanged', () => {
+            const isDayBlockedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController
+              {...props}
+              isDayBlocked={isDayBlockedStub}
+            />);
+            const prevCallCount = isDayBlockedStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isDayBlocked: isDayBlockedStub,
+            });
+            expect(isDayBlockedStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isDayBlocked if changed', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
-            expect(isDayBlockedStub.callCount).to.equal(0);
+            expect(isDayBlockedStub.callCount).to.not.equal(0);
           });
         });
 
@@ -1011,12 +1039,26 @@ describe('DayPickerRangeController', () => {
         describe('focusedInput did not change', () => {
           it('does not call isDayHighlighted', () => {
             const isDayHighlightedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController
+              {...props}
+              isDayHighlighted={isDayHighlightedStub}
+            />);
+            const prevCallCount = isDayHighlightedStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isDayHighlighted: isDayHighlightedStub,
+            });
+            expect(isDayHighlightedStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isDayHighlighted if changed', () => {
+            const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
-            expect(isDayHighlightedStub.callCount).to.equal(0);
+            expect(isDayHighlightedStub.callCount).to.not.equal(0);
           });
         });
 

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -157,14 +157,30 @@ describe('DayPickerSingleDateController', () => {
 
       describe('blocked-out-of-range', () => {
         describe('props.focused did not change', () => {
-          it('does not call isOutsideRange', () => {
+          it('does not call isOutsideRange if unchanged', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(
+              <DayPickerSingleDateController
+                {...props}
+                isOutsideRange={isOutsideRangeStub}
+              />,
+            );
+            const prevCallCount = isOutsideRangeStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isOutsideRange if changed', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
-            expect(isOutsideRangeStub.callCount).to.equal(0);
+            expect(isOutsideRangeStub.callCount).to.not.equal(0);
           });
         });
 
@@ -238,14 +254,28 @@ describe('DayPickerSingleDateController', () => {
 
       describe('blocked-calendar', () => {
         describe('props.focused did not change', () => {
-          it('does not call isDayBlocked', () => {
+          it('does not call isDayBlocked if unchanged', () => {
+            const isDayBlockedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerSingleDateController
+              {...props}
+              isDayBlocked={isDayBlockedStub}
+            />);
+            const prevCallCount = isDayBlockedStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isDayBlocked: isDayBlockedStub,
+            });
+            expect(isDayBlockedStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isDayBlocked if changed', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
-            expect(isDayBlockedStub.callCount).to.equal(0);
+            expect(isDayBlockedStub.callCount).to.not.equal(0);
           });
         });
 
@@ -308,14 +338,28 @@ describe('DayPickerSingleDateController', () => {
 
       describe('highlighted-calendar', () => {
         describe('focusedInput did not change', () => {
-          it('does not call isDayHighlighted', () => {
+          it('does not call isDayHighlighted if unchanged', () => {
+            const isDayHighlightedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerSingleDateController
+              {...props}
+              isDayHighlighted={isDayHighlightedStub}
+            />);
+            const prevCallCount = isDayHighlightedStub.callCount;
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              isDayHighlighted: isDayHighlightedStub,
+            });
+            expect(isDayHighlightedStub.callCount).to.equal(prevCallCount);
+          });
+
+          it('calls isDayHighlighted if changed', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
-            expect(isDayHighlightedStub.callCount).to.equal(0);
+            expect(isDayHighlightedStub.callCount).to.not.equal(0);
           });
         });
 


### PR DESCRIPTION
Sometimes it's useful to force the picker to recompute which days should be blocked or highlighted (for instance, if we need to force the set of blocked days to change based on data fetched asynchronously). This change forces the picker to refetch the blocked/highlighted modifiers for all visible dates when the `isOutsideRange`, `isDayBlocked`, or `isDayHighlighted` props change.

Alex Meed