### PR TITLE
Add ariaLabelFormat Prop into CalendarDay component

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -24,6 +24,7 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderDay: PropTypes.func,
+  ariaLabelFormat: PropTypes.string,
 
   // internationalization
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
@@ -40,6 +41,7 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   renderDay: null,
+  ariaLabelFormat: 'dddd, LL',
 
   // internationalization
   phrases: CalendarDayPhrases,
@@ -87,6 +89,7 @@ class CalendarDay extends React.Component {
   render() {
     const {
       day,
+      ariaLabelFormat,
       daySize,
       isOutsideDay,
       modifiers,
@@ -101,7 +104,7 @@ class CalendarDay extends React.Component {
 
     if (!day) return <td />;
 
-    const formattedDate = { date: `${day.format('dddd')}, ${day.format('LL')}` };
+    const formattedDate = { date: day.format(ariaLabelFormat) };
 
     const ariaLabel = modifiers.has(BLOCKED_MODIFIER)
       ? getPhrase(dateIsUnavailable, formattedDate)

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -50,6 +50,7 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+  dayAriaLabelFormat: PropTypes.string,
 });
 
 const defaultProps = {
@@ -154,6 +155,7 @@ class CalendarMonth extends React.Component {
       isFocused,
       styles,
       phrases,
+      dayAriaLabelFormat,
     } = this.props;
 
     const { weeks } = this.state;
@@ -202,6 +204,7 @@ class CalendarMonth extends React.Component {
                     renderDay={renderDay}
                     phrases={phrases}
                     modifiers={modifiers[toISODateString(day)]}
+                    ariaLabelFormat={dayAriaLabelFormat}
                   />
                 ))}
               </tr>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -54,6 +54,7 @@ const propTypes = forbidExtraProps({
   // i18n
   monthFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+  dayAriaLabelFormat: PropTypes.string,
 });
 
 const defaultProps = {
@@ -230,6 +231,7 @@ class CalendarMonthGrid extends React.Component {
       isRTL,
       styles,
       phrases,
+      dayAriaLabelFormat,
     } = this.props;
 
     const { months } = this.state;
@@ -306,6 +308,7 @@ class CalendarMonthGrid extends React.Component {
                 isFocused={isFocused}
                 phrases={phrases}
                 setMonthHeight={(height) => { this.setMonthHeight(height, i); }}
+                dayAriaLabelFormat={dayAriaLabelFormat}
               />
             </div>
           );

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -84,6 +84,7 @@ const propTypes = forbidExtraProps({
   monthFormat: PropTypes.string,
   weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerPhrases)),
+  dayAriaLabelFormat: PropTypes.string,
 });
 
 export const defaultProps = {
@@ -686,6 +687,7 @@ class DayPicker extends React.Component {
       styles,
       phrases,
       verticalHeight,
+      dayAriaLabelFormat,
     } = this.props;
 
     const numOfWeekHeaders = this.isVertical() ? 1 : numberOfMonths;
@@ -805,6 +807,7 @@ class DayPicker extends React.Component {
                 focusedDate={focusedDate}
                 phrases={phrases}
                 isRTL={isRTL}
+                dayAriaLabelFormat={dayAriaLabelFormat}
               />
               {verticalScrollable && this.renderNavigation()}
             </div>

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -87,6 +87,18 @@ describe('CalendarDay', () => {
           expect(phrases.dateIsUnavailable.calledWith(expectedFormattedDay)).to.equal(true);
           expect(wrapper.find('button').prop('aria-label')).to.equal('dateIsUnavailable text');
         });
+
+        it('should set aria-label with a value pass through ariaLabelFormat prop if it exists', () => {
+          const modifiers = new Set();
+
+          const wrapper = shallow(<CalendarDay
+            modifiers={modifiers}
+            day={day}
+            ariaLabelFormat="MMMM Do YYYY"
+          />).dive();
+
+          expect(wrapper.find('button').prop('aria-label')).to.equal('October 10th 2017');
+        });
       });
     });
   });


### PR DESCRIPTION
This is a PR to fix #778.
I've added `ariaLabelFormat` for `CalendarDay` and added 'dayAriaLabelFormat` for `CalendarMonth`, `CalendarMonthGrid` and `DayPicker` to pass through `ariaLabelFormat`