### PR TITLE
Add year selection to DatePicker

### DIFF
--- a/css/MonthYearSwitch.scss
+++ b/css/MonthYearSwitch.scss
@@ -1,0 +1,64 @@
+$monthWidth: 60%;
+
+.MonthYearSwitch {
+  height: 21px;
+
+  button {
+    border: 1px solid $react-dates-color-border-light;
+    background-color: $react-dates-color-white;
+    color: $react-dates-color-placeholder-text;
+    cursor: pointer;
+    border-radius: 3px;
+    padding: 3px 6px;
+    vertical-align: middle;
+    z-index: $react-dates-z-index + 2;
+
+    &:focus,
+    &:hover {
+      border: 1px solid $react-dates-color-border-medium;
+    }
+
+    &:active {
+      background: darken($react-dates-color-white, 5%);
+    }
+
+    svg {
+      height: 13px;
+      width: 13px;
+      fill: $react-dates-color-gray-light;
+    }
+
+    + button {
+      margin-left: 3px;
+    }
+  }
+
+  .Month,
+  .Year {
+    display: inline-block;
+  }
+
+  .Month--title,
+  .Year--title {
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .Month {
+    text-align: left;
+    width: $monthWidth;
+
+    .Month--title {
+      margin-left: 10px;
+    }
+  }
+
+  .Year {
+    text-align: right;
+    width: 100% - $monthWidth;
+
+    .Year--title {
+      margin-right: 10px;
+    }
+  }
+}

--- a/css/styles.scss
+++ b/css/styles.scss
@@ -7,5 +7,6 @@
 @import 'DateInput';
 @import 'DateRangePicker';
 @import 'DateRangePickerInput';
+@import 'MonthYearSwitch';
 @import 'SingleDatePicker';
 @import 'SingleDatePickerInput';

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -12,6 +12,7 @@ import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
 import CalendarDay from './CalendarDay';
+import MonthYearSwitch from './MonthYearSwitch';
 
 import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 import isSameDay from '../utils/isSameDay';
@@ -37,6 +38,8 @@ const propTypes = forbidExtraProps({
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
+  onSelectMonth: PropTypes.func,
+  onSelectYear: PropTypes.func,
   renderMonth: PropTypes.func,
   renderDay: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
@@ -59,12 +62,15 @@ const defaultProps = {
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
+  onSelectMonth() {},
+  onSelectYear() {},
   renderMonth: null,
   renderDay: null,
   firstDayOfWeek: null,
 
   focusedDate: null,
   isFocused: false,
+  isYearsEnabled: false,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -113,11 +119,14 @@ export default class CalendarMonth extends React.Component {
       onDayClick,
       onDayMouseEnter,
       onDayMouseLeave,
+      onSelectMonth,
+      onSelectYear,
       renderMonth,
       renderDay,
       daySize,
       focusedDate,
       isFocused,
+      isYearsEnabled,
       phrases,
     } = this.props;
 
@@ -134,9 +143,14 @@ export default class CalendarMonth extends React.Component {
       <div className={calendarMonthClasses} data-visible={isVisible}>
         <table>
           <caption className="CalendarMonth__caption js-CalendarMonth__caption">
-            <strong>{monthTitle}</strong>
+            { isYearsEnabled ?
+              <MonthYearSwitch
+                date={month}
+                onSelectMonth={onSelectMonth}
+                onSelectYear={onSelectYear}
+              />
+              : monthTitle }
           </caption>
-
           <tbody className="js-CalendarMonth__grid">
             {weeks.map((week, i) => (
               <tr key={i}>

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -65,6 +65,8 @@ const propTypes = forbidExtraProps({
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  onMonthChange: PropTypes.func,
+  onYearChange: PropTypes.func,
   onOutsideClick: PropTypes.func,
   renderDay: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
@@ -112,6 +114,8 @@ const defaultProps = {
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
+  onMonthChange() {},
+  onYearChange() {},
   onOutsideClick() {},
 
   renderDay: null,
@@ -167,6 +171,8 @@ export default class DayPickerRangeController extends React.Component {
     this.onDayMouseLeave = this.onDayMouseLeave.bind(this);
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
+    this.onMonthChange = this.onMonthChange.bind(this);
+    this.onYearChange = this.onYearChange.bind(this);
     this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
@@ -543,6 +549,30 @@ export default class DayPickerRangeController extends React.Component {
     onNextMonthClick(newCurrentMonth.clone());
   }
 
+  onMonthChange(newMonth) {
+    const { numberOfMonths, enableOutsideDays, orientation } = this.props;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    const newVisibleDays =
+      getVisibleDays(newMonth, numberOfMonths, enableOutsideDays, withoutTransitionMonths);
+
+    this.setState({
+      currentMonth: newMonth.clone(),
+      visibleDays: this.getModifiers(newVisibleDays),
+    });
+  }
+
+  onYearChange(newMonth) {
+    const { numberOfMonths, enableOutsideDays, orientation } = this.props;
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+    const newVisibleDays =
+      getVisibleDays(newMonth, numberOfMonths, enableOutsideDays, withoutTransitionMonths);
+
+    this.setState({
+      currentMonth: newMonth.clone(),
+      visibleDays: this.getModifiers(newVisibleDays),
+    });
+  }
+
   onMultiplyScrollableMonths() {
     const { numberOfMonths, enableOutsideDays } = this.props;
     const { currentMonth, visibleDays } = this.state;
@@ -853,6 +883,8 @@ export default class DayPickerRangeController extends React.Component {
         onDayMouseLeave={this.onDayMouseLeave}
         onPrevMonthClick={this.onPrevMonthClick}
         onNextMonthClick={this.onNextMonthClick}
+        onMonthChange={this.onMonthChange}
+        onYearChange={this.onYearChange}
         onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
         monthFormat={monthFormat}
         renderMonth={renderMonth}

--- a/src/components/MonthYearSwitch.jsx
+++ b/src/components/MonthYearSwitch.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import shallowCompare from 'react-addons-shallow-compare';
+import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps } from 'airbnb-prop-types';
+import moment from 'moment';
+
+import LeftArrow from '../svg/arrow-left.svg';
+import RightArrow from '../svg/arrow-right.svg';
+
+const propTypes = forbidExtraProps({
+  date: momentPropTypes.momentObj,
+  onSelectMonth: PropTypes.func,
+  onSelectYear: PropTypes.func,
+});
+
+const defaultProps = {
+  date: moment(),
+  onSelectMonth() {},
+  onSelectYear() {},
+};
+
+export default class MonthSelector extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
+  render() {
+    const {
+      date,
+      onSelectMonth,
+      onSelectYear,
+    } = this.props;
+
+    const currentMonth = date.format('MMMM');
+    const currentYear = date.format('YYYY');
+
+    return (
+      <div className="MonthYearSwitch">
+        <div className="Month">
+          <button onClick={() => onSelectMonth(date, date.get('month') - 1)}>
+            <LeftArrow />
+          </button>
+          <button onClick={() => onSelectMonth(date, date.get('month') + 1)}>
+            <RightArrow />
+          </button>
+          <span className="Month--title">{currentMonth}</span>
+        </div>
+        <div className="Year">
+          <span className="Year--title">{currentYear}</span>
+          <button onClick={() => onSelectYear(date, date.get('year') - 1)}>
+            <LeftArrow />
+          </button>
+          <button onClick={() => onSelectYear(date, date.get('year') + 1)}>
+            <RightArrow />
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+MonthSelector.propTypes = propTypes;
+MonthSelector.defaultProps = defaultProps;

--- a/src/utils/isNextMonth.js
+++ b/src/utils/isNextMonth.js
@@ -1,0 +1,6 @@
+import moment from 'moment';
+
+export default function isNextMonth(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+  return b.isSame(a.clone().add(1, 'month'), 'month');
+}

--- a/src/utils/isPrevMonth.js
+++ b/src/utils/isPrevMonth.js
@@ -1,0 +1,6 @@
+import moment from 'moment';
+
+export default function isPrevMonth(a, b) {
+  if (!moment.isMoment(a) || !moment.isMoment(b)) return false;
+  return b.isSame(a.clone().subtract(1, 'month'), 'month');
+}

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -55,6 +55,11 @@ storiesOf('DayPicker', module)
   .addWithInfo('single month', () => (
     <DayPicker numberOfMonths={1} />
   ))
+
+  .addWithInfo('single month with years enabled', () => (
+    <DayPicker numberOfMonths={1} isYearsEnabled />
+  ))
+
   .addWithInfo('3 months', () => (
     <DayPicker numberOfMonths={3} />
   ))

--- a/test/utils/isNextMonth__spec.js
+++ b/test/utils/isNextMonth__spec.js
@@ -1,0 +1,32 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isNextMonth from '../../src/utils/isNextMonth';
+
+const today = moment();
+const nextMonth = moment().add(1, 'months');
+const twoMonths = moment().add(2, 'months');
+
+describe('isNextMonth', () => {
+  it('returns true if second argument is the next month after the first', () => {
+    expect(isNextMonth(today, nextMonth)).to.equal(true);
+  });
+
+  it('returns false if second argument is not the next month after the first', () => {
+    expect(isNextMonth(nextMonth, today)).to.equal(false);
+  });
+
+  it('returns false if second argument is more than one month after the first', () => {
+    expect(isNextMonth(today, twoMonths)).to.equal(false);
+  });
+
+  describe('non-moment arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isNextMonth(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isNextMonth(today, 'foo')).to.equal(false);
+    });
+  });
+});

--- a/test/utils/isPrevMonth_spec.js
+++ b/test/utils/isPrevMonth_spec.js
@@ -1,0 +1,32 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import isPrevMonth from '../../src/utils/isPrevMonth';
+
+const today = moment();
+const lastMonth = moment().subtract(1, 'months');
+const twoMonthsAgo = moment().subtract(2, 'months');
+
+describe('isPrevMonth', () => {
+  it('returns true if second argument is the month before the first', () => {
+    expect(isPrevMonth(today, lastMonth)).to.equal(true);
+  });
+
+  it('returns false if second argument is not the month before the first', () => {
+    expect(isPrevMonth(lastMonth, today)).to.equal(false);
+  });
+
+  it('returns false if second argument is more than one month before the first', () => {
+    expect(isPrevMonth(today, twoMonthsAgo)).to.equal(false);
+  });
+
+  describe('non-moment arguments', () => {
+    it('is false if first argument is not a moment object', () => {
+      expect(isPrevMonth(null, today)).to.equal(false);
+    });
+
+    it('is false if second argument is not a moment object', () => {
+      expect(isPrevMonth(today, 'foo')).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
This adds a year picker as requested in https://github.com/airbnb/react-dates/issues/25 and suggested in https://github.com/airbnb/react-dates/pull/558. I copied some logic for comparing months / years from https://github.com/airbnb/react-dates/pull/558 but used a "next" implementation instead of dropdowns. 

This is my first PR to this repo, so please tell me where I can improve

![screen shot 2017-08-16 at 12 50 46](https://user-images.githubusercontent.com/8612041/29415130-3cc7ff28-8362-11e7-93f6-d43f27bc0b71.png)
