### PR TITLE
babel transforms jsx files for storybook

### DIFF
--- a/.storybook-css/webpack.config.js
+++ b/.storybook-css/webpack.config.js
@@ -19,10 +19,15 @@ module.exports = {
               presets: ['airbnb'],
             },
           },
+        ],
+      },
+      {
+        test: /\.jsx$/,
+        use: [
           {
-            loader: 'react-svg-loader',
+            loader: 'babel-loader',
             query: {
-              jsx: true,
+              presets: ['airbnb'],
             },
           },
         ],

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -19,10 +19,15 @@ module.exports = {
               presets: ['airbnb'],
             },
           },
+        ],
+      },
+      {
+        test: /\.jsx$/,
+        use: [
           {
-            loader: 'react-svg-loader',
+            loader: 'babel-loader',
             query: {
-              jsx: true,
+              presets: ['airbnb'],
             },
           },
         ],


### PR DESCRIPTION
This is a fix for https://github.com/airbnb/react-dates/issues/832

The removal of the explicit `import React`s from the icon files didn't take into account that those files were not being babel transformed for storybook. This addresses the issue.

(I'm gonna merge through so master can be unfucked, but I'm opening this PR for posterity)

FYI @ljharb @lencioni 