### PR TITLE
[Breaking] Make DateRangePicker key down handlers match SingleDatePicker's

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -474,8 +474,8 @@ class DateRangePicker extends React.Component {
             withFullScreenPortal={withFullScreenPortal}
             onDatesChange={onDatesChange}
             onFocusChange={this.onDateRangePickerInputFocus}
-            onArrowDown={this.onDayPickerFocus}
-            onQuestionMark={this.showKeyboardShortcutsPanel}
+            onKeyDownArrowDown={this.onDayPickerFocus}
+            onKeyDownQuestionMark={this.showKeyboardShortcutsPanel}
             onClose={onClose}
             phrases={phrases}
             screenReaderMessage={screenReaderInputMessage}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -39,8 +39,8 @@ const propTypes = forbidExtraProps({
   onStartDateShiftTab: PropTypes.func,
   onEndDateTab: PropTypes.func,
   onClearDates: PropTypes.func,
-  onArrowDown: PropTypes.func,
-  onQuestionMark: PropTypes.func,
+  onKeyDownArrowDown: PropTypes.func,
+  onKeyDownQuestionMark: PropTypes.func,
 
   startDate: PropTypes.string,
   endDate: PropTypes.string,
@@ -81,8 +81,8 @@ const defaultProps = {
   onStartDateShiftTab() {},
   onEndDateTab() {},
   onClearDates() {},
-  onArrowDown() {},
-  onQuestionMark() {},
+  onKeyDownArrowDown() {},
+  onKeyDownQuestionMark() {},
 
   startDate: '',
   endDate: '',
@@ -126,8 +126,8 @@ function DateRangePickerInput({
   onEndDateChange,
   onEndDateFocus,
   onEndDateTab,
-  onArrowDown,
-  onQuestionMark,
+  onKeyDownArrowDown,
+  onKeyDownQuestionMark,
   onClearDates,
   showClearDates,
   disabled,
@@ -162,7 +162,7 @@ function DateRangePickerInput({
       type="button"
       disabled={disabled}
       aria-label={phrases.focusStartDate}
-      onClick={onArrowDown}
+      onClick={onKeyDownArrowDown}
     >
       {calendarIcon}
     </button>
@@ -193,8 +193,8 @@ function DateRangePickerInput({
         onChange={onStartDateChange}
         onFocus={onStartDateFocus}
         onKeyDownShiftTab={onStartDateShiftTab}
-        onKeyDownArrowDown={onArrowDown}
-        onKeyDownQuestionMark={onQuestionMark}
+        onKeyDownArrowDown={onKeyDownArrowDown}
+        onKeyDownQuestionMark={onKeyDownQuestionMark}
       />
 
       <div
@@ -220,8 +220,8 @@ function DateRangePickerInput({
         onChange={onEndDateChange}
         onFocus={onEndDateFocus}
         onKeyDownTab={onEndDateTab}
-        onKeyDownArrowDown={onArrowDown}
-        onKeyDownQuestionMark={onQuestionMark}
+        onKeyDownArrowDown={onKeyDownArrowDown}
+        onKeyDownQuestionMark={onKeyDownQuestionMark}
       />
 
       {showClearDates && (

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -52,8 +52,8 @@ const propTypes = forbidExtraProps({
   onFocusChange: PropTypes.func,
   onClose: PropTypes.func,
   onDatesChange: PropTypes.func,
-  onArrowDown: PropTypes.func,
-  onQuestionMark: PropTypes.func,
+  onKeyDownArrowDown: PropTypes.func,
+  onKeyDownQuestionMark: PropTypes.func,
 
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
@@ -99,8 +99,8 @@ const defaultProps = {
   onFocusChange() {},
   onClose() {},
   onDatesChange() {},
-  onArrowDown() {},
-  onQuestionMark() {},
+  onKeyDownArrowDown() {},
+  onKeyDownQuestionMark() {},
 
   customInputIcon: null,
   customArrowIcon: null,
@@ -258,8 +258,8 @@ export default class DateRangePickerInputController extends React.Component {
       openDirection,
       isFocused,
       phrases,
-      onArrowDown,
-      onQuestionMark,
+      onKeyDownArrowDown,
+      onKeyDownQuestionMark,
       isRTL,
     } = this.props;
 
@@ -297,8 +297,8 @@ export default class DateRangePickerInputController extends React.Component {
         showClearDates={showClearDates}
         onClearDates={this.clearDates}
         screenReaderMessage={screenReaderMessage}
-        onArrowDown={onArrowDown}
-        onQuestionMark={onQuestionMark}
+        onKeyDownArrowDown={onKeyDownArrowDown}
+        onKeyDownQuestionMark={onKeyDownQuestionMark}
         isRTL={isRTL}
       />
     );

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -299,7 +299,7 @@ export default class DayPickerSingleDateController extends React.Component {
 
     onDateChange(day);
     if (!keepOpenOnDateSelect) {
-      onFocusChange({ focused: null });
+      onFocusChange({ focused: false });
       onClose({ date: day });
     }
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -197,8 +197,7 @@ class SingleDatePicker extends React.Component {
 
   onClearFocus() {
     const {
-      startDate,
-      endDate,
+      date,
       focused,
       onFocusChange,
       onClose,
@@ -211,7 +210,7 @@ class SingleDatePicker extends React.Component {
     });
 
     onFocusChange({ focused: false });
-    onClose({ startDate, endDate });
+    onClose({ date });
   }
 
   onDayPickerFocus() {

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -91,11 +91,11 @@ describe('DateRangePickerInput', () => {
 
   describe('calendar icon interaction', () => {
     describe('onClick', () => {
-      it('props.onArrowDown gets triggered', () => {
+      it('props.onKeyDownArrowDown gets triggered', () => {
         const onArrowDownSpy = sinon.spy();
         const wrapper = shallow((
           <DateRangePickerInput
-            onArrowDown={onArrowDownSpy}
+            onKeyDownArrowDown={onArrowDownSpy}
             showDefaultInputIcon
           />
         )).dive();


### PR DESCRIPTION
Some minor clean up of function name inconsistencies between SingleDatePicker and DateRangePicker.  SingleDatePicker has `onKeyDownArrowDown` and `onKeyDownQuestionMark` and that's what DateInput has, so it seemed like DateRangePicker should match.