### PR TITLE
Add DateRangePicker example with presets

### DIFF
--- a/.storybook-css/config.js
+++ b/.storybook-css/config.js
@@ -67,6 +67,7 @@ function loadStories() {
   require('../stories/DayPickerRangeController');
   require('../stories/DayPickerSingleDateController');
   require('../stories/DayPicker');
+  require('../stories/PresetDateRangePicker');
 }
 
 setAddon(infoAddon);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -67,6 +67,7 @@ function loadStories() {
   require('../stories/DayPickerRangeController');
   require('../stories/DayPickerSingleDateController');
   require('../stories/DayPicker');
+  require('../stories/PresetDateRangePicker');
 }
 
 setAddon(infoAddon);

--- a/examples/PresetDateRangePicker.jsx
+++ b/examples/PresetDateRangePicker.jsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import momentPropTypes from 'react-moment-proptypes';
+import moment from 'moment';
+import omit from 'lodash/omit';
+
+import { withStyles, withStylesPropTypes, css } from 'react-with-styles';
+
+import DateRangePicker from '../src/components/DateRangePicker';
+
+import { DateRangePickerPhrases } from '../src/defaultPhrases';
+import DateRangePickerShape from '../src/shapes/DateRangePickerShape';
+import { START_DATE, END_DATE, HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../src/constants';
+import isSameDay from '../src/utils/isSameDay';
+
+const propTypes = {
+  ...withStylesPropTypes,
+
+  // example props for the demo
+  autoFocus: PropTypes.bool,
+  autoFocusEndDate: PropTypes.bool,
+  initialStartDate: momentPropTypes.momentObj,
+  initialEndDate: momentPropTypes.momentObj,
+  presets: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string,
+    start: momentPropTypes.momentObj,
+    end: momentPropTypes.momentObj,
+  })),
+
+  ...omit(DateRangePickerShape, [
+    'startDate',
+    'endDate',
+    'onDatesChange',
+    'focusedInput',
+    'onFocusChange',
+  ]),
+};
+
+const defaultProps = {
+  // example props for the demo
+  autoFocus: false,
+  autoFocusEndDate: false,
+  initialStartDate: null,
+  initialEndDate: null,
+  presets: [],
+
+  // input related props
+  startDateId: START_DATE,
+  startDatePlaceholderText: 'Start Date',
+  endDateId: END_DATE,
+  endDatePlaceholderText: 'End Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDates: false,
+  showDefaultInputIcon: false,
+  customInputIcon: null,
+  customArrowIcon: null,
+  customCloseIcon: null,
+
+  // calendar presentation and interaction related props
+  renderMonth: null,
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDates: false,
+  isRTL: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+  onClose() {},
+
+  // day presentation and interaction related props
+  renderDay: null,
+  minimumNights: 0,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => false,
+  isDayHighlighted: () => false,
+
+  // internationalization
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: DateRangePickerPhrases,
+};
+
+class DateRangePickerWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    let focusedInput = null;
+    if (props.autoFocus) {
+      focusedInput = START_DATE;
+    } else if (props.autoFocusEndDate) {
+      focusedInput = END_DATE;
+    }
+
+    this.state = {
+      focusedInput,
+      startDate: props.initialStartDate,
+      endDate: props.initialEndDate,
+    };
+
+    this.onDatesChange = this.onDatesChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+    this.renderDatePresets = this.renderDatePresets.bind(this);
+  }
+
+  onDatesChange({ startDate, endDate }) {
+    this.setState({ startDate, endDate });
+  }
+
+  onFocusChange(focusedInput) {
+    this.setState({ focusedInput });
+  }
+
+  renderDatePresets() {
+    const { presets, styles } = this.props;
+    const { startDate, endDate } = this.state;
+
+    return (
+      <div {...css(styles.PresetDateRangePicker_panel)}>
+        {presets.map(({ text, start, end }) => {
+          const isSelected = isSameDay(start, startDate) && isSameDay(end, endDate);
+          return (
+            <button
+              key={text}
+              {...css(
+                styles.PresetDateRangePicker_button,
+                isSelected && styles.PresetDateRangePicker_button__selected,
+              )}
+              type="button"
+              onClick={() => this.onDatesChange({ startDate: start, endDate: end })}
+            >
+              {text}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  render() {
+    const { focusedInput, startDate, endDate } = this.state;
+
+    // autoFocus, autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
+    // example wrapper but are not props on the SingleDatePicker itself and
+    // thus, have to be omitted.
+    const props = omit(this.props, [
+      'autoFocus',
+      'autoFocusEndDate',
+      'initialStartDate',
+      'initialEndDate',
+      'presets',
+    ]);
+
+    return (
+      <div>
+        <DateRangePicker
+          {...props}
+          renderCalendarInfo={this.renderDatePresets}
+          onDatesChange={this.onDatesChange}
+          onFocusChange={this.onFocusChange}
+          focusedInput={focusedInput}
+          startDate={startDate}
+          endDate={endDate}
+        />
+      </div>
+    );
+  }
+}
+
+DateRangePickerWrapper.propTypes = propTypes;
+DateRangePickerWrapper.defaultProps = defaultProps;
+
+export default withStyles(({ reactDates: { color } }) => ({
+  PresetDateRangePicker_panel: {
+    padding: '0 22px 11px 22px',
+  },
+
+  PresetDateRangePicker_button: {
+    position: 'relative',
+    height: '100%',
+    textAlign: 'center',
+    background: 'none',
+    border: `2px solid ${color.core.primary}`,
+    color: color.core.primary,
+    padding: '4px 12px',
+    marginRight: 8,
+    font: 'inherit',
+    fontWeight: 700,
+    lineHeight: 'normal',
+    overflow: 'visible',
+    boxSizing: 'border-box',
+    cursor: 'pointer',
+
+    ':active': {
+      outline: 0,
+    },
+  },
+
+  PresetDateRangePicker_button__selected: {
+    color: color.core.white,
+    background: color.core.primary,
+  },
+}))(DateRangePickerWrapper);

--- a/scripts/buildCSS.js
+++ b/scripts/buildCSS.js
@@ -16,12 +16,14 @@ require('../test/_helpers/ignoreSVGStrings');
 registerMaxSpecificity(0);
 registerCSSInterfaceWithDefaultTheme();
 
-const DateRangePickerPath = './src/components/DateRangePicker.jsx';
-const SingleDatePickerPath = './src/components/SingleDatePicker.jsx';
+const DateRangePickerPath = './examples/DateRangePickerWrapper.jsx';
+const SingleDatePickerPath = './examples/SingleDatePickerWrapper.jsx';
+const PresetDateRangePickerPath = './examples/PresetDateRangePicker.jsx';
 
 const dateRangePickerCSS = compileCSS(DateRangePickerPath);
 const singleDatePickerCSS = compileCSS(SingleDatePickerPath);
-const CSS = dateRangePickerCSS + singleDatePickerCSS;
+const presetDatePickerCSS = compileCSS(PresetDateRangePickerPath);
+const CSS = dateRangePickerCSS + singleDatePickerCSS + presetDatePickerCSS;
 
 const format = new CleanCSS({
   level: optimizeForProduction ? 2 : 0,

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -2,14 +2,14 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf, action } from '@storybook/react';
 
+import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
+
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
 import { VERTICAL_ORIENTATION } from '../src/constants';
 
 import DayPickerRangeControllerWrapper from '../examples/DayPickerRangeControllerWrapper';
-
-const monospace = text => `<span style="font-family:monospace;background:#f7f7f7">${text}</span>`;
 
 const dayPickerRangeControllerInfo = `The ${monospace('DayPickerRangeController')} component is a
   fully controlled version of the ${monospace('DayPicker')} that has built-in rules for selecting a
@@ -27,27 +27,6 @@ const dayPickerRangeControllerInfo = `The ${monospace('DayPickerRangeController'
   The ${monospace('DayPickerRangeController')} is particularly useful if you are interested in the
   ${monospace('DateRangePicker')} functionality and calendar presentation, but would like to
   implement your own inputs.`;
-
-const InfoPanel = ({ text }) => (
-  <div
-    style={{
-      backgroundColor: '#fff',
-      fontColor: '#3c3f40',
-      fontSize: 14,
-      margin: '8px 0',
-      padding: 16,
-    }}
-  >
-    <span dangerouslySetInnerHTML={{ __html: text }} />
-  </div>
-);
-
-const InfoPanelDecorator = story => (
-  <div>
-    <InfoPanel text={dayPickerRangeControllerInfo} />
-    {story()}
-  </div>
-);
 
 const TestPrevIcon = () => (
   <span
@@ -99,7 +78,7 @@ const datesList = [
 ];
 
 storiesOf('DayPickerRangeController', module)
-  .addDecorator(InfoPanelDecorator)
+  .addDecorator(InfoPanelDecorator(dayPickerRangeControllerInfo))
   .addWithInfo('default', () => (
     <DayPickerRangeControllerWrapper
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -2,6 +2,8 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf, action } from '@storybook/react';
 
+import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
+
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
@@ -9,9 +11,7 @@ import { VERTICAL_ORIENTATION } from '../src/constants';
 
 import DayPickerSingleDateControllerWrapper from '../examples/DayPickerSingleDateControllerWrapper';
 
-const monospace = text => `<span style="font-family:monospace;background:#f7f7f7">${text}</span>`;
-
-const dayPickerRangeControllerInfo = `The ${monospace('DayPickerSingleDateController')} component is a
+const dayPickerSingleDateControllerInfo = `The ${monospace('DayPickerSingleDateController')} component is a
   fully controlled version of the ${monospace('DayPicker')} that has built-in rules for selecting a
   single date. Unlike the ${monospace('DayPicker')}, which requires the consumer to explicitly define
   ${monospace('onDayMouseEnter')}, ${monospace('onDayMouseLeave')}, and ${monospace('onDayClick')}
@@ -27,27 +27,6 @@ const dayPickerRangeControllerInfo = `The ${monospace('DayPickerSingleDateContro
   The ${monospace('DayPickerSingleDateController')} is particularly useful if you are interested in the
   ${monospace('SingleDatePicker')} functionality and calendar presentation, but would like to
   implement your own input.`;
-
-const InfoPanel = ({ text }) => (
-  <div
-    style={{
-      backgroundColor: '#fff',
-      fontColor: '#3c3f40',
-      fontSize: 14,
-      margin: '8px 0',
-      padding: 16,
-    }}
-  >
-    <span dangerouslySetInnerHTML={{ __html: text }} />
-  </div>
-);
-
-const InfoPanelDecorator = story => (
-  <div>
-    <InfoPanel text={dayPickerRangeControllerInfo} />
-    {story()}
-  </div>
-);
 
 const TestPrevIcon = () => (
   <span
@@ -99,7 +78,7 @@ const datesList = [
 ];
 
 storiesOf('DayPickerSingleDateController', module)
-  .addDecorator(InfoPanelDecorator)
+  .addDecorator(InfoPanelDecorator(dayPickerSingleDateControllerInfo))
   .addWithInfo('default', () => (
     <DayPickerSingleDateControllerWrapper
       onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}

--- a/stories/InfoPanelDecorator.js
+++ b/stories/InfoPanelDecorator.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export function monospace(text) {
+  return `<span style="font-family:monospace;background:#f7f7f7">${text}</span>`;
+}
+
+function InfoPanel({ text }) {
+  return (
+    <div
+      style={{
+        backgroundColor: '#fff',
+        fontColor: '#3c3f40',
+        fontSize: 14,
+        margin: '8px 0',
+        padding: 16,
+      }}
+    >
+      <span dangerouslySetInnerHTML={{ __html: text }} />
+    </div>
+  );
+}
+
+InfoPanel.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default function InfoPanelDecorator(text) {
+  return story => (
+    <div>
+      <InfoPanel text={text} />
+      {story()}
+    </div>
+  );
+}

--- a/stories/PresetDateRangePicker.js
+++ b/stories/PresetDateRangePicker.js
@@ -4,6 +4,17 @@ import moment from 'moment';
 
 import PresetDateRangePicker from '../examples/PresetDateRangePicker';
 
+import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
+
+const presetDateRangePickerControllerInfo = `The ${monospace('PresetDateRangePicker')} component is not
+  exported by ${monospace('react-dates')}. It is instead an example of how you might use the
+  ${monospace('DateRangePicker')} along with the ${monospace('renderCalendarInfo')} prop in
+  order to add preset range buttons for easy range selection. You can see the example code
+  <a href="https://github.com/airbnb/react-dates/blob/master/examples/PresetDateRangePicker.jsx">
+  here</a> and
+  <a href="https://github.com/airbnb/react-dates/blob/master/stories/PresetDateRangePicker.js">
+  here</a>.`;
+
 const today = moment();
 const tomorrow = moment().add(1, 'day');
 const presets = [{
@@ -28,6 +39,7 @@ const presets = [{
 }];
 
 storiesOf('PresetDatePicker', module)
+  .addDecorator(InfoPanelDecorator(presetDateRangePickerControllerInfo))
   .addWithInfo('default', () => (
     <PresetDateRangePicker
       presets={presets}

--- a/stories/PresetDateRangePicker.js
+++ b/stories/PresetDateRangePicker.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import moment from 'moment';
+
+import PresetDateRangePicker from '../examples/PresetDateRangePicker';
+
+const today = moment();
+const tomorrow = moment().add(1, 'day');
+const presets = [{
+  text: 'Today',
+  start: today,
+  end: today,
+},
+{
+  text: 'Tomorrow',
+  start: tomorrow,
+  end: tomorrow,
+},
+{
+  text: 'Next Week',
+  start: today,
+  end: moment().add(1, 'week'),
+},
+{
+  text: 'Next Month',
+  start: today,
+  end: moment().add(1, 'month'),
+}];
+
+storiesOf('PresetDatePicker', module)
+  .addWithInfo('default', () => (
+    <PresetDateRangePicker
+      presets={presets}
+      autoFocus
+    />
+  ));


### PR DESCRIPTION
Somewhat of a fix for #29 

So I am loath to introduce this as a separate prop because it is already possible to accomplish with the current API (and the current API allows for full customization of however you'd want to make this look). This adds an example for how exactly you might set up preset date ranges using `renderCalendarInfo` and a regular ol' `DateRangePicker`.

I think I still need to get this working with the css storybook, but here's a screenshot of the aphrodite storybook example:
![screen shot 2017-11-28 at 12 06 54 pm](https://user-images.githubusercontent.com/1383861/33341912-2b87736e-d435-11e7-86be-c8f21a2a93c4.png)

to: @ljharb @erin-doyle @airbnb/webinfra 
