### PR TITLE
Fix: use constructor-bound methods for ref callbacks

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -45,6 +45,12 @@ const defaultProps = {
 };
 
 export default class CalendarDay extends React.Component {
+  constructor(...args) {
+    super(...args);
+
+    this.setButtonRef = this.setButtonRef.bind(this);
+  }
+
   shouldComponentUpdate(nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   }
@@ -71,6 +77,10 @@ export default class CalendarDay extends React.Component {
   onDayMouseLeave(day, e) {
     const { onDayMouseLeave } = this.props;
     onDayMouseLeave(day, e);
+  }
+
+  setButtonRef(ref) {
+    this.buttonRef = ref;
   }
 
   render() {
@@ -112,7 +122,7 @@ export default class CalendarDay extends React.Component {
       <td className={className} style={daySizeStyles}>
         <button
           type="button"
-          ref={(ref) => { this.buttonRef = ref; }}
+          ref={this.setButtonRef}
           className="CalendarDay__button"
           aria-label={ariaLabel}
           onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -101,6 +101,7 @@ export default class CalendarMonthGrid extends React.Component {
 
     this.isTransitionEndSupported = isTransitionEndSupported();
     this.onTransitionEnd = this.onTransitionEnd.bind(this);
+    this.setContainerRef = this.setContainerRef.bind(this);
   }
 
   componentDidMount() {
@@ -161,6 +162,10 @@ export default class CalendarMonthGrid extends React.Component {
     this.props.onMonthTransitionEnd();
   }
 
+  setContainerRef(ref) {
+    this.container = ref;
+  }
+
   render() {
     const {
       enableOutsideDays,
@@ -209,7 +214,7 @@ export default class CalendarMonthGrid extends React.Component {
 
     return (
       <div
-        ref={(ref) => { this.container = ref; }}
+        ref={this.setContainerRef}
         className={className}
         style={style}
         onTransitionEnd={onMonthTransitionEnd}

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -55,6 +55,7 @@ const defaultProps = {
 export default class DateInput extends React.Component {
   constructor(props) {
     super(props);
+
     this.state = {
       dateString: '',
       isTouchDevice: false,
@@ -62,6 +63,7 @@ export default class DateInput extends React.Component {
 
     this.onChange = this.onChange.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.setInputRef = this.setInputRef.bind(this);
   }
 
   componentDidMount() {
@@ -128,6 +130,10 @@ export default class DateInput extends React.Component {
     }
   }
 
+  setInputRef(ref) {
+    this.inputRef = ref;
+  }
+
   render() {
     const {
       dateString,
@@ -164,7 +170,7 @@ export default class DateInput extends React.Component {
           type="text"
           id={id}
           name={id}
-          ref={(ref) => { this.inputRef = ref; }}
+          ref={this.setInputRef}
           value={value}
           onChange={this.onChange}
           onKeyDown={throttle(this.onKeyDown, 300)}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -116,6 +116,9 @@ export default class DateRangePicker extends React.Component {
     this.showKeyboardShortcutsPanel = this.showKeyboardShortcutsPanel.bind(this);
 
     this.responsivizePickerPosition = this.responsivizePickerPosition.bind(this);
+
+    this.setDayPickerContainerRef = this.setDayPickerContainerRef.bind(this);
+    this.setDayPickerRef = this.setDayPickerRef.bind(this);
   }
 
   componentDidMount() {
@@ -225,6 +228,14 @@ export default class DateRangePicker extends React.Component {
     return ReactDOM.findDOMNode(this.dayPicker); // eslint-disable-line react/no-find-dom-node
   }
 
+  setDayPickerContainerRef(ref) {
+    this.dayPickerContainer = ref;
+  }
+
+  setDayPickerRef(ref) {
+    this.dayPicker = ref;
+  }
+
   isOpened() {
     const { focusedInput } = this.props;
     return focusedInput === START_DATE || focusedInput === END_DATE;
@@ -332,13 +343,13 @@ export default class DateRangePicker extends React.Component {
 
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-        ref={(ref) => { this.dayPickerContainer = ref; }}
+        ref={this.setDayPickerContainerRef}
         className={this.getDayPickerContainerClasses()}
         style={dayPickerContainerStyles}
         onClick={onOutsideClick}
       >
         <DayPickerRangeController
-          ref={(ref) => { this.dayPicker = ref; }}
+          ref={this.setDayPickerRef}
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
           numberOfMonths={numberOfMonths}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -218,6 +218,9 @@ export default class DayPicker extends React.Component {
 
     this.openKeyboardShortcutsPanel = this.openKeyboardShortcutsPanel.bind(this);
     this.closeKeyboardShortcutsPanel = this.closeKeyboardShortcutsPanel.bind(this);
+
+    this.setContainerRef = this.setContainerRef.bind(this);
+    this.setTransitionContainerRef = this.setTransitionContainerRef.bind(this);
   }
 
   componentDidMount() {
@@ -453,6 +456,14 @@ export default class DayPicker extends React.Component {
 
   setCalendarMonthGridRef(ref) {
     this.calendarMonthGrid = ref;
+  }
+
+  setContainerRef(ref) {
+    this.container = ref;
+  }
+
+  setTransitionContainerRef(ref) {
+    this.transitionContainer = ref;
   }
 
   maybeTransitionNextMonth(newFocusedDate) {
@@ -819,7 +830,7 @@ export default class DayPicker extends React.Component {
 
           <div // eslint-disable-line jsx-a11y/no-noninteractive-element-interactions
             className="DayPicker__focus-region"
-            ref={(ref) => { this.container = ref; }}
+            ref={this.setContainerRef}
             onClick={(e) => { e.stopPropagation(); }}
             onKeyDown={throttle(this.onKeyDown, 300)}
             onMouseUp={() => { this.setState({ withMouseInteractions: true }); }}
@@ -830,7 +841,7 @@ export default class DayPicker extends React.Component {
 
             <div
               className={transitionContainerClasses}
-              ref={(ref) => { this.transitionContainer = ref; }}
+              ref={this.setTransitionContainerRef}
               style={transitionContainerStyle}
             >
               <CalendarMonthGrid

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -60,12 +60,29 @@ KeyboardShortcutRow.propTypes = {
 };
 
 export default class DayPickerKeyboardShortcuts extends React.Component {
+  constructor(...args) {
+    super(...args);
+
+    this.onClick = this.onClick.bind(this);
+    this.setShowKeyboardShortcutsButtonRef = this.setShowKeyboardShortcutsButtonRef.bind(this);
+  }
+
+  onClick() {
+    const { openKeyboardShortcutsPanel } = this.props;
+
+    // we want to return focus to this button after closing the keyboard shortcuts panel
+    openKeyboardShortcutsPanel(() => { this.showKeyboardShortcutsButton.focus(); });
+  }
+
+  setShowKeyboardShortcutsButtonRef(ref) {
+    this.showKeyboardShortcutsButton = ref;
+  }
+
   render() {
     const {
       block,
       buttonLocation,
       showKeyboardShortcutsPanel,
-      openKeyboardShortcutsPanel,
       closeKeyboardShortcutsPanel,
       phrases,
     } = this.props;
@@ -114,7 +131,7 @@ export default class DayPickerKeyboardShortcuts extends React.Component {
     return (
       <div>
         <button
-          ref={(ref) => { this.showKeyboardShortcutsButton = ref; }}
+          ref={this.setShowKeyboardShortcutsButtonRef}
           className={cx('DayPickerKeyboardShortcuts__show', {
             'DayPickerKeyboardShortcuts__show--bottom-right': buttonLocation === BOTTOM_RIGHT,
             'DayPickerKeyboardShortcuts__show--top-right': buttonLocation === TOP_RIGHT,
@@ -122,10 +139,7 @@ export default class DayPickerKeyboardShortcuts extends React.Component {
           })}
           type="button"
           aria-label={toggleButtonText}
-          onClick={() => {
-            // we want to return focus to this button after closing the keyboard shortcuts panel
-            openKeyboardShortcutsPanel(() => { this.showKeyboardShortcutsButton.focus(); });
-          }}
+          onClick={this.onClick}
           onMouseUp={(e) => {
             e.currentTarget.blur();
           }}

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -13,14 +13,14 @@ export const TOP_LEFT = 'top-left';
 export const TOP_RIGHT = 'top-right';
 export const BOTTOM_RIGHT = 'bottom-right';
 
-const propTypes = forbidExtraProps({
+const propTypes = {
   block: PropTypes.bool,
   buttonLocation: PropTypes.oneOf([TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT]),
   showKeyboardShortcutsPanel: PropTypes.bool,
   openKeyboardShortcutsPanel: PropTypes.func,
   closeKeyboardShortcutsPanel: PropTypes.func,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerKeyboardShortcutsPhrases)),
-});
+};
 
 const defaultProps = {
   block: false,
@@ -59,119 +59,123 @@ KeyboardShortcutRow.propTypes = {
   action: PropTypes.string.isRequired,
 };
 
-export default function DayPickerKeyboardShortcuts({
-  block,
-  buttonLocation,
-  showKeyboardShortcutsPanel,
-  openKeyboardShortcutsPanel,
-  closeKeyboardShortcutsPanel,
-  phrases,
-}) {
-  const keyboardShortcuts = [{
-    unicode: '↵',
-    label: phrases.enterKey,
-    action: phrases.selectFocusedDate,
-  },
-  {
-    unicode: '←/→',
-    label: phrases.leftArrowRightArrow,
-    action: phrases.moveFocusByOneDay,
-  },
-  {
-    unicode: '↑/↓',
-    label: phrases.upArrowDownArrow,
-    action: phrases.moveFocusByOneWeek,
-  },
-  {
-    unicode: 'PgUp/PgDn',
-    label: phrases.pageUpPageDown,
-    action: phrases.moveFocusByOneMonth,
-  },
-  {
-    unicode: 'Home/End',
-    label: phrases.homeEnd,
-    action: phrases.moveFocustoStartAndEndOfWeek,
-  },
-  {
-    unicode: 'Esc',
-    label: phrases.escape,
-    action: phrases.returnFocusToInput,
-  },
-  {
-    unicode: '?',
-    label: phrases.questionMark,
-    action: phrases.openThisPanel,
-  },
-  ];
+export default class DayPickerKeyboardShortcuts extends React.Component {
+  render() {
+    const {
+      block,
+      buttonLocation,
+      showKeyboardShortcutsPanel,
+      openKeyboardShortcutsPanel,
+      closeKeyboardShortcutsPanel,
+      phrases,
+    } = this.props;
 
-  const toggleButtonText = showKeyboardShortcutsPanel
-    ? phrases.hideKeyboardShortcutsPanel
-    : phrases.showKeyboardShortcutsPanel;
+    const keyboardShortcuts = [{
+      unicode: '↵',
+      label: phrases.enterKey,
+      action: phrases.selectFocusedDate,
+    },
+    {
+      unicode: '←/→',
+      label: phrases.leftArrowRightArrow,
+      action: phrases.moveFocusByOneDay,
+    },
+    {
+      unicode: '↑/↓',
+      label: phrases.upArrowDownArrow,
+      action: phrases.moveFocusByOneWeek,
+    },
+    {
+      unicode: 'PgUp/PgDn',
+      label: phrases.pageUpPageDown,
+      action: phrases.moveFocusByOneMonth,
+    },
+    {
+      unicode: 'Home/End',
+      label: phrases.homeEnd,
+      action: phrases.moveFocustoStartAndEndOfWeek,
+    },
+    {
+      unicode: 'Esc',
+      label: phrases.escape,
+      action: phrases.returnFocusToInput,
+    },
+    {
+      unicode: '?',
+      label: phrases.questionMark,
+      action: phrases.openThisPanel,
+    },
+    ];
 
-  return (
-    <div>
-      <button
-        ref={(ref) => { this.showKeyboardShortcutsButton = ref; }}
-        className={cx('DayPickerKeyboardShortcuts__show', {
-          'DayPickerKeyboardShortcuts__show--bottom-right': buttonLocation === BOTTOM_RIGHT,
-          'DayPickerKeyboardShortcuts__show--top-right': buttonLocation === TOP_RIGHT,
-          'DayPickerKeyboardShortcuts__show--top-left': buttonLocation === TOP_LEFT,
-        })}
-        type="button"
-        aria-label={toggleButtonText}
-        onClick={() => {
-          // we want to return focus to this button after closing the keyboard shortcuts panel
-          openKeyboardShortcutsPanel(() => { this.showKeyboardShortcutsButton.focus(); });
-        }}
-        onMouseUp={(e) => {
-          e.currentTarget.blur();
-        }}
-      >
-        <span className="DayPickerKeyboardShortcuts__show_span">?</span>
-      </button>
+    const toggleButtonText = showKeyboardShortcutsPanel
+      ? phrases.hideKeyboardShortcutsPanel
+      : phrases.showKeyboardShortcutsPanel;
 
-      {showKeyboardShortcutsPanel &&
-        <div
-          className={cx('DayPickerKeyboardShortcuts__panel', {
-            'DayPickerKeyboardShortcuts__panel--block': block,
+    return (
+      <div>
+        <button
+          ref={(ref) => { this.showKeyboardShortcutsButton = ref; }}
+          className={cx('DayPickerKeyboardShortcuts__show', {
+            'DayPickerKeyboardShortcuts__show--bottom-right': buttonLocation === BOTTOM_RIGHT,
+            'DayPickerKeyboardShortcuts__show--top-right': buttonLocation === TOP_RIGHT,
+            'DayPickerKeyboardShortcuts__show--top-left': buttonLocation === TOP_LEFT,
           })}
-          role="dialog"
-          aria-labelledby="DayPickerKeyboardShortcuts__title"
+          type="button"
+          aria-label={toggleButtonText}
+          onClick={() => {
+            // we want to return focus to this button after closing the keyboard shortcuts panel
+            openKeyboardShortcutsPanel(() => { this.showKeyboardShortcutsButton.focus(); });
+          }}
+          onMouseUp={(e) => {
+            e.currentTarget.blur();
+          }}
         >
+          <span className="DayPickerKeyboardShortcuts__show_span">?</span>
+        </button>
+
+        {showKeyboardShortcutsPanel &&
           <div
-            id="DayPickerKeyboardShortcuts__title"
-            className="DayPickerKeyboardShortcuts__title"
+            className={cx('DayPickerKeyboardShortcuts__panel', {
+              'DayPickerKeyboardShortcuts__panel--block': block,
+            })}
+            role="dialog"
+            aria-labelledby="DayPickerKeyboardShortcuts__title"
           >
-            {phrases.keyboardShortcuts}
+            <div
+              id="DayPickerKeyboardShortcuts__title"
+              className="DayPickerKeyboardShortcuts__title"
+            >
+              {phrases.keyboardShortcuts}
+            </div>
+
+            <button
+              className="DayPickerKeyboardShortcuts__close"
+              type="button"
+              aria-label={phrases.hideKeyboardShortcutsPanel}
+              onClick={closeKeyboardShortcutsPanel}
+              onKeyDown={(e) => {
+                // Because the close button is the only focusable element inside of the panel, this
+                // amount to a very basic focus trap. The user can exit the panel by "pressing" the
+                // close button or hitting escape
+                if (e.key === 'Tab') {
+                  e.preventDefault();
+                }
+              }}
+            >
+              <CloseButton />
+            </button>
+
+            <ul className="DayPickerKeyboardShortcuts__list">
+              {keyboardShortcuts.map(({ unicode, label, action }) => (
+                <KeyboardShortcutRow key={label} unicode={unicode} label={label} action={action} />
+              ))}
+            </ul>
           </div>
-
-          <button
-            className="DayPickerKeyboardShortcuts__close"
-            type="button"
-            aria-label={phrases.hideKeyboardShortcutsPanel}
-            onClick={closeKeyboardShortcutsPanel}
-            onKeyDown={(e) => {
-              // Because the close button is the only focusable element inside of the panel, this
-              // amount to a very basic focus trap. The user can exit the panel by "pressing" the
-              // close button or hitting escape
-              if (e.key === 'Tab') {
-                e.preventDefault();
-              }
-            }}
-          >
-            <CloseButton />
-          </button>
-
-          <ul className="DayPickerKeyboardShortcuts__list">
-            {keyboardShortcuts.map(({ unicode, label, action }) => (
-              <KeyboardShortcutRow key={label} unicode={unicode} label={label} action={action} />
-            ))}
-          </ul>
-        </div>
-      }
-    </div>
-  );
+        }
+      </div>
+    );
+  }
 }
 
-DayPickerKeyboardShortcuts.propTypes = propTypes;
+DayPickerKeyboardShortcuts.propTypes = forbidExtraProps(propTypes);
 DayPickerKeyboardShortcuts.defaultProps = defaultProps;

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -169,6 +169,7 @@ export default class DayPickerRangeController extends React.Component {
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
+    this.setDayPickerRef = this.setDayPickerRef.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -622,6 +623,10 @@ export default class DayPickerRangeController extends React.Component {
     return { currentMonth, visibleDays };
   }
 
+  setDayPickerRef(ref) {
+    this.dayPicker = ref;
+  }
+
   addModifier(updatedDays, day, modifier) {
     const { numberOfMonths: numberOfVisibleMonths, enableOutsideDays, orientation } = this.props;
     const { currentMonth: firstVisibleMonth, visibleDays } = this.state;
@@ -843,7 +848,7 @@ export default class DayPickerRangeController extends React.Component {
 
     return (
       <DayPicker
-        ref={(ref) => { this.dayPicker = ref; }}
+        ref={this.setDayPickerRef}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
         modifiers={visibleDays}

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -15,9 +15,11 @@ const defaultProps = {
 };
 
 export default class OutsideClickHandler extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor(...args) {
+    super(...args);
+
     this.onOutsideClick = this.onOutsideClick.bind(this);
+    this.setChildNodeRef = this.setChildNodeRef.bind(this);
   }
 
   componentDidMount() {
@@ -32,7 +34,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.clickHandle) removeEventListener(this.clickHandle);
+    if (this.clickHandle) { removeEventListener(this.clickHandle); }
   }
 
   onOutsideClick(e) {
@@ -42,9 +44,13 @@ export default class OutsideClickHandler extends React.Component {
     }
   }
 
+  setChildNodeRef(ref) {
+    this.childNode = ref;
+  }
+
   render() {
     return (
-      <div ref={(ref) => { this.childNode = ref; }}>
+      <div ref={this.setChildNodeRef}>
         {this.props.children}
       </div>
     );

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -113,6 +113,8 @@ export default class SingleDatePicker extends React.Component {
     this.clearDate = this.clearDate.bind(this);
 
     this.responsivizePickerPosition = this.responsivizePickerPosition.bind(this);
+
+    this.setDayPickerContainerRef = this.setDayPickerContainerRef.bind(this);
   }
 
   /* istanbul ignore next */
@@ -238,6 +240,10 @@ export default class SingleDatePicker extends React.Component {
     return typeof displayFormat === 'string' ? displayFormat : displayFormat();
   }
 
+  setDayPickerContainerRef(ref) {
+    this.dayPickerContainer = ref;
+  }
+
   clearDate() {
     const { onDateChange, reopenPickerOnClearDate, onFocusChange } = this.props;
     onDateChange(null);
@@ -340,7 +346,7 @@ export default class SingleDatePicker extends React.Component {
 
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-        ref={(ref) => { this.dayPickerContainer = ref; }}
+        ref={this.setDayPickerContainerRef}
         className={this.getDayPickerContainerClasses()}
         style={dayPickerContainerStyles}
         onClick={onOutsideClick}


### PR DESCRIPTION
Use constructor-bound methods for ref callbacks instead of arrow functions.

Because this avoids creating a new function every render, it's both more performant, and also ensures React never sees two `!==` ref callbacks, which thus causes it to call the old one with `null` and the new one with the ref, which can sometimes cause issues like #437.

Separately, DayPickerKeyboardShortcuts has a ref but was an SFC, which makes no sense - so this also fixes it to be a class-based component.

Fixes #437.