### PR TITLE
Changes css style specificity to 0

### DIFF
--- a/scripts/buildCSS.js
+++ b/scripts/buildCSS.js
@@ -13,9 +13,7 @@ const optimizeForProduction = args.includes('-o') || args.includes('--optimize')
 
 require('../test/_helpers/ignoreSVGStrings');
 
-// This magic number of 11 is selected from the maximum number of arguments
-// passed into any css call in this package.
-registerMaxSpecificity(11);
+registerMaxSpecificity(0);
 registerCSSInterfaceWithDefaultTheme();
 
 const DateRangePickerPath = './src/components/DateRangePicker.jsx';

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -126,9 +126,9 @@ class CalendarDay extends React.Component {
       modifiers.has('selected-start') ||
       modifiers.has('selected-end');
 
-    const hoveredSpan =
+    const hoveredSpan = !selected && (
       modifiers.has('hovered-span') ||
-      modifiers.has('after-hovered-start');
+      modifiers.has('after-hovered-start'));
 
     const isOutsideRange = modifiers.has('blocked-out-of-range');
 


### PR DESCRIPTION
While having specificity be quite high is a necessity in having `react-with-styles-interface-css` be fully operable, it is not actually necessary (with one small tweak) for `react-dates` itself. In order to have our exported css file be less of a trash-fire, I am reducing the specificity to zero.

to: @ljharb @lencioni 