### PR TITLE
Update consolidated-events usage to newer API

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -5,7 +5,7 @@ import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
-import { addEventListener, removeEventListener } from 'consolidated-events';
+import { addEventListener } from 'consolidated-events';
 
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -113,7 +113,7 @@ class CalendarMonthGrid extends React.Component {
 
   componentDidMount() {
     const { setCalendarMonthHeights } = this.props;
-    this.eventHandle = addEventListener(
+    this.removeEventListener = addEventListener(
       this.container,
       'transitionend',
       this.onTransitionEnd,
@@ -173,7 +173,7 @@ class CalendarMonthGrid extends React.Component {
   }
 
   componentWillUnmount() {
-    removeEventListener(this.eventHandle);
+    if (this.removeEventListener) this.removeEventListener();
     if (this.setCalendarMonthHeightsTimeout) {
       clearTimeout(this.setCalendarMonthHeightsTimeout);
     }

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import Portal from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { addEventListener, removeEventListener } from 'consolidated-events';
+import { addEventListener } from 'consolidated-events';
 import isTouchDevice from 'is-touch-device';
 
 import { DateRangePickerPhrases } from '../defaultPhrases';
@@ -128,7 +128,7 @@ class DateRangePicker extends React.Component {
   }
 
   componentDidMount() {
-    this.resizeHandle = addEventListener(
+    this.removeEventListener = addEventListener(
       window,
       'resize',
       this.responsivizePickerPosition,
@@ -157,7 +157,7 @@ class DateRangePicker extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.resizeHandle) removeEventListener(this.resizeHandle);
+    if (this.removeEventListener) this.removeEventListener();
   }
 
   onOutsideClick() {

--- a/src/components/OutsideClickHandler.jsx
+++ b/src/components/OutsideClickHandler.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 // import { forbidExtraProps } from 'airbnb-prop-types'; // TODO: add to propTypes; semver-major
-import { addEventListener, removeEventListener } from 'consolidated-events';
+import { addEventListener } from 'consolidated-events';
 
 const propTypes = {
   children: PropTypes.node,
@@ -25,7 +25,7 @@ export default class OutsideClickHandler extends React.Component {
   componentDidMount() {
     // `capture` flag is set to true so that a `stopPropagation` in the children
     // will not prevent all outside click handlers from firing - maja
-    this.clickHandle = addEventListener(
+    this.removeEventListener = addEventListener(
       document,
       'click',
       this.onOutsideClick,
@@ -34,7 +34,7 @@ export default class OutsideClickHandler extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.clickHandle) { removeEventListener(this.clickHandle); }
+    if (this.removeEventListener) { this.removeEventListener(); }
   }
 
   onOutsideClick(e) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import Portal from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { addEventListener, removeEventListener } from 'consolidated-events';
+import { addEventListener } from 'consolidated-events';
 import isTouchDevice from 'is-touch-device';
 
 import SingleDatePickerShape from '../shapes/SingleDatePickerShape';
@@ -125,7 +125,7 @@ class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentDidMount() {
-    this.resizeHandle = addEventListener(
+    this.removeEventListener = addEventListener(
       window,
       'resize',
       this.responsivizePickerPosition,
@@ -150,7 +150,7 @@ class SingleDatePicker extends React.Component {
 
   /* istanbul ignore next */
   componentWillUnmount() {
-    removeEventListener(this.resizeHandle);
+    if (this.removeEventListener) this.removeEventListener();
   }
 
   onChange(dateString) {


### PR DESCRIPTION
In v1.1.0, addEventListener returns a function that can be called to
remove the event listener.

https://github.com/lencioni/consolidated-events/blob/master/CHANGELOG.md#v110