### PR TITLE
Add Babel config for production environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,13 @@
         ["transform-replace-object-assign", "object.assign"],
       ],
     },
+    "production": {
+      "presets": ["airbnb"],
+      "plugins": [
+        "inline-react-svg",
+        ["transform-replace-object-assign", "object.assign"],
+      ],
+    },
     "cjs": {
       "presets": ["airbnb"],
       "plugins": [


### PR DESCRIPTION
In https://github.com/airbnb/react-dates/pull/791 I added an ESM build,
but ended up breaking the production build for gh-pages. Storybook
builds with NODE_ENV=production, so this should fix that problem.

@majapw 