### PR TITLE
Bump react-with-styles-interface-css version

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-svg-loader": "^1.1.1",
     "react-test-renderer": "^15.6.1",
     "react-with-styles-interface-aphrodite": "^3.1.1",
+    "react-with-styles-interface-css-compiler": "^1.0.1",
     "rimraf": "^2.6.2",
     "safe-publish-latest": "^1.1.1",
     "sass-loader": "^6.0.6",
@@ -121,7 +122,7 @@
     "react-moment-proptypes": "^1.5.0",
     "react-portal": "^3.1.0",
     "react-with-styles": "^2.2.0",
-    "react-with-styles-interface-css": "^2.0.2"
+    "react-with-styles-interface-css": "^3.0.0"
   },
   "peerDependencies": {
     "moment": "^2.18.1",

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": [2, {
+      "devDependencies": true
+    }],
+  }
+}

--- a/scripts/buildCSS.js
+++ b/scripts/buildCSS.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const CleanCSS = require('clean-css');
 
-const compileCSS = require('react-with-styles-interface-css/compile');
+const compileCSS = require('react-with-styles-interface-css-compiler');
 
 const registerMaxSpecificity = require('react-with-styles-interface-css/dist/utils/registerMaxSpecificity').default;
 const registerCSSInterfaceWithDefaultTheme = require('../src/utils/registerCSSInterfaceWithDefaultTheme').default;


### PR DESCRIPTION
Previously `react-with-styles-interface-css` included both the interface and the compiler. Because the compiler was doing some build step shenanigans to do compilation on the fly, it included a regular dependency on `babel-register` to do some babel compilation on the fly. This, of course, got passed down to consumers of `react-dates` which wasn't great. `react-with-styles-interface-css` split into ``react-with-styles-interface-css` and `react-with-styles-interface-css-compiler` in v3, and this PR addresses that change.

to: @ljharb