### PR TITLE
Remove unnecessary caption object from CalendarMonth styles

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -226,9 +226,6 @@ export default withStyles(({ reactDates: { color, font, spacing } }) => ({
   CalendarMonth_table: {
     borderCollapse: 'collapse',
     borderSpacing: 0,
-    caption: {
-      captionSide: 'initial',
-    },
   },
 
   CalendarMonth_caption: {


### PR DESCRIPTION
This should fix #754

to: @ljharb @airbnb/webinfra 