### PR TITLE
Clear hovered span when there is no start and end date selected

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -234,15 +234,6 @@ export default class DayPickerRangeController extends React.Component {
 
     let modifiers = {};
 
-    if (modifiers.length && !startDate && !endDate) {
-      modifiers = this.deleteModifierFromRange(
-        modifiers,
-        initialVisibleMonth(),
-        initialVisibleMonth().add(numberOfMonths, 'months').endOf('month'),
-        'hovered-span',
-      );
-    }
-
     if (didStartDateChange) {
       modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
       modifiers = this.addModifier(modifiers, startDate, 'selected-start');
@@ -260,6 +251,15 @@ export default class DayPickerRangeController extends React.Component {
           this.props.startDate,
           this.props.endDate.clone().add(1, 'day'),
           'selected-span',
+        );
+      }
+
+      if (!startDate && !endDate) {
+        modifiers = this.deleteModifierFromRange(
+          modifiers,
+          initialVisibleMonth(),
+          initialVisibleMonth().add(numberOfMonths, 'months').endOf('month'),
+          'hovered-span',
         );
       }
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -234,6 +234,15 @@ export default class DayPickerRangeController extends React.Component {
 
     let modifiers = {};
 
+    if (modifiers.length && !startDate && !endDate) {
+      modifiers = this.deleteModifierFromRange(
+        modifiers,
+        initialVisibleMonth(),
+        initialVisibleMonth().add(numberOfMonths, 'months').endOf('month'),
+        'hovered-span',
+      );
+    }
+
     if (didStartDateChange) {
       modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
       modifiers = this.addModifier(modifiers, startDate, 'selected-start');

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -257,8 +257,8 @@ export default class DayPickerRangeController extends React.Component {
       if (!startDate && !endDate) {
         modifiers = this.deleteModifierFromRange(
           modifiers,
-          initialVisibleMonth(),
-          initialVisibleMonth().add(numberOfMonths, 'months').endOf('month'),
+          this.state.currentMonth,
+          this.state.currentMonth.add(numberOfMonths, 'months').endOf('month'),
           'hovered-span',
         );
       }


### PR DESCRIPTION
My issue and my use case is described in: https://github.com/airbnb/react-dates/issues/622

Basically, in short, I would like to be able to clear all the hovered--span classes from the datepicker days when the `startDate` and `endDate` are not defined. 

Performance wise, I think this shouldn't affect anything in the majority of cases. The only way to get `startDate` and `endDate` to be not defined is:

* When the datepicker first renders. But there are no classes applied yet at this point, so removing the modifiers should be a noop (or close to a noop).
* When a "clear" button is implemented (like in our case), in which case I currently don't see a more performant way to do this.

This PR is not ready for merging yet as it is missing tests, but probably adding tests for this won't be so easy 😄 I will of course add tests if the proposed fix is approved.