### PR TITLE
Reset after-hovered-start in componentWillReceiveProps - Fixes #831

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -206,23 +206,38 @@ export default class DayPickerRangeController extends React.Component {
       numberOfMonths,
       enableOutsideDays,
     } = nextProps;
+
+    const {
+      startDate: prevStartDate,
+      endDate: prevEndDate,
+      focusedInput: prevFocusedInput,
+      minimumNights: prevMinimumNights,
+      isOutsideRange: prevIsOutsideRange,
+      isDayBlocked: prevIsDayBlocked,
+      isDayHighlighted: prevIsDayHighlighted,
+      phrases: prevPhrases,
+      initialVisibleMonth: prevInitialVisibleMonth,
+      numberOfMonths: prevNumberOfMonths,
+      enableOutsideDays: prevEnableOutsideDays,
+    } = this.props;
+
     let { visibleDays } = this.state;
 
     let recomputeOutsideRange = false;
     let recomputeDayBlocked = false;
     let recomputeDayHighlighted = false;
 
-    if (isOutsideRange !== this.props.isOutsideRange) {
+    if (isOutsideRange !== prevIsOutsideRange) {
       this.modifiers['blocked-out-of-range'] = day => isOutsideRange(day);
       recomputeOutsideRange = true;
     }
 
-    if (isDayBlocked !== this.props.isDayBlocked) {
+    if (isDayBlocked !== prevIsDayBlocked) {
       this.modifiers['blocked-calendar'] = day => isDayBlocked(day);
       recomputeDayBlocked = true;
     }
 
-    if (isDayHighlighted !== this.props.isDayHighlighted) {
+    if (isDayHighlighted !== prevIsDayHighlighted) {
       this.modifiers['highlighted-calendar'] = day => isDayHighlighted(day);
       recomputeDayHighlighted = true;
     }
@@ -231,16 +246,16 @@ export default class DayPickerRangeController extends React.Component {
       recomputeOutsideRange || recomputeDayBlocked || recomputeDayHighlighted
     );
 
-    const didStartDateChange = startDate !== this.props.startDate;
-    const didEndDateChange = endDate !== this.props.endDate;
-    const didFocusChange = focusedInput !== this.props.focusedInput;
+    const didStartDateChange = startDate !== prevStartDate;
+    const didEndDateChange = endDate !== prevEndDate;
+    const didFocusChange = focusedInput !== prevFocusedInput;
 
     if (
-      numberOfMonths !== this.props.numberOfMonths ||
-      enableOutsideDays !== this.props.enableOutsideDays ||
+      numberOfMonths !== prevNumberOfMonths ||
+      enableOutsideDays !== prevEnableOutsideDays ||
       (
-        initialVisibleMonth !== this.props.initialVisibleMonth &&
-        !this.props.focusedInput &&
+        initialVisibleMonth !== prevInitialVisibleMonth &&
+        !prevFocusedInput &&
         didFocusChange
       )
     ) {
@@ -256,26 +271,27 @@ export default class DayPickerRangeController extends React.Component {
     let modifiers = {};
 
     if (didStartDateChange) {
-      modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
+      modifiers = this.deleteModifier(modifiers, prevStartDate, 'selected-start');
       modifiers = this.addModifier(modifiers, startDate, 'selected-start');
-      if (this.props.startDate) {
-        const startSpan = this.props.startDate.clone().add(1, 'day');
-        const endSpan = this.props.startDate.clone().add(this.props.minimumNights + 1, 'days');
+
+      if (prevStartDate) {
+        const startSpan = prevStartDate.clone().add(1, 'day');
+        const endSpan = prevStartDate.clone().add(prevMinimumNights + 1, 'days');
         modifiers = this.deleteModifierFromRange(modifiers, startSpan, endSpan, 'after-hovered-start');
       }
     }
 
     if (didEndDateChange) {
-      modifiers = this.deleteModifier(modifiers, this.props.endDate, 'selected-end');
+      modifiers = this.deleteModifier(modifiers, prevEndDate, 'selected-end');
       modifiers = this.addModifier(modifiers, endDate, 'selected-end');
     }
 
     if (didStartDateChange || didEndDateChange) {
-      if (this.props.startDate && this.props.endDate) {
+      if (prevStartDate && prevEndDate) {
         modifiers = this.deleteModifierFromRange(
           modifiers,
-          this.props.startDate,
-          this.props.endDate.clone().add(1, 'day'),
+          prevStartDate,
+          prevEndDate.clone().add(1, 'day'),
           'selected-span',
         );
       }
@@ -303,9 +319,9 @@ export default class DayPickerRangeController extends React.Component {
       modifiers = this.addModifierToRange(modifiers, startSpan, endSpan, 'after-hovered-start');
     }
 
-    if (minimumNights > 0 || minimumNights !== this.props.minimumNights) {
+    if (minimumNights > 0 || minimumNights !== prevMinimumNights) {
       if (didFocusChange || didStartDateChange) {
-        const startSpan = this.props.startDate ? this.props.startDate : this.today;
+        const startSpan = prevStartDate || this.today;
         modifiers = this.deleteModifierFromRange(
           modifiers,
           startSpan,
@@ -378,7 +394,7 @@ export default class DayPickerRangeController extends React.Component {
       });
     }
 
-    if (didFocusChange || phrases !== this.props.phrases) {
+    if (didFocusChange || phrases !== prevPhrases) {
       // set the appropriate CalendarDay phrase based on focusedInput
       const chooseAvailableDate = getChooseAvailableDatePhrase(phrases, focusedInput);
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -258,6 +258,11 @@ export default class DayPickerRangeController extends React.Component {
     if (didStartDateChange) {
       modifiers = this.deleteModifier(modifiers, this.props.startDate, 'selected-start');
       modifiers = this.addModifier(modifiers, startDate, 'selected-start');
+      if (this.props.startDate) {
+        const startSpan = this.props.startDate.clone().add(1, 'day');
+        const endSpan = this.props.startDate.clone().add(this.props.minimumNights + 1, 'days');
+        modifiers = this.deleteModifierFromRange(modifiers, startSpan, endSpan, 'after-hovered-start');
+      }
     }
 
     if (didEndDateChange) {
@@ -462,10 +467,6 @@ export default class DayPickerRangeController extends React.Component {
       }
 
       if (startDate) {
-        const startSpan = startDate.clone().add(1, 'day');
-        const endSpan = startDate.clone().add(minimumNights + 1, 'days');
-        modifiers = this.deleteModifierFromRange(modifiers, startSpan, endSpan, 'after-hovered-start');
-
         if (isSameDay(day, startDate)) {
           const newStartSpan = startDate.clone().add(1, 'day');
           const newEndSpan = startDate.clone().add(minimumNights + 1, 'days');

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -296,6 +296,34 @@ describe('DayPickerRangeController', () => {
           });
           expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
         });
+        describe('startDate changed from one date to another', () => {
+          it('removes previous `after-hovered-start` range', () => {
+            const minimumNights = 5;
+            const startDate = moment().add(7, 'days');
+            const dayAfterStartDate = startDate.clone().add(1, 'day');
+            const firstAvailableDate = startDate.clone().add(minimumNights + 1, 'days');
+            const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
+            const nextStartDate = moment().add(4, 'days');
+            const wrapper = shallow((
+              <DayPickerRangeController
+                onDatesChange={sinon.stub()}
+                onFocusChange={sinon.stub()}
+                startDate={startDate}
+                focusedInput={START_DATE}
+                minimumNights={minimumNights}
+              />
+            ));
+            deleteModifierFromRangeSpy.reset();
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              startDate: nextStartDate,
+            });
+            const afterHoverStartCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'after-hovered-start');
+            expect(afterHoverStartCalls.length).to.equal(1);
+            expect(isSameDay(afterHoverStartCalls[0].args[1], dayAfterStartDate)).to.equal(true);
+            expect(isSameDay(afterHoverStartCalls[0].args[2], firstAvailableDate)).to.equal(true);
+          });
+        });
       });
     });
 
@@ -1615,29 +1643,6 @@ describe('DayPickerRangeController', () => {
         });
 
         describe('startDate exists', () => {
-          it('removes previous `after-hovered-start` range', () => {
-            const minimumNights = 5;
-            const startDate = moment().add(7, 'days');
-            const dayAfterStartDate = startDate.clone().add(1, 'day');
-            const firstAvailableDate = startDate.clone().add(minimumNights + 1, 'days');
-            const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
-            const wrapper = shallow((
-              <DayPickerRangeController
-                onDatesChange={sinon.stub()}
-                onFocusChange={sinon.stub()}
-                startDate={startDate}
-                focusedInput={START_DATE}
-                minimumNights={minimumNights}
-              />
-            ));
-            deleteModifierFromRangeSpy.reset();
-            wrapper.instance().onDayMouseEnter(today);
-            const afterHoverStartCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'after-hovered-start');
-            expect(afterHoverStartCalls.length).to.equal(1);
-            expect(isSameDay(afterHoverStartCalls[0].args[1], dayAfterStartDate)).to.equal(true);
-            expect(isSameDay(afterHoverStartCalls[0].args[2], firstAvailableDate)).to.equal(true);
-          });
-
           describe('hoverDate is startDate', () => {
             it('adds new `after-hovered-start` range', () => {
               const minimumNights = 5;


### PR DESCRIPTION
after-hovered-start was being unset in onDayClick, which led to an issue
where the modifier was left as applied when changing dates via keyboard
navigation. This moves that logic into componentWillReceiveProps so that
it works in both cases.

Fixes #831 

Gif of keyboard navigation and changing dates after the fix, for comparison with gif in the issue:
![ghostvaluesgone](https://user-images.githubusercontent.com/72922/32863767-757ab914-ca11-11e7-8e67-260961724935.gif)

cc @backwardok @majapw 