### PR TITLE
Some improvements for screen readers [a11y]

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -132,10 +132,13 @@ export default class CalendarMonth extends React.Component {
 
     return (
       <div className={calendarMonthClasses} data-visible={isVisible}>
-        <table>
-          <caption className="CalendarMonth__caption js-CalendarMonth__caption">
-            <strong>{monthTitle}</strong>
-          </caption>
+        <div
+          id="CalendarMonth__caption"
+          className="CalendarMonth__caption js-CalendarMonth__caption"
+        >
+          <strong>{monthTitle}</strong>
+        </div>
+        <table role="presentation">
 
           <tbody className="js-CalendarMonth__grid">
             {weeks.map((week, i) => (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -825,6 +825,9 @@ export default class DayPicker extends React.Component {
       <div
         className={dayPickerClassNames}
         style={dayPickerStyle}
+        role="application"
+        aria-label="Calendar"
+        aria-describedby="CalendarMonth__caption"
       >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
           <div

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -826,8 +826,7 @@ export default class DayPicker extends React.Component {
         className={dayPickerClassNames}
         style={dayPickerStyle}
         role="application"
-        aria-label="Calendar"
-        aria-describedby="CalendarMonth__caption"
+        aria-label={phrases.calendarLabel}
       >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
           <div

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -132,6 +132,15 @@ const defaultProps = {
   isRTL: false,
 };
 
+const getChooseAvailableDatePhrase = (phrases, focusedInput) => {
+  if (focusedInput === START_DATE) {
+    return phrases.chooseAvailableStartDate;
+  } else if (focusedInput === END_DATE) {
+    return phrases.chooseAvailableEndDate;
+  }
+  return phrases.chooseAvailableDate;
+};
+
 export default class DayPickerRangeController extends React.Component {
   constructor(props) {
     super(props);
@@ -172,6 +181,22 @@ export default class DayPickerRangeController extends React.Component {
     this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
     this.setDayPickerRef = this.setDayPickerRef.bind(this);
+  }
+
+  componentDidMount() {
+    const { focusedInput } = this.props;
+    const { phrases } = this.state;
+
+    // initialize phrases
+    // set the appropriate CalendarDay phrase based on focusedInput
+    const chooseAvailableDate = getChooseAvailableDatePhrase(phrases, focusedInput);
+
+    this.setState({
+      phrases: {
+        ...phrases,
+        chooseAvailableDate,
+      },
+    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -356,12 +381,7 @@ export default class DayPickerRangeController extends React.Component {
 
     if (didFocusChange || phrases !== this.props.phrases) {
       // set the appropriate CalendarDay phrase based on focusedInput
-      let chooseAvailableDate = phrases.chooseAvailableDate;
-      if (focusedInput === START_DATE) {
-        chooseAvailableDate = phrases.chooseAvailableStartDate;
-      } else if (focusedInput === END_DATE) {
-        chooseAvailableDate = phrases.chooseAvailableEndDate;
-      }
+      const chooseAvailableDate = getChooseAvailableDatePhrase(phrases, focusedInput);
 
       this.setState({
         phrases: {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -166,10 +166,17 @@ export default class DayPickerRangeController extends React.Component {
 
     const { currentMonth, visibleDays } = this.getStateForNewMonth(props);
 
+    // initialize phrases
+    // set the appropriate CalendarDay phrase based on focusedInput
+    const chooseAvailableDate = getChooseAvailableDatePhrase(props.phrases, props.focusedInput);
+
     this.state = {
       hoverDate: null,
       currentMonth,
-      phrases: props.phrases,
+      phrases: {
+        ...props.phrases,
+        chooseAvailableDate,
+      },
       visibleDays,
     };
 
@@ -181,22 +188,6 @@ export default class DayPickerRangeController extends React.Component {
     this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
     this.setDayPickerRef = this.setDayPickerRef.bind(this);
-  }
-
-  componentDidMount() {
-    const { focusedInput } = this.props;
-    const { phrases } = this.state;
-
-    // initialize phrases
-    // set the appropriate CalendarDay phrase based on focusedInput
-    const chooseAvailableDate = getChooseAvailableDatePhrase(phrases, focusedInput);
-
-    this.setState({
-      phrases: {
-        ...phrases,
-        chooseAvailableDate,
-      },
-    });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -1,3 +1,4 @@
+const calendarLabel = 'Calendar';
 const closeDatePicker = 'Close';
 const focusStartDate = 'Interact with the calendar and add the check-in date for your trip.';
 const clearDate = 'Clear Date';
@@ -33,6 +34,7 @@ const chooseAvailableDate = ({ date }) => date;
 const dateIsUnavailable = ({ date }) => `Not available. ${date}`;
 
 export default {
+  calendarLabel,
   closeDatePicker,
   focusStartDate,
   clearDate,
@@ -64,6 +66,7 @@ export default {
 };
 
 export const DateRangePickerPhrases = {
+  calendarLabel,
   closeDatePicker,
   clearDates,
   focusStartDate,
@@ -99,6 +102,7 @@ export const DateRangePickerInputPhrases = {
 };
 
 export const SingleDatePickerPhrases = {
+  calendarLabel,
   closeDatePicker,
   clearDate,
   jumpToPrevMonth,
@@ -131,6 +135,7 @@ export const SingleDatePickerInputPhrases = {
 };
 
 export const DayPickerPhrases = {
+  calendarLabel,
   jumpToPrevMonth,
   jumpToNextMonth,
   keyboardShortcuts,

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -41,18 +41,18 @@ describe('CalendarMonth', () => {
 
     describe('caption', () => {
       it('.CalendarMonth__caption class is present', () => {
-        const caption = shallow(<CalendarMonth />).find('caption');
+        const caption = shallow(<CalendarMonth />).find('#CalendarMonth__caption');
         expect(caption.is('.CalendarMonth__caption')).to.equal(true);
       });
 
       it('.js-CalendarMonth__caption class is present', () => {
-        const caption = shallow(<CalendarMonth />).find('caption');
+        const caption = shallow(<CalendarMonth />).find('#CalendarMonth__caption');
         expect(caption.is('.js-CalendarMonth__caption')).to.equal(true);
       });
 
       it('text is the correctly formatted month title', () => {
         const MONTH = moment();
-        const caption = shallow(<CalendarMonth month={MONTH} />).find('caption');
+        const caption = shallow(<CalendarMonth month={MONTH} />).find('#CalendarMonth__caption');
         expect(caption.text()).to.equal(MONTH.format('MMMM YYYY'));
       });
     });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -122,7 +122,7 @@ describe('DateRangePicker', () => {
     describe('props.openDirection === OPEN_DOWN', () => {
       it('renders .DateRangePicker__picker--open-down class', () => {
         const wrapper = shallow(
-          <DateRangePicker openDirection={OPEN_DOWN} focusedInput={START_DATE} />,
+          <DateRangePicker {...requiredProps} openDirection={OPEN_DOWN} focusedInput={START_DATE} />,
         );
         expect(wrapper.find('.DateRangePicker__picker--open-down')).to.have.length(1);
       });
@@ -131,7 +131,7 @@ describe('DateRangePicker', () => {
     describe('props.openDirection === OPEN_UP', () => {
       it('renders .DateRangePicker__picker--open-up class', () => {
         const wrapper = shallow(
-          <DateRangePicker openDirection={OPEN_UP} focusedInput={START_DATE} />,
+          <DateRangePicker {...requiredProps} openDirection={OPEN_UP} focusedInput={START_DATE} />,
         );
         expect(wrapper.find('.DateRangePicker__picker--open-up')).to.have.length(1);
       });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -20,37 +20,50 @@ import {
   OPEN_UP,
 } from '../../constants';
 
+const requiredProps = {
+  onDatesChange: () => {},
+  onFocusChange: () => {},
+};
+
 describe('DateRangePicker', () => {
   describe('#render()', () => {
     it('has .DateRangePicker class', () => {
-      const wrapper = shallow(<DateRangePicker />);
+      const wrapper = shallow(<DateRangePicker {...requiredProps} />);
       expect(wrapper.find('.DateRangePicker')).to.have.length(1);
     });
 
     it('renders .DateRangePicker__picker class', () => {
-      const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
+      const wrapper = shallow(<DateRangePicker {...requiredProps} focusedInput={START_DATE} />);
       expect(wrapper.find('.DateRangePicker__picker')).to.have.length(1);
     });
 
     it('renders .DateRangePicker__picker--rtl class', () => {
-      const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} isRTL />);
+      const wrapper = shallow(<DateRangePicker
+        {...requiredProps}
+        focusedInput={START_DATE}
+        isRTL
+      />);
       expect(wrapper.find('.DateRangePicker__picker--rtl')).to.have.length(1);
     });
 
     it('renders <DateRangePickerInputWithHandlers />', () => {
-      const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
+      const wrapper = shallow(<DateRangePicker {...requiredProps} focusedInput={START_DATE} />);
       expect(wrapper.find(DateRangePickerInputController)).to.have.length(1);
     });
 
     it('renders <DayPickerRangeController />', () => {
-      const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
+      const wrapper = shallow(<DateRangePicker {...requiredProps} focusedInput={START_DATE} />);
       expect(wrapper.find(DayPickerRangeController)).to.have.length(1);
     });
 
     describe('props.orientation === VERTICAL_ORIENTATION', () => {
       it('renders .DateRangePicker__picker--vertical class', () => {
         const wrapper = shallow(
-          <DateRangePicker orientation={VERTICAL_ORIENTATION} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            orientation={VERTICAL_ORIENTATION}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find('.DateRangePicker__picker--vertical')).to.have.length(1);
       });
@@ -59,14 +72,22 @@ describe('DateRangePicker', () => {
     describe('props.orientation === HORIZONTAL_ORIENTATION', () => {
       it('renders .DateRangePicker__picker--horizontal class', () => {
         const wrapper = shallow(
-          <DateRangePicker orientation={HORIZONTAL_ORIENTATION} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            orientation={HORIZONTAL_ORIENTATION}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find('.DateRangePicker__picker--horizontal')).to.have.length(1);
       });
 
       it('renders <DayPickerRangeController /> with props.numberOfMonths === 2', () => {
         const wrapper = shallow(
-          <DateRangePicker orientation={HORIZONTAL_ORIENTATION} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            orientation={HORIZONTAL_ORIENTATION}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find(DayPickerRangeController).props().numberOfMonths).to.equal(2);
       });
@@ -75,7 +96,11 @@ describe('DateRangePicker', () => {
     describe('props.anchorDirection === ANCHOR_LEFT', () => {
       it('renders .DateRangePicker__picker--direction-left class', () => {
         const wrapper = shallow(
-          <DateRangePicker anchorDirection={ANCHOR_LEFT} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            anchorDirection={ANCHOR_LEFT}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find('.DateRangePicker__picker--direction-left')).to.have.length(1);
       });
@@ -84,7 +109,11 @@ describe('DateRangePicker', () => {
     describe('props.anchorDirection === ANCHOR_RIGHT', () => {
       it('renders .DateRangePicker__picker--direction-right class', () => {
         const wrapper = shallow(
-          <DateRangePicker anchorDirection={ANCHOR_RIGHT} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            anchorDirection={ANCHOR_RIGHT}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find('.DateRangePicker__picker--direction-right')).to.have.length(1);
       });
@@ -110,24 +139,39 @@ describe('DateRangePicker', () => {
 
     describe('props.withPortal is truthy', () => {
       it('renders .DateRangePicker__picker--portal class', () => {
-        const wrapper = shallow(<DateRangePicker withPortal focusedInput={START_DATE} />);
+        const wrapper = shallow(
+          <DateRangePicker
+            {...requiredProps}
+            withPortal
+            focusedInput={START_DATE}
+          />);
         expect(wrapper.find('.DateRangePicker__picker--portal')).to.have.length(1);
       });
 
       describe('<Portal />', () => {
         it('is rendered', () => {
-          const wrapper = shallow(<DateRangePicker withPortal focusedInput={START_DATE} />);
+          const wrapper = shallow(
+            <DateRangePicker
+              {...requiredProps}
+              withPortal
+              focusedInput={START_DATE}
+            />);
           expect(wrapper.find(Portal)).to.have.length(1);
         });
 
         it('is not rendered if props.focusedInput === null', () => {
           const wrapper =
-            shallow(<DateRangePicker focusedInput={null} withPortal />);
+            shallow(<DateRangePicker {...requiredProps} focusedInput={null} withPortal />);
           expect(wrapper.find(Portal)).to.have.length(0);
         });
 
         it('isOpened prop is true if props.focusedInput !== null', () => {
-          const wrapper = shallow(<DateRangePicker withPortal focusedInput={START_DATE} />);
+          const wrapper = shallow(
+            <DateRangePicker
+              {...requiredProps}
+              withPortal
+              focusedInput={START_DATE}
+            />);
           expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
@@ -135,37 +179,57 @@ describe('DateRangePicker', () => {
 
     describe('props.withFullScreenPortal is truthy', () => {
       it('renders .DateRangePicker__picker--portal class', () => {
-        const wrapper = shallow(<DateRangePicker withFullScreenPortal focusedInput={START_DATE} />);
+        const wrapper = shallow(
+          <DateRangePicker
+            {...requiredProps}
+            withFullScreenPortal
+            focusedInput={START_DATE}
+          />);
         expect(wrapper.find('.DateRangePicker__picker--portal')).to.have.length(1);
       });
 
       it('renders .DateRangePicker__picker--full-screen-portal class', () => {
-        const wrapper = shallow(<DateRangePicker withFullScreenPortal focusedInput={START_DATE} />);
+        const wrapper = shallow(
+          <DateRangePicker
+            {...requiredProps}
+            withFullScreenPortal
+            focusedInput={START_DATE}
+          />);
         expect(wrapper.find('.DateRangePicker__picker--full-screen-portal')).to.have.length(1);
       });
 
       it('does not render <DayPickerRangeController>', () => {
-        const wrapper = shallow(<DateRangePicker withFullScreenPortal />);
+        const wrapper = shallow(<DateRangePicker {...requiredProps} withFullScreenPortal />);
         expect(wrapper.find(DayPickerRangeController)).to.have.length(0);
       });
 
       describe('<Portal />', () => {
         it('is rendered', () => {
           const wrapper = shallow(
-            <DateRangePicker withFullScreenPortal focusedInput={START_DATE} />,
+            <DateRangePicker {...requiredProps} withFullScreenPortal focusedInput={START_DATE} />,
           );
           expect(wrapper.find(Portal)).to.have.length(1);
         });
 
         it('is not rendered if props.focusedInput === null', () => {
           const wrapper =
-            shallow(<DateRangePicker focusedInput={null} withFullScreenPortal />);
+            shallow(
+              <DateRangePicker
+                {...requiredProps}
+                focusedInput={null}
+                withFullScreenPortal
+              />);
           expect(wrapper.find(Portal)).to.have.length(0);
         });
 
         it('isOpened prop is true if props.focusedInput !== null', () => {
           const wrapper =
-            shallow(<DateRangePicker withFullScreenPortal focusedInput={START_DATE} />);
+            shallow(
+              <DateRangePicker
+                {...requiredProps}
+                withFullScreenPortal
+                focusedInput={START_DATE}
+              />);
           expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
@@ -173,12 +237,12 @@ describe('DateRangePicker', () => {
 
     describe('props.focusedInput', () => {
       it('renders <DayPickerRangeController> if props.focusedInput != null', () => {
-        const wrapper = shallow(<DateRangePicker focusedInput={START_DATE} />);
+        const wrapper = shallow(<DateRangePicker {...requiredProps} focusedInput={START_DATE} />);
         expect(wrapper.find(DayPickerRangeController)).to.have.length(1);
       });
 
       it('does not render <DayPickerRangeController> if props.focusedInput = null', () => {
-        const wrapper = shallow(<DateRangePicker focusedInput={null} />);
+        const wrapper = shallow(<DateRangePicker {...requiredProps} focusedInput={null} />);
         expect(wrapper.find(DayPickerRangeController)).to.have.length(0);
       });
     });
@@ -188,7 +252,12 @@ describe('DateRangePicker', () => {
     it('does not call props.onFocusChange if props.focusedInput = null', () => {
       const onFocusChangeStub = sinon.stub();
       const wrapper =
-        shallow(<DateRangePicker focusedInput={null} onFocusChange={onFocusChangeStub} />);
+        shallow(
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={null}
+            onFocusChange={onFocusChangeStub}
+          />);
       wrapper.instance().onOutsideClick();
       expect(onFocusChangeStub.callCount).to.equal(0);
     });
@@ -196,7 +265,12 @@ describe('DateRangePicker', () => {
     it('calls props.onFocusChange if props.focusedInput != null', () => {
       const onFocusChangeStub = sinon.stub();
       const wrapper =
-        shallow(<DateRangePicker focusedInput={START_DATE} onFocusChange={onFocusChangeStub} />);
+        shallow(
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            onFocusChange={onFocusChangeStub}
+          />);
       wrapper.instance().onOutsideClick();
       expect(onFocusChangeStub.callCount).to.equal(1);
     });
@@ -204,6 +278,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDateRangePickerInputFocused to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           focusedInput={START_DATE}
           onFocusChange={sinon.stub()}
           onDatesChange={sinon.stub()}
@@ -219,6 +294,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDayPickerFocused to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           focusedInput={START_DATE}
           onFocusChange={sinon.stub()}
           onDatesChange={sinon.stub()}
@@ -234,6 +310,7 @@ describe('DateRangePicker', () => {
     it('sets state.showKeyboardShortcuts to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           focusedInput={START_DATE}
           onFocusChange={sinon.stub()}
           onDatesChange={sinon.stub()}
@@ -250,6 +327,7 @@ describe('DateRangePicker', () => {
       const onCloseStub = sinon.stub();
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           focusedInput={null}
           onClose={onCloseStub}
           onFocusChange={() => null}
@@ -265,6 +343,7 @@ describe('DateRangePicker', () => {
       const onCloseStub = sinon.stub();
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           startDate={startDate}
           endDate={endDate}
           focusedInput={START_DATE}
@@ -286,6 +365,7 @@ describe('DateRangePicker', () => {
       const onFocusChangeStub = sinon.stub();
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={onFocusChangeStub}
         />,
@@ -299,6 +379,7 @@ describe('DateRangePicker', () => {
       const onFocusChangeStub = sinon.stub();
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={onFocusChangeStub}
         />,
@@ -320,6 +401,7 @@ describe('DateRangePicker', () => {
       it('calls onDayPickerFocus if focusedInput and withPortal/withFullScreenPortal', () => {
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             onDatesChange={sinon.stub()}
             onFocusChange={sinon.stub()}
             withPortal
@@ -332,6 +414,7 @@ describe('DateRangePicker', () => {
       it('calls onDayPickerFocus if focusedInput and withFullScreenPortal', () => {
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             onDatesChange={sinon.stub()}
             onFocusChange={sinon.stub()}
             withFullScreenPortal
@@ -345,6 +428,7 @@ describe('DateRangePicker', () => {
         const onDayPickerBlurSpy = sinon.spy(DateRangePicker.prototype, 'onDayPickerBlur');
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             onDatesChange={sinon.stub()}
             onFocusChange={sinon.stub()}
           />,
@@ -359,6 +443,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDateRangePickerInputFocused to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -373,6 +458,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDayPickerFocused to true', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -387,6 +473,7 @@ describe('DateRangePicker', () => {
     it('sets state.showKeyboardShortcuts to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -403,6 +490,7 @@ describe('DateRangePicker', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             focusedInput={START_DATE}
             onDatesChange={sinon.stub()}
             onFocusChange={onFocusChangeStub}
@@ -418,6 +506,7 @@ describe('DateRangePicker', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             focusedInput={null}
             onDatesChange={sinon.stub()}
             onFocusChange={onFocusChangeStub}
@@ -431,6 +520,7 @@ describe('DateRangePicker', () => {
         const onFocusChangeStub = sinon.stub();
         const wrapper = shallow(
           <DateRangePicker
+            {...requiredProps}
             focusedInput={null}
             onDatesChange={sinon.stub()}
             onFocusChange={onFocusChangeStub}
@@ -446,6 +536,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDateRangePickerInputFocused to true', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -460,6 +551,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDayPickerFocused to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -474,6 +566,7 @@ describe('DateRangePicker', () => {
     it('sets state.showKeyboardShortcuts to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -490,6 +583,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDateRangePickerInputFocused to false', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -504,6 +598,7 @@ describe('DateRangePicker', () => {
     it('sets state.isDayPickerFocused to true', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -518,6 +613,7 @@ describe('DateRangePicker', () => {
     it('sets state.showKeyboardShortcuts to true', () => {
       const wrapper = shallow(
         <DateRangePicker
+          {...requiredProps}
           onDatesChange={sinon.stub()}
           onFocusChange={sinon.stub()}
         />,
@@ -535,7 +631,11 @@ describe('DateRangePicker', () => {
       it('DayPickerRangeController.props.initialVisibleMonth is equal to initialVisibleMonth', () => {
         const initialVisibleMonth = () => {};
         const wrapper = shallow(
-          <DateRangePicker focusedInput={START_DATE} initialVisibleMonth={initialVisibleMonth} />,
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            initialVisibleMonth={initialVisibleMonth}
+          />,
         );
         const dayPicker = wrapper.find(DayPickerRangeController);
         expect(dayPicker.props().initialVisibleMonth).to.equal(initialVisibleMonth);
@@ -546,7 +646,12 @@ describe('DateRangePicker', () => {
       it('DayPickerRangeController.props.initialVisibleMonth evaluates to startDate', () => {
         const startDate = moment().add(10, 'days');
         const wrapper =
-          shallow(<DateRangePicker focusedInput={START_DATE} startDate={startDate} />);
+          shallow(
+            <DateRangePicker
+              {...requiredProps}
+              focusedInput={START_DATE}
+              startDate={startDate}
+            />);
         const dayPicker = wrapper.find(DayPickerRangeController);
         expect(dayPicker.props().initialVisibleMonth()).to.equal(startDate);
       });
@@ -554,7 +659,12 @@ describe('DateRangePicker', () => {
       it('DayPickerRangeController.props.initialVisibleMonth evaluates to endDate if !startDate', () => {
         const endDate = moment().add(5, 'days');
         const wrapper =
-          shallow(<DateRangePicker focusedInput={START_DATE} endDate={endDate} />);
+          shallow(
+            <DateRangePicker
+              {...requiredProps}
+              focusedInput={START_DATE}
+              endDate={endDate}
+            />);
         const dayPicker = wrapper.find(DayPickerRangeController);
         expect(dayPicker.props().initialVisibleMonth()).to.equal(endDate);
       });
@@ -562,7 +672,7 @@ describe('DateRangePicker', () => {
       it('DayPickerRangeController.props.initialVisibleMonth evaluates to today if !startDate && !endDate', () => {
         const today = moment();
         const wrapper =
-          shallow(<DateRangePicker focusedInput={START_DATE} />);
+          shallow(<DateRangePicker {...requiredProps} focusedInput={START_DATE} />);
         const dayPicker = wrapper.find(DayPickerRangeController);
         expect(dayPicker.props().initialVisibleMonth().isSame(today, 'day')).to.equal(true);
       });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -122,7 +122,11 @@ describe('DateRangePicker', () => {
     describe('props.openDirection === OPEN_DOWN', () => {
       it('renders .DateRangePicker__picker--open-down class', () => {
         const wrapper = shallow(
-          <DateRangePicker {...requiredProps} openDirection={OPEN_DOWN} focusedInput={START_DATE} />,
+          <DateRangePicker
+            {...requiredProps}
+            openDirection={OPEN_DOWN}
+            focusedInput={START_DATE}
+          />,
         );
         expect(wrapper.find('.DateRangePicker__picker--open-down')).to.have.length(1);
       });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -59,7 +59,6 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />,
           );
-          wrapper.instance().componentDidMount();
           const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
           expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableStartDate);
         });
@@ -74,7 +73,6 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />,
           );
-          wrapper.instance().componentDidMount();
           const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
           expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableEndDate);
         });
@@ -89,7 +87,6 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />,
           );
-          wrapper.instance().componentDidMount();
           const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
           expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableDate);
         });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -36,6 +36,67 @@ describe('DayPickerRangeController', () => {
     });
   });
 
+  describe('#componentDidMount', () => {
+    const props = {
+      ...DayPickerRangeController.defaultProps,
+      onDatesChange() {},
+      onFocusChange() {},
+    };
+
+    describe('phrases', () => {
+      const phrases = {
+        chooseAvailableDate: 'test1',
+        chooseAvailableStartDate: 'test2',
+        chooseAvailableEndDate: 'test3',
+      };
+
+      describe('focusedInput is START_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableStartDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              {...props}
+              focusedInput={START_DATE}
+              phrases={phrases}
+            />,
+          );
+          wrapper.instance().componentDidMount();
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableStartDate);
+        });
+      });
+
+      describe('focusedInput is END_DATE', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableEndDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              {...props}
+              focusedInput={END_DATE}
+              phrases={phrases}
+            />,
+          );
+          wrapper.instance().componentDidMount();
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableEndDate);
+        });
+      });
+
+      describe('focusedInput is null', () => {
+        it('state.phrases.chooseAvailableDate equals props.phrases.chooseAvailableDate', () => {
+          const wrapper = shallow(
+            <DayPickerRangeController
+              {...props}
+              focusedInput={null}
+              phrases={phrases}
+            />,
+          );
+          wrapper.instance().componentDidMount();
+          const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
+          expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableDate);
+        });
+      });
+    });
+  });
+
   describe('#componentWillReceiveProps', () => {
     const props = {
       ...DayPickerRangeController.defaultProps,

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -21,41 +21,45 @@ describe('SingleDatePickerInput', () => {
   describe('clear date', () => {
     describe('props.showClearDate is falsey', () => {
       it('does not have .SingleDatePickerInput__clear-date class', () => {
-        const wrapper = shallow(<SingleDatePickerInput showClearDate={false} />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate={false} />);
         expect(wrapper.find('.SingleDatePickerInput__clear-date')).to.have.lengthOf(0);
       });
     });
 
     describe('props.showClearDate is truthy', () => {
       it('has .SingleDatePickerInput__clear-date class', () => {
-        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate />);
         expect(wrapper.find('.SingleDatePickerInput__clear-date')).to.have.lengthOf(1);
       });
 
       it('has .SingleDatePickerInput__clear-date--hover class if state.isClearDateHovered',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+          const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate />);
           wrapper.setState({ isClearDateHovered: true });
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hover')).to.have.lengthOf(1);
         });
 
       it('no .SingleDatePickerInput__clear-date--hover class if !state.isClearDateHovered',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+          const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate />);
           wrapper.setState({ isClearDateHovered: false });
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hover')).to.have.lengthOf(0);
         });
 
       it('has .SingleDatePickerInput__clear-date--hide class if there is no date',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate displayValue={null} />);
+          const wrapper = shallow(<SingleDatePickerInput
+            id="date"
+            showClearDate
+            displayValue={null}
+          />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(1);
         });
 
       it('does not have .SingleDatePickerInput__clear-date--hide class if there is a date',
         () => {
           const wrapper =
-            shallow(<SingleDatePickerInput showClearDate displayValue="2016-07-13" />);
+            shallow(<SingleDatePickerInput id="date" showClearDate displayValue="2016-07-13" />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
         });
     });
@@ -64,6 +68,7 @@ describe('SingleDatePickerInput', () => {
       it('has custom icon', () => {
         const wrapper = shallow(
           <SingleDatePickerInput
+            id="date"
             showClearDate
             customCloseIcon={<span className="custom-close-icon" />}
           />);
@@ -75,14 +80,14 @@ describe('SingleDatePickerInput', () => {
   describe('show calendar icon', () => {
     describe('props.showInputIcon is falsey', () => {
       it('does not have .SingleDatePickerInput__calendar-icon class', () => {
-        const wrapper = shallow(<SingleDatePickerInput showDefaultInputIcon={false} />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showDefaultInputIcon={false} />);
         expect(wrapper.find('.SingleDatePickerInput__calendar-icon')).to.have.lengthOf(0);
       });
     });
 
     describe('props.showInputIcon is truthy', () => {
       it('has .SingleDatePickerInput__calendar-icon class', () => {
-        const wrapper = shallow(<SingleDatePickerInput showDefaultInputIcon />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showDefaultInputIcon />);
         expect(wrapper.find('.SingleDatePickerInput__calendar-icon')).to.have.lengthOf(1);
       });
     });
@@ -91,6 +96,7 @@ describe('SingleDatePickerInput', () => {
       it('has custom icon', () => {
         const wrapper = shallow(
           <SingleDatePickerInput
+            id="date"
             customInputIcon={<span className="custom-icon" />}
           />);
         expect(wrapper.find('.SingleDatePickerInput__calendar-icon .custom-icon')).to.have.lengthOf(1);
@@ -100,7 +106,7 @@ describe('SingleDatePickerInput', () => {
 
   describe('#onClearDateMouseEnter', () => {
     it('sets state.isClearDateHovered to true', () => {
-      const wrapper = shallow(<SingleDatePickerInput />);
+      const wrapper = shallow(<SingleDatePickerInput id="date" />);
       wrapper.setState({ isClearDateHovered: false });
       wrapper.instance().onClearDateMouseEnter();
       expect(wrapper.state().isClearDateHovered).to.equal(true);
@@ -109,7 +115,7 @@ describe('SingleDatePickerInput', () => {
 
   describe('#onClearDateMouseLeave', () => {
     it('sets state.isClearDateHovered to false', () => {
-      const wrapper = shallow(<SingleDatePickerInput />);
+      const wrapper = shallow(<SingleDatePickerInput id="date" />);
       wrapper.setState({ isClearDateHovered: true });
       wrapper.instance().onClearDateMouseLeave();
       expect(wrapper.state().isClearDateHovered).to.equal(false);
@@ -122,6 +128,7 @@ describe('SingleDatePickerInput', () => {
         const onClearDateSpy = sinon.spy();
         const wrapper = shallow(
           <SingleDatePickerInput
+            id="date"
             onClearDate={onClearDateSpy}
             showClearDate
           />,
@@ -138,7 +145,7 @@ describe('SingleDatePickerInput', () => {
           SingleDatePickerInput.prototype,
           'onClearDateMouseEnter',
         );
-        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate />);
         const clearDateWrapper = wrapper.find('.SingleDatePickerInput__clear-date');
 
         clearDateWrapper.simulate('mouseEnter');
@@ -153,7 +160,7 @@ describe('SingleDatePickerInput', () => {
           SingleDatePickerInput.prototype,
           'onClearDateMouseLeave',
         );
-        const wrapper = shallow(<SingleDatePickerInput showClearDate />);
+        const wrapper = shallow(<SingleDatePickerInput id="date" showClearDate />);
         const clearDateWrapper = wrapper.find('.SingleDatePickerInput__clear-date');
 
         clearDateWrapper.simulate('mouseLeave');


### PR DESCRIPTION
Doing some screen reader testing on this and identified some things that could make the reading a little more clear/helpful:

1. The table was being interpreted as a data table versus a layout table and was reading extraneous info about the number of columns and rows in the current cell happened to be.  The cell already nicely reads the full date and day of the week and therefore there's no need for the screen reader to associate the column headers with the cell.

1. The DayPickerRangeController did not seem to be properly setting the chooseAvailableStartDate phrase after first mounting so only after picking a start date and moving to the end date would the reader nicely read "it's available" for the date options.

1. I did also notice Issue #713 where unavailable dates are not reading as "unavailable" but I haven't figured out what's causing that yet and since it's already a known issue wanted to move forward with these changes before moving on to trying to help out with that one.