### PR TITLE
fix(CalendarDay): apply styles for start and end modifiers

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -142,6 +142,8 @@ class CalendarDay extends React.Component {
           hoveredSpan && styles.CalendarDay__hovered_span,
           modifiers.has('selected-span') && styles.CalendarDay__selected_span,
           modifiers.has('last-in-range') && styles.CalendarDay__last_in_range,
+          modifiers.has('selected-start') && styles.CalendarDay__selected_start,
+          modifiers.has('selected-end') && styles.CalendarDay__selected_end,
           selected && styles.CalendarDay__selected,
           isOutsideRange && styles.CalendarDay__blocked_out_of_range,
           daySizeStyles,
@@ -343,5 +345,8 @@ export default withStyles(({ reactDates: { color } }) => ({
       color: color.blocked_out_of_range.color_active,
     },
   },
+
+  CalendarDay__selected_start: {},
+  CalendarDay__selected_end: {},
 
 }))(CalendarDay);


### PR DESCRIPTION
Previous versions of the library would add the `CalendarDay--selected-start` and `CalendarDay--selected-end` class names when`selected-start` and `selected-end` modifiers were passed.

I think after the switch to `react-with-styles` these classes got lost and making it harder to modify the styles of the beginning and end of a range.

I'm not very familiar with `react-with-styles`, so I don't know if this is the proper way to get those class names set in the component.

I would also like to add unit tests for this, but I didn't see tests in `CalendarDay` regarding other modifiers and I'm not quite sure how to test this. I see that the wrapper gets the class names in the test, but they have what it seems a random modifier at the end. Also, the `react-with-styles` docs mention that `css(...)` returns an object with an opaque structure, so definitely, checking the value of the props added by this object doesn't seem a good testing option.

Fixes #786.