### PR TITLE
add verticalHeight prop for DayPicker

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -78,6 +78,7 @@ const defaultProps = {
   daySize: DAY_SIZE,
   isRTL: false,
   firstDayOfWeek: null,
+  verticalHeight: null,
 
   // navigation related props
   navPrev: null,
@@ -320,6 +321,7 @@ class DateRangePicker extends React.Component {
       isRTL,
       weekDayFormat,
       styles,
+      verticalHeight,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -386,6 +388,7 @@ class DateRangePicker extends React.Component {
           isRTL={isRTL}
           firstDayOfWeek={firstDayOfWeek}
           weekDayFormat={weekDayFormat}
+          verticalHeight={verticalHeight}
         />
 
         {withFullScreenPortal && (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -55,6 +55,7 @@ const propTypes = forbidExtraProps({
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
   isRTL: PropTypes.bool,
+  verticalHeight: nonNegativeInteger,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -99,6 +100,7 @@ export const defaultProps = {
   hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
   isRTL: false,
+  verticalHeight: null,
 
   // navigation props
   navPrev: null,
@@ -686,6 +688,7 @@ class DayPicker extends React.Component {
       isRTL,
       styles,
       phrases,
+      verticalHeight,
     } = this.props;
 
     const numOfWeekHeaders = this.isVertical() ? 1 : numberOfMonths;
@@ -706,15 +709,13 @@ class DayPicker extends React.Component {
       marginTop: this.isHorizontal() && withPortal && -calendarMonthWidth / 2,
     };
 
-    // this is a kind of made-up value that generally looks good. we'll
-    // probably want to let the user set this explicitly.
-    const verticalHeight = 1.75 * calendarMonthWidth;
-
     let height;
     if (this.isHorizontal()) {
       height = this.calendarMonthGridHeight;
     } else if (this.isVertical() && !verticalScrollable && !withPortal) {
-      height = verticalHeight;
+      // If the user doesn't set a desired height,
+      // we default back to this kind of made-up value that generally looks good
+      height = verticalHeight || 1.75 * calendarMonthWidth;
     }
 
     const transitionContainerStyle = {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -69,6 +69,7 @@ const propTypes = forbidExtraProps({
   renderDay: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
+  verticalHeight: nonNegativeInteger,
 
   // accessibility
   onBlur: PropTypes.func,
@@ -118,6 +119,7 @@ const defaultProps = {
   renderDay: null,
   renderCalendarInfo: null,
   firstDayOfWeek: null,
+  verticalHeight: null,
 
   // accessibility
   onBlur() {},
@@ -882,6 +884,7 @@ export default class DayPickerRangeController extends React.Component {
       showKeyboardShortcuts,
       isRTL,
       weekDayFormat,
+      verticalHeight,
     } = this.props;
 
     const { currentMonth, phrases, visibleDays } = this.state;
@@ -919,6 +922,7 @@ export default class DayPickerRangeController extends React.Component {
         phrases={phrases}
         isRTL={isRTL}
         weekDayFormat={weekDayFormat}
+        verticalHeight={verticalHeight}
       />
     );
   }

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -53,6 +53,7 @@ const propTypes = forbidExtraProps({
   firstDayOfWeek: DayOfWeekShape,
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
+  verticalHeight: nonNegativeInteger,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -99,6 +100,7 @@ const defaultProps = {
   initialVisibleMonth: null,
   firstDayOfWeek: null,
   daySize: DAY_SIZE,
+  verticalHeight: null,
 
   navPrev: null,
   navNext: null,
@@ -585,6 +587,7 @@ export default class DayPickerSingleDateController extends React.Component {
       onBlur,
       showKeyboardShortcuts,
       weekDayFormat,
+      verticalHeight,
     } = this.props;
 
     const { currentMonth, visibleDays } = this.state;
@@ -619,6 +622,7 @@ export default class DayPickerSingleDateController extends React.Component {
         isRTL={isRTL}
         showKeyboardShortcuts={showKeyboardShortcuts}
         weekDayFormat={weekDayFormat}
+        verticalHeight={verticalHeight}
       />
     );
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -73,6 +73,7 @@ const defaultProps = {
   hideKeyboardShortcutsPanel: false,
   daySize: DAY_SIZE,
   isRTL: false,
+  verticalHeight: null,
 
   // navigation related props
   navPrev: null,
@@ -345,6 +346,7 @@ class SingleDatePicker extends React.Component {
       isDayHighlighted,
       weekDayFormat,
       styles,
+      verticalHeight,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
 
@@ -398,6 +400,7 @@ class SingleDatePicker extends React.Component {
           isDayHighlighted={isDayHighlighted}
           firstDayOfWeek={firstDayOfWeek}
           weekDayFormat={weekDayFormat}
+          verticalHeight={verticalHeight}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -56,6 +56,7 @@ export default {
   reopenPickerOnClearDates: PropTypes.bool,
   renderCalendarInfo: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
+  verticalHeight: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -49,6 +49,7 @@ export default {
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
   isRTL: PropTypes.bool,
+  verticalHeight: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -2,6 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
+import {
+  VERTICAL_ORIENTATION,
+} from '../constants';
 
 import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
 
@@ -87,4 +90,10 @@ storiesOf('DateRangePicker (DRP)', module)
         renderDay={day => momentJalaali(day).format('jD')}
       />
     );
-  });
+  })
+  .addWithInfo('vertical with custom height', () => (
+    <DateRangePickerWrapper
+      orientation={VERTICAL_ORIENTATION}
+      verticalHeight={568}
+    />
+  ));

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -84,6 +84,13 @@ storiesOf('DayPicker', module)
       daySize={50}
     />
   ))
+  .addWithInfo('vertical with custom height', () => (
+    <DayPicker
+      numberOfMonths={2}
+      orientation={VERTICAL_ORIENTATION}
+      verticalHeight={568}
+    />
+  ))
   .addWithInfo('with custom arrows', () => (
     <DayPicker
       navPrev={<TestPrevIcon />}

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -2,6 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
+import {
+  VERTICAL_ORIENTATION,
+} from '../constants';
 
 import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 
@@ -55,4 +58,10 @@ storiesOf('SingleDatePicker (SDP)', module)
         renderDay={day => momentJalaali(day).format('jD')}
       />
     );
-  });
+  })
+  .addWithInfo('vertical with custom height', () => (
+    <SingleDatePickerWrapper
+      orientation={VERTICAL_ORIENTATION}
+      verticalHeight={568}
+    />
+  ));


### PR DESCRIPTION
Addresses #632 

👋

These changes allow the user of DayPicker to specify a vertical height (applied only when on vertical orientation), while keeping the current behavior (an arbitrary size) as the default if no height is specified.

This is actually slightly different than what the issue's title suggests, but imho it seems easier for the user to just have full control on the height rather than trying different "factors". Open to different opinions obviously!