### PR TITLE
Move calendar month caption div outside of table

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -171,18 +171,18 @@ class CalendarMonth extends React.Component {
         )}
         data-visible={isVisible}
       >
-        <table {...css(styles.CalendarMonth_table)} role="presentation">
-          <div
-            id="CalendarMonth__caption"
-            ref={this.setCaptionRef}
-            {...css(
-              styles.CalendarMonth_caption,
-              verticalScrollable && styles.CalendarMonth_caption__verticalScrollable,
-            )}
-          >
-            <strong>{monthTitle}</strong>
-          </div>
+        <div
+          id="CalendarMonth__caption"
+          ref={this.setCaptionRef}
+          {...css(
+            styles.CalendarMonth_caption,
+            verticalScrollable && styles.CalendarMonth_caption__verticalScrollable,
+          )}
+        >
+          <strong>{monthTitle}</strong>
+        </div>
 
+        <table {...css(styles.CalendarMonth_table)} role="presentation">
           <tbody ref={this.setGridRef}>
             {weeks.map((week, i) => (
               <tr key={i}>


### PR DESCRIPTION
In a bad rebase, I left this div inside the table which caused... problems.

to: @ljharb