### PR TITLE
Reset visibleDays/currentMonth state when enableOutsideDays or numberOfMonths has changed

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -283,8 +283,13 @@ export default class DayPicker extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
+    const { numberOfMonths } = this.props;
     const { monthTransition, currentMonth, focusedDate } = this.state;
-    if (monthTransition || !currentMonth.isSame(prevState.currentMonth)) {
+    if (
+      monthTransition ||
+      !currentMonth.isSame(prevState.currentMonth) ||
+      numberOfMonths !== prevProps.numberOfMonths
+    ) {
       if (this.isHorizontal()) {
         this.adjustDayPickerHeight();
       }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -215,11 +215,10 @@ export default class DayPickerRangeController extends React.Component {
     const didFocusChange = focusedInput !== this.props.focusedInput;
 
     if (
+      numberOfMonths !== this.props.numberOfMonths ||
+      enableOutsideDays !== this.props.enableOutsideDays ||
       (
-        initialVisibleMonth !== this.props.initialVisibleMonth ||
-        numberOfMonths !== this.props.numberOfMonths ||
-        enableOutsideDays !== this.props.enableOutsideDays
-      ) && (
+        initialVisibleMonth !== this.props.initialVisibleMonth &&
         !this.props.focusedInput &&
         didFocusChange
       )

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -197,9 +197,13 @@ export default class DayPickerSingleDateController extends React.Component {
       recomputeOutsideRange || recomputeDayBlocked || recomputeDayHighlighted;
 
     if (
-      initialVisibleMonth !== this.props.initialVisibleMonth ||
       numberOfMonths !== this.props.numberOfMonths ||
-      enableOutsideDays !== this.props.enableOutsideDays
+      enableOutsideDays !== this.props.enableOutsideDays ||
+      (
+        initialVisibleMonth !== this.props.initialVisibleMonth &&
+        !this.props.focused &&
+        focused
+      )
     ) {
       const newMonthState = this.getStateForNewMonth(nextProps);
       const currentMonth = newMonthState.currentMonth;

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -143,198 +143,88 @@ describe('DayPickerRangeController', () => {
       });
 
       describe('numberOfMonths changed', () => {
-        describe('focusedInput has changed and is truthy', () => {
-          it('calls getStateForNewMonth with nextProps', () => {
-            const getStateForNewMonthSpy =
-              sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            getStateForNewMonthSpy.reset();
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              numberOfMonths: 5,
-            });
-            expect(getStateForNewMonthSpy.callCount).to.equal(1);
+        it('calls getStateForNewMonth with nextProps', () => {
+          const getStateForNewMonthSpy =
+            sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          getStateForNewMonthSpy.reset();
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            numberOfMonths: 5,
           });
-
-          it('sets state.currentMonth to getStateForNewMonth.currentMonth', () => {
-            const currentMonth = moment().add(10, 'months');
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              numberOfMonths: 5,
-            });
-            expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
-          });
-
-          it('sets state.visibleDays to getStateForNewMonth.visibleDays', () => {
-            const currentMonth = moment().add(10, 'months');
-            const visibleDays = getVisibleDays(currentMonth, 1);
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth, visibleDays });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              numberOfMonths: 5,
-            });
-            expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
-          });
+          expect(getStateForNewMonthSpy.callCount).to.equal(1);
         });
 
-        describe('focusedInput has not changed', () => {
-          it('does not call getStateForNewMonth', () => {
-            const getStateForNewMonthSpy =
-              sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            getStateForNewMonthSpy.reset();
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              numberOfMonths: 5,
-            });
-            expect(getStateForNewMonthSpy.callCount).to.equal(0);
+        it('sets state.currentMonth to getStateForNewMonth.currentMonth', () => {
+          const currentMonth = moment().add(10, 'months');
+          const getStateForNewMonthStub =
+            sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
+
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            numberOfMonths: 5,
           });
+          expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
+        });
 
-          it('does not change state.currentMonth', () => {
-            const currentMonth = moment().add(10, 'months');
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth: moment(), visibleDays: {} });
+        it('sets state.visibleDays to getStateForNewMonth.visibleDays', () => {
+          const currentMonth = moment().add(10, 'months');
+          const visibleDays = getVisibleDays(currentMonth, 1);
+          const getStateForNewMonthStub =
+            sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          getStateForNewMonthStub.returns({ currentMonth, visibleDays });
 
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.setState({ currentMonth });
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              numberOfMonths: 5,
-            });
-            expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            numberOfMonths: 5,
           });
-
-          it('does not change state.visibleDays', () => {
-            const visibleDays = {};
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({
-              currentMonth: moment(),
-              visibleDays: getVisibleDays(moment(), 1),
-            });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              numberOfMonths: 5,
-            });
-            expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
-          });
+          expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
         });
       });
 
       describe('enableOutsideDays changed', () => {
-        describe('focusedInput has changed and is truthy', () => {
-          it('calls getStateForNewMonth with nextProps', () => {
-            const getStateForNewMonthSpy =
-              sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            getStateForNewMonthSpy.reset();
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              enableOutsideDays: true,
-            });
-            expect(getStateForNewMonthSpy.callCount).to.equal(1);
+        it('calls getStateForNewMonth with nextProps', () => {
+          const getStateForNewMonthSpy =
+            sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          getStateForNewMonthSpy.reset();
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            enableOutsideDays: true,
           });
-
-          it('sets state.currentMonth to getStateForNewMonth.currentMonth', () => {
-            const currentMonth = moment().add(10, 'months');
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              enableOutsideDays: true,
-            });
-            expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
-          });
-
-          it('sets state.visibleDays to getStateForNewMonth.visibleDays', () => {
-            const currentMonth = moment().add(10, 'months');
-            const visibleDays = getVisibleDays(currentMonth, 1);
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth, visibleDays });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: START_DATE,
-              enableOutsideDays: true,
-            });
-            expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
-          });
+          expect(getStateForNewMonthSpy.callCount).to.equal(1);
         });
 
-        describe('focusedInput has not changed', () => {
-          it('does not call getStateForNewMonth', () => {
-            const getStateForNewMonthSpy =
-              sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            getStateForNewMonthSpy.reset();
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              enableOutsideDays: true,
-            });
-            expect(getStateForNewMonthSpy.callCount).to.equal(0);
+        it('sets state.currentMonth to getStateForNewMonth.currentMonth', () => {
+          const currentMonth = moment().add(10, 'months');
+          const getStateForNewMonthStub =
+            sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
+
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            enableOutsideDays: true,
           });
+          expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
+        });
 
-          it('does not change state.currentMonth', () => {
-            const currentMonth = moment().add(10, 'months');
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({ currentMonth: moment(), visibleDays: {} });
+        it('sets state.visibleDays to getStateForNewMonth.visibleDays', () => {
+          const currentMonth = moment().add(10, 'months');
+          const visibleDays = getVisibleDays(currentMonth, 1);
+          const getStateForNewMonthStub =
+            sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
+          getStateForNewMonthStub.returns({ currentMonth, visibleDays });
 
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.setState({ currentMonth });
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              enableOutsideDays: true,
-            });
-            expect(wrapper.instance().state.currentMonth).to.equal(currentMonth);
+          const wrapper = shallow(<DayPickerRangeController {...props} />);
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            enableOutsideDays: true,
           });
-
-          it('does not change state.visibleDays', () => {
-            const visibleDays = {};
-            const getStateForNewMonthStub =
-              sinon.stub(DayPickerRangeController.prototype, 'getStateForNewMonth');
-            getStateForNewMonthStub.returns({
-              currentMonth: moment(),
-              visibleDays: getVisibleDays(moment(), 1),
-            });
-
-            const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              focusedInput: null,
-              enableOutsideDays: true,
-            });
-            expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
-          });
+          expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
         });
       });
     });


### PR DESCRIPTION
Address #700 

Basically, the state in the DayPickerRangeController would previously be recomputed for a change in enableOutsideDays or numberOfMonths if and only the component had become focused. This change makes it so that they are always recomputed.

cc: @ArtyomResh @ljharb @gabergg @airbnb/webinfra 