### PR TITLE
Fix background-color theming for Calendar and DateInput

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -180,7 +180,7 @@ export default withStyles(({ reactDates: { color } }) => ({
     padding: 0,
     boxSizing: 'border-box',
     color: color.text,
-    background: '#fff',
+    background: color.background,
 
     ':hover': {
       background: color.core.borderLight,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -293,6 +293,7 @@ export default withStyles(({
       fontWeight: 200,
       fontSize: font.input.size,
       color: color.text,
+      backgroundColor: color.background,
       width: '100%',
       padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
       border: border.input.border,


### PR DESCRIPTION
Hi, first of all great library, thanks for the great work! 👍👍

We're using a dark theme with `react-dates` and noticed some backgrounds were not themable or hardcoded to white. This pull request fixes that, so you can correctly theme the background color. 

Before (the calendar navigation borders are not affected by this PR):
![image](https://user-images.githubusercontent.com/13645069/33213842-9f7d4cb2-d129-11e7-8df0-83e3daba235c.png)
![image](https://user-images.githubusercontent.com/13645069/33213854-af6a79c4-d129-11e7-8c82-1005463909a9.png)

After:
![image](https://user-images.githubusercontent.com/13645069/33213819-7f2b2010-d129-11e7-8bb7-43a048140618.png)
![image](https://user-images.githubusercontent.com/13645069/33213859-b60fe26e-d129-11e7-9774-bc0df600b677.png)

Love to see this merged.

regards,
Rick & Hein