### PR TITLE
Fix some apparent a11y issues with react-dates

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -172,7 +172,6 @@ class CalendarMonth extends React.Component {
         data-visible={isVisible}
       >
         <div
-          id="CalendarMonth__caption"
           ref={this.setCaptionRef}
           {...css(
             styles.CalendarMonth_caption,
@@ -182,7 +181,10 @@ class CalendarMonth extends React.Component {
           <strong>{monthTitle}</strong>
         </div>
 
-        <table {...css(styles.CalendarMonth_table)} role="presentation">
+        <table
+          {...css(styles.CalendarMonth_table)}
+          role="presentation"
+        >
           <tbody ref={this.setGridRef}>
             {weeks.map((week, i) => (
               <tr key={i}>

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -13,7 +13,6 @@ const propTypes = forbidExtraProps({
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
-  inputValue: PropTypes.string,
   screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -37,7 +36,6 @@ const propTypes = forbidExtraProps({
 const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
-  inputValue: '',
   screenReaderMessage: '',
   focused: false,
   disabled: false,
@@ -90,7 +88,6 @@ class DateInput extends React.Component {
 
     if (focused && isFocused) {
       this.inputRef.focus();
-      this.inputRef.select();
     } else {
       this.inputRef.blur();
     }
@@ -149,7 +146,6 @@ class DateInput extends React.Component {
       id,
       placeholder,
       displayValue,
-      inputValue,
       screenReaderMessage,
       focused,
       showCaret,
@@ -161,8 +157,7 @@ class DateInput extends React.Component {
       styles,
     } = this.props;
 
-    const displayText = displayValue || inputValue || dateString || placeholder || '';
-    const value = inputValue || displayValue || dateString || '';
+    const value = displayValue || dateString || '';
     const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     const withCaret = showCaret && focused;
@@ -181,6 +176,8 @@ class DateInput extends React.Component {
           {...css(
             styles.DateInput_input,
             readOnly && styles.DateInput_input__readOnly,
+            focused && styles.DateInput_input__focused,
+            disabled && styles.DateInput_input__disabled,
           )}
           aria-label={placeholder}
           type="text"
@@ -204,17 +201,6 @@ class DateInput extends React.Component {
             {screenReaderMessage}
           </p>
         )}
-
-        <div
-          {...css(
-            styles.DateInput_displayText,
-            !!value && styles.DateInput_displayText__hasInput,
-            focused && styles.DateInput_displayText__focused,
-            disabled && styles.DateInput_displayText__disabled,
-          )}
-        >
-          {displayText}
-        </div>
       </div>
     );
   }
@@ -225,7 +211,7 @@ DateInput.defaultProps = defaultProps;
 
 export default withStyles(({
   reactDates: {
-    color, sizing, spacing, font, zIndex,
+    border, color, sizing, spacing, font, zIndex,
   },
 }) => {
   const inputHeight = parseInt(font.input.lineHeight, 10)
@@ -267,7 +253,6 @@ export default withStyles(({
         border: `${sizing.tooltipArrowWidth / 2}px solid transparent`,
         left: 22,
         zIndex: zIndex + 2,
-
       },
     },
 
@@ -301,20 +286,39 @@ export default withStyles(({
 
     DateInput__disabled: {
       background: color.disabled,
+      color: color.textDisabled,
     },
 
     DateInput_input: {
-      opacity: 0,
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      border: 0,
-      height: '100%',
+      fontWeight: 200,
+      fontSize: font.input.size,
+      color: color.text,
       width: '100%',
+      padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
+      border: border.input.border,
+      borderTop: border.input.borderTop,
+      borderRight: border.input.borderRight,
+      borderBottom: border.input.borderBottom,
+      borderLeft: border.input.borderLeft,
     },
 
     DateInput_input__readOnly: {
       userSelect: 'none',
+    },
+
+    DateInput_input__focused: {
+      outline: border.input.outlineFocused,
+      background: color.backgroundFocused,
+      border: border.input.borderFocused,
+      borderTop: border.input.borderTopFocused,
+      borderRight: border.input.borderRightFocused,
+      borderBottom: border.input.borderBottomFocused,
+      borderLeft: border.input.borderLeftFocused,
+    },
+
+    DateInput_input__disabled: {
+      background: color.disabled,
+      fontStyle: font.input.styleDisabled,
     },
 
     DateInput_screenReaderMessage: {
@@ -326,27 +330,6 @@ export default withStyles(({
       padding: 0,
       position: 'absolute',
       width: 1,
-    },
-
-    DateInput_displayText: {
-      padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-    },
-
-    DateInput_displayText__hasInput: {
-      color: color.text,
-    },
-
-    DateInput_displayText__focused: {
-      background: color.backgroundFocused,
-      borderColor: color.backgroundFocused,
-      borderRadius: 3,
-      color: color.textFocused,
-    },
-
-    DateInput_displayText__disabled: {
-      fontStyle: 'italic',
     },
   };
 })(DateInput);

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -43,9 +43,7 @@ const propTypes = forbidExtraProps({
   onQuestionMark: PropTypes.func,
 
   startDate: PropTypes.string,
-  startDateValue: PropTypes.string,
   endDate: PropTypes.string,
-  endDateValue: PropTypes.string,
 
   isStartDateFocused: PropTypes.bool,
   isEndDateFocused: PropTypes.bool,
@@ -87,9 +85,7 @@ const defaultProps = {
   onQuestionMark() {},
 
   startDate: '',
-  startDateValue: '',
   endDate: '',
-  endDateValue: '',
 
   isStartDateFocused: false,
   isEndDateFocused: false,
@@ -116,7 +112,6 @@ const defaultProps = {
 
 function DateRangePickerInput({
   startDate,
-  startDateValue,
   startDateId,
   startDatePlaceholderText,
   screenReaderMessage,
@@ -125,7 +120,6 @@ function DateRangePickerInput({
   onStartDateFocus,
   onStartDateShiftTab,
   endDate,
-  endDateValue,
   endDateId,
   endDatePlaceholderText,
   isEndDateFocused,
@@ -188,7 +182,6 @@ function DateRangePickerInput({
         id={startDateId}
         placeholder={startDatePlaceholderText}
         displayValue={startDate}
-        inputValue={startDateValue}
         screenReaderMessage={screenReaderText}
         focused={isStartDateFocused}
         isFocused={isFocused}
@@ -216,7 +209,6 @@ function DateRangePickerInput({
         id={endDateId}
         placeholder={endDatePlaceholderText}
         displayValue={endDate}
-        inputValue={endDateValue}
         screenReaderMessage={screenReaderText}
         focused={isEndDateFocused}
         isFocused={isFocused}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -15,7 +15,6 @@ import IconPositionShape from '../shapes/IconPositionShape';
 
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
-import toISODateString from '../utils/toISODateString';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isBeforeDay from '../utils/isBeforeDay';
@@ -265,19 +264,15 @@ export default class DateRangePickerInputController extends React.Component {
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
-    const startDateValue = toISODateString(startDate);
     const endDateString = this.getDateString(endDate);
-    const endDateValue = toISODateString(endDate);
 
     return (
       <DateRangePickerInput
         startDate={startDateString}
-        startDateValue={startDateValue}
         startDateId={startDateId}
         startDatePlaceholderText={startDatePlaceholderText}
         isStartDateFocused={isStartDateFocused}
         endDate={endDateString}
-        endDateValue={endDateValue}
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}
         isEndDateFocused={isEndDateFocused}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -14,8 +14,6 @@ import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
 
-import toISODateString from '../utils/toISODateString';
-
 import SingleDatePickerInput from './SingleDatePickerInput';
 import DayPickerSingleDateController from './DayPickerSingleDateController';
 
@@ -445,7 +443,6 @@ class SingleDatePicker extends React.Component {
     const { isInputFocused } = this.state;
 
     const displayValue = this.getDateString(date);
-    const inputValue = toISODateString(date);
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onClearFocus : undefined;
 
@@ -469,7 +466,6 @@ class SingleDatePicker extends React.Component {
             customCloseIcon={customCloseIcon}
             customInputIcon={customInputIcon}
             displayValue={displayValue}
-            inputValue={inputValue}
             onChange={this.onChange}
             onFocus={this.onFocus}
             onKeyDownShiftTab={this.onClearFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -20,7 +20,6 @@ const propTypes = forbidExtraProps({
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
-  inputValue: PropTypes.string,
   screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   isFocused: PropTypes.bool, // describes actual DOM focus
@@ -49,7 +48,6 @@ const propTypes = forbidExtraProps({
 const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
-  inputValue: '',
   screenReaderMessage: '',
   focused: false,
   isFocused: false,
@@ -80,7 +78,6 @@ function SingleDatePickerInput({
   id,
   placeholder,
   displayValue,
-  inputValue,
   focused,
   isFocused,
   disabled,
@@ -138,7 +135,6 @@ function SingleDatePickerInput({
         id={id}
         placeholder={placeholder} // also used as label
         displayValue={displayValue}
-        inputValue={inputValue}
         screenReaderMessage={screenReaderText}
         focused={focused}
         isFocused={isFocused}

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -26,15 +26,32 @@ const core = {
 export default {
   reactDates: {
     zIndex: 0,
+    border: {
+      input: {
+        border: 0,
+        borderTop: 0,
+        borderRight: 0,
+        borderBottom: '2px solid transparent',
+        borderLeft: 0,
+        outlineFocused: 0,
+        borderFocused: 0,
+        borderTopFocused: 0,
+        borderLeftFocused: 0,
+        borderBottomFocused: `2px solid ${core.primary_dark}`,
+        borderRightFocused: 0,
+      },
+    },
+
     color: {
       core,
 
-      disabled: core.grayLighter,
+      disabled: core.grayLightest,
 
       background: core.white,
       backgroundDark: '#f2f2f2',
-      backgroundFocused: '#99ede6',
+      backgroundFocused: core.white,
       text: core.gray,
+      textDisabled: core.border,
       textFocused: '#007a87',
       placeholderText: '#757575',
 
@@ -130,10 +147,10 @@ export default {
     spacing: {
       captionPaddingTop: 22,
       captionPaddingBottom: 37,
-      inputPadding: 8,
+      inputPadding: 0,
       inputMarginBottom: 72, // spacing in between the input and the picker
-      displayTextPaddingVertical: 4,
-      displayTextPaddingHorizontal: 8,
+      displayTextPaddingVertical: 12,
+      displayTextPaddingHorizontal: 12,
     },
 
     sizing: {
@@ -148,6 +165,7 @@ export default {
       input: {
         size: 18,
         lineHeight: '24px',
+        styleDisabled: 'italic',
       },
     },
   },

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -20,15 +20,10 @@ describe('CalendarMonth', () => {
     });
 
     describe('caption', () => {
-      it('.CalendarMonth__caption id is present', () => {
-        const wrapper = shallow(<CalendarMonth />).dive();
-        expect(wrapper.find('#CalendarMonth__caption')).to.have.lengthOf(1);
-      });
-
       it('text is the correctly formatted month title', () => {
         const MONTH = moment();
-        const caption = shallow(<CalendarMonth month={MONTH} />).dive().find('#CalendarMonth__caption');
-        expect(caption.text()).to.equal(MONTH.format('MMMM YYYY'));
+        const captionWrapper = shallow(<CalendarMonth month={MONTH} />).dive().find('strong');
+        expect(captionWrapper.text()).to.equal(MONTH.format('MMMM YYYY'));
       });
     });
   });

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -16,19 +16,13 @@ describe('DateInput', () => {
         expect(wrapper.find('input').props()['aria-label']).to.equal(placeholder);
       });
 
-      it('has value === props.inputValue if prop is passed in', () => {
-        const INPUT_VALUE = 'foobar';
-        const wrapper = shallow(<DateInput id="date" inputValue={INPUT_VALUE} />).dive();
-        expect(wrapper.find('input').props().value).to.equal(INPUT_VALUE);
-      });
-
-      it('has value === props.displayValue if inputValue is not passed in', () => {
+      it('has value === props.displayValue', () => {
         const DISPLAY_VALUE = 'foobar';
         const wrapper = shallow(<DateInput id="date" displayValue={DISPLAY_VALUE} />).dive();
         expect(wrapper.find('input').props().value).to.equal(DISPLAY_VALUE);
       });
 
-      it('has value === state.dateString if neither inputValue or displayValue are passed in', () => {
+      it('has value === state.dateString if displayValue is not passed in', () => {
         const DATE_STRING = 'foobar';
         const wrapper = shallow(<DateInput id="date" />).dive();
         wrapper.setState({
@@ -215,20 +209,18 @@ describe('DateInput', () => {
       const el = {
         blur() {},
         focus() {},
-        select() {},
       };
 
       beforeEach(() => {
         sinon.spy(el, 'blur');
         sinon.spy(el, 'focus');
-        sinon.spy(el, 'select');
       });
 
       afterEach(() => {
         sinon.restore();
       });
 
-      it('focuses and selects inputRef when becoming focused', () => {
+      it('focuses inputRef when becoming focused', () => {
         const wrapper = shallow(
           <DateInput id="date" focused={false} isFocused={false} />,
           { disableLifecycleMethods: false },
@@ -240,7 +232,6 @@ describe('DateInput', () => {
 
         expect(el.blur).to.have.property('callCount', 0);
         expect(el.focus).to.have.property('callCount', 1);
-        expect(el.select).to.have.property('callCount', 1);
       });
 
       it('blurs when becoming unfocused', () => {
@@ -255,7 +246,6 @@ describe('DateInput', () => {
 
         expect(el.blur).to.have.property('callCount', 1);
         expect(el.focus).to.have.property('callCount', 0);
-        expect(el.select).to.have.property('callCount', 0);
       });
     });
 


### PR DESCRIPTION
I recently pulled in the latest version of `react-dates` into our internal repos and discovered a few accessibility issues through our automatic testing.

1. The caption id was not unique! Namely it was the same on each month which was causing some problems. It also was missing the corresponding `aria-labelledby` attribute the table itself.
2. There was a text-contrast issue with the focus background color, so I modified the default styling to match what is currently used on airbnb.com. I still need to go back and make sure everything is customizable. :)
3. I took the opportunity to address a lot of queries in the issues on this repo and make the input a real input. 

to: @ljharb @gabergg @backwardok @airbnb/webinfra 