### PR TITLE
Update CalendarMonthGrid.jsx

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -149,8 +149,9 @@ class CalendarMonthGrid extends React.Component {
       newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
     }
 
-    if (this.locale !== moment.locale()) {
-      this.locale = moment.locale();
+    const momentLocale = moment.locale();
+    if (this.locale !== momentLocale) {
+      this.locale = momentLocale;
       newMonths = newMonths.map(m => m.locale(this.locale));
     }
 

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -146,6 +146,9 @@ class CalendarMonthGrid extends React.Component {
       const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
       newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
     }
+    
+    var momentLocale = moment.locale();
+    newMonths = newMonths.map(m => m.locale(momentLocale));
 
     this.setState({
       months: newMonths,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -109,6 +109,8 @@ class CalendarMonthGrid extends React.Component {
     this.isTransitionEndSupported = isTransitionEndSupported();
     this.onTransitionEnd = this.onTransitionEnd.bind(this);
     this.setContainerRef = this.setContainerRef.bind(this);
+
+    this.locale = moment.locale();
   }
 
   componentDidMount() {
@@ -146,9 +148,11 @@ class CalendarMonthGrid extends React.Component {
       const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
       newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
     }
-    
-    var momentLocale = moment.locale();
-    newMonths = newMonths.map(m => m.locale(momentLocale));
+
+    if (this.locale !== moment.locale()) {
+      this.locale = moment.locale();
+      newMonths = newMonths.map(m => m.locale(this.locale));
+    }
 
     this.setState({
       months: newMonths,


### PR DESCRIPTION
Makes sure months in state of CalendarMonthGrid are in current locale so whenever moment.locale() changes month names are rendered correctly.

I think it could solve [issue 480](https://github.com/airbnb/react-dates/issues/480) and maybe [issue 637](https://github.com/airbnb/react-dates/issues/637)