### PR TITLE
Replace react-addons-shallow-compare with React.PureComponent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
   global:
     - TEST=true
   matrix:
-    - REACT=0.14
     - REACT=15
     - REACT=16
 sudo: false

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ensure packages are installed with correct version numbers by running:
   Which produces and runs a command like:
 
   ```sh
-  npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.## react-addons-shallow-compare@>=#.##
+  npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.##
   ```
 
 ### Initialize

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "nyc": "^11.2.1",
     "raw-loader": "^0.5.1",
     "react": "^0.14 || ^15.5.4",
-    "react-addons-shallow-compare": "^0.14 || ^15.5.2",
     "react-addons-test-utils": "^0.14 || ^15.5.1",
     "react-dom": "^0.14 || ^15.5.4",
     "react-test-renderer": "^15.6.1",
@@ -127,8 +126,7 @@
   "peerDependencies": {
     "moment": "^2.18.1",
     "react": ">=0.14",
-    "react-dom": ">=0.14",
-    "react-addons-shallow-compare": ">=0.14"
+    "react-dom": ">=0.14"
   },
   "greenkeeper": {
     "ignore": [

--- a/package.json
+++ b/package.json
@@ -96,9 +96,9 @@
     "node-sass": "^4.5.3",
     "nyc": "^11.2.1",
     "raw-loader": "^0.5.1",
-    "react": "^0.14 || ^15.5.4",
-    "react-addons-test-utils": "^0.14 || ^15.5.1",
-    "react-dom": "^0.14 || ^15.5.4",
+    "react": "^15.5.4",
+    "react-addons-test-utils": "^15.5.1",
+    "react-dom": "^15.5.4",
     "react-test-renderer": "^15.6.1",
     "react-with-styles-interface-aphrodite": "^3.1.1",
     "react-with-styles-interface-css-compiler": "^1.0.1",
@@ -125,8 +125,8 @@
   },
   "peerDependencies": {
     "moment": "^2.18.1",
-    "react": ">=0.14",
-    "react-dom": ">=0.14"
+    "react": ">=15",
+    "react-dom": ">=15"
   },
   "greenkeeper": {
     "ignore": [

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -45,15 +44,11 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-class CalendarDay extends React.Component {
+class CalendarDay extends React.PureComponent {
   constructor(...args) {
     super(...args);
 
     this.setButtonRef = this.setButtonRef.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -75,7 +74,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-class CalendarMonth extends React.Component {
+class CalendarMonth extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -109,10 +108,6 @@ class CalendarMonth extends React.Component {
         ),
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillUnmount() {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -96,7 +95,7 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
   return months;
 }
 
-class CalendarMonthGrid extends React.Component {
+class CalendarMonthGrid extends React.PureComponent {
   constructor(props) {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
@@ -158,10 +157,6 @@ class CalendarMonthGrid extends React.Component {
     this.setState({
       months: newMonths,
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import Portal from 'react-portal';
@@ -104,7 +103,7 @@ const defaultProps = {
   phrases: DateRangePickerPhrases,
 };
 
-class DateRangePicker extends React.Component {
+class DateRangePicker extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
@@ -143,10 +142,6 @@ class DateRangePicker extends React.Component {
     }
 
     this.isTouchDevice = isTouchDevice();
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
@@ -131,7 +130,7 @@ export const defaultProps = {
   phrases: DayPickerPhrases,
 };
 
-class DayPicker extends React.Component {
+class DayPicker extends React.PureComponent {
   constructor(props) {
     super(props);
 
@@ -227,10 +226,6 @@ class DayPicker extends React.Component {
         this.setState({ focusedDate: null });
       }
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
[react-addons-shallow-compare](https://www.npmjs.com/package/react-addons-shallow-compare) is a legacy React addon, and is no longer maintained. Instead, we should use [`React.PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent).

Note that because `React.PureComponent` was introduced in React 15, this pull request also **drops support for React 0.14**. I realize this will be a controversial change, but I figured that I would propose it anyway.