### PR TITLE
Allow react-portal v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "prop-types": "^15.5.10",
     "react-addons-shallow-compare": "^15.5.2",
     "react-moment-proptypes": "^1.5.0",
-    "react-portal": "^3.1.0",
+    "react-portal": "^3.1.0 || ^4.0.0",
     "react-with-styles": "^2.2.0",
     "react-with-styles-interface-css": "^3.0.0"
   },


### PR DESCRIPTION
This is the version you will want to use if you are on React 16. It
looks like the API is the same, so it should be safe to allow this.

Fixes #860 

Note: I haven't tested this at all, so not sure if it actually works.