### PR TITLE
Add missing customCloseIcon prop/usage to SingleDatePicker.

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -416,6 +416,7 @@ class SingleDatePicker extends React.Component {
       showClearDate,
       showDefaultInputIcon,
       inputIconPosition,
+      customCloseIcon,
       customInputIcon,
       date,
       phrases,
@@ -450,6 +451,7 @@ class SingleDatePicker extends React.Component {
             showClearDate={showClearDate}
             showDefaultInputIcon={showDefaultInputIcon}
             inputIconPosition={inputIconPosition}
+            customCloseIcon={customCloseIcon}
             customInputIcon={customInputIcon}
             displayValue={displayValue}
             inputValue={inputValue}


### PR DESCRIPTION
Properly pass the customCloseIcon property from the SingleDatePicker to the SingleDatePickerInput.