### PR TITLE
Fixed onKeyDownQuestionMark for the SingleDatePicker

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -108,10 +108,12 @@ class SingleDatePicker extends React.Component {
       dayPickerContainerStyles: {},
       isDayPickerFocused: false,
       isInputFocused: false,
+      showKeyboardShortcuts: false,
     };
 
     this.onDayPickerFocus = this.onDayPickerFocus.bind(this);
     this.onDayPickerBlur = this.onDayPickerBlur.bind(this);
+    this.showKeyboardShortcutsPanel = this.showKeyboardShortcutsPanel.bind(this);
 
     this.onChange = this.onChange.bind(this);
     this.onFocus = this.onFocus.bind(this);
@@ -218,6 +220,7 @@ class SingleDatePicker extends React.Component {
     this.setState({
       isInputFocused: false,
       isDayPickerFocused: true,
+      showKeyboardShortcuts: false,
     });
   }
 
@@ -225,6 +228,7 @@ class SingleDatePicker extends React.Component {
     this.setState({
       isInputFocused: true,
       isDayPickerFocused: false,
+      showKeyboardShortcuts: false,
     });
   }
 
@@ -292,6 +296,14 @@ class SingleDatePicker extends React.Component {
     }
   }
 
+  showKeyboardShortcutsPanel() {
+    this.setState({
+      isInputFocused: false,
+      isDayPickerFocused: true,
+      showKeyboardShortcuts: true,
+    });
+  }
+
   maybeRenderDayPickerWithPortal() {
     const { focused, withPortal, withFullScreenPortal } = this.props;
 
@@ -346,7 +358,7 @@ class SingleDatePicker extends React.Component {
       styles,
       verticalHeight,
     } = this.props;
-    const { dayPickerContainerStyles, isDayPickerFocused } = this.state;
+    const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
     const closeIcon = customCloseIcon || (<CloseButton />);
@@ -390,6 +402,7 @@ class SingleDatePicker extends React.Component {
           renderDay={renderDay}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}
+          showKeyboardShortcuts={showKeyboardShortcuts}
           phrases={phrases}
           daySize={daySize}
           isRTL={isRTL}
@@ -471,6 +484,7 @@ class SingleDatePicker extends React.Component {
             onKeyDownShiftTab={this.onClearFocus}
             onKeyDownTab={this.onClearFocus}
             onKeyDownArrowDown={this.onDayPickerFocus}
+            onKeyDownQuestionMark={this.showKeyboardShortcutsPanel}
             screenReaderMessage={screenReaderInputMessage}
             phrases={phrases}
             isRTL={isRTL}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -40,6 +40,7 @@ const propTypes = forbidExtraProps({
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
   onKeyDownArrowDown: PropTypes.func,
+  onKeyDownQuestionMark: PropTypes.func,
 
   // i18n
   phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerInputPhrases)),
@@ -69,6 +70,7 @@ const defaultProps = {
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
   onKeyDownArrowDown() {},
+  onKeyDownQuestionMark() {},
 
   // i18n
   phrases: SingleDatePickerInputPhrases,
@@ -94,6 +96,7 @@ function SingleDatePickerInput({
   onKeyDownShiftTab,
   onKeyDownTab,
   onKeyDownArrowDown,
+  onKeyDownQuestionMark,
   screenReaderMessage,
   customCloseIcon,
   customInputIcon,
@@ -147,6 +150,7 @@ function SingleDatePickerInput({
         onKeyDownShiftTab={onKeyDownShiftTab}
         onKeyDownTab={onKeyDownTab}
         onKeyDownArrowDown={onKeyDownArrowDown}
+        onKeyDownQuestionMark={onKeyDownQuestionMark}
         openDirection={openDirection}
       />
 

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -545,6 +545,20 @@ describe('SingleDatePicker', () => {
       wrapper.instance().onDayPickerFocus();
       expect(wrapper.state().isInputFocused).to.equal(false);
     });
+
+    it('sets state.showKeyboardShortcuts to false', () => {
+      const wrapper = shallow((
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      )).dive();
+      wrapper.setState({
+        showKeyboardShortcuts: true,
+      });
+      wrapper.instance().onDayPickerFocus();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
+    });
   });
 
   describe('#onDayPickerBlur', () => {
@@ -574,6 +588,64 @@ describe('SingleDatePicker', () => {
       });
       wrapper.instance().onDayPickerBlur();
       expect(wrapper.state().isInputFocused).to.equal(true);
+    });
+
+    it('sets state.showKeyboardShortcuts to false', () => {
+      const wrapper = shallow((
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      )).dive();
+      wrapper.setState({
+        showKeyboardShortcuts: true,
+      });
+      wrapper.instance().onDayPickerBlur();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(false);
+    });
+  });
+
+  describe('#showKeyboardShortcutsPanel', () => {
+    it('sets state.isInputFocused to false', () => {
+      const wrapper = shallow((
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      )).dive();
+      wrapper.setState({
+        isInputFocused: true,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().isInputFocused).to.equal(false);
+    });
+
+    it('sets state.isDayPickerFocused to true', () => {
+      const wrapper = shallow((
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      )).dive();
+      wrapper.setState({
+        isDayPickerFocused: false,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().isDayPickerFocused).to.equal(true);
+    });
+
+    it('sets state.showKeyboardShortcuts to true', () => {
+      const wrapper = shallow((
+        <SingleDatePicker
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      )).dive();
+      wrapper.setState({
+        showKeyboardShortcuts: false,
+      });
+      wrapper.instance().showKeyboardShortcutsPanel();
+      expect(wrapper.state().showKeyboardShortcuts).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Being able to hit the question mark key in the input of a SingleDatePicker to display the Keyboard Shortcuts panel was not working.  Now it is all connected up and in parity with the DateRangePicker.

I also cleaned up some small naming inconsistencies on the DateRangePicker side and a couple copy/paste mistakes from DateRange to SingleDate, hope that's ok!