### PR TITLE
Add transitionDuration prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ navNext: PropTypes.node,
 onPrevMonthClick: PropTypes.func,
 onNextMonthClick: PropTypes.func,
 onClose: PropTypes.func,
+transitionDuration: nonNegativeInteger, // milliseconds
 
 // day presentation and interaction related props
 renderDay: PropTypes.func,
@@ -224,6 +225,7 @@ navNext: PropTypes.node,
 onPrevMonthClick: PropTypes.func,
 onNextMonthClick: PropTypes.func,
 onClose: PropTypes.func,
+transitionDuration: nonNegativeInteger, // milliseconds
 
 // day presentation and interaction related props
 renderDay: PropTypes.func,
@@ -273,6 +275,7 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
   navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
+  transitionDuration: nonNegativeInteger, // milliseconds
 
   // day presentation and interaction related props
   renderDay: PropTypes.func,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -50,6 +50,7 @@ const propTypes = forbidExtraProps({
   firstDayOfWeek: DayOfWeekShape,
   setCalendarMonthHeights: PropTypes.func,
   isRTL: PropTypes.bool,
+  transitionDuration: nonNegativeInteger,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -78,6 +79,7 @@ const defaultProps = {
   firstDayOfWeek: null,
   setCalendarMonthHeights() {},
   isRTL: false,
+  transitionDuration: 200,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -166,11 +168,17 @@ class CalendarMonthGrid extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { isAnimating, onMonthTransitionEnd, setCalendarMonthHeights } = this.props;
+    const {
+      isAnimating,
+      transitionDuration,
+      onMonthTransitionEnd,
+      setCalendarMonthHeights,
+    } = this.props;
 
     // For IE9, immediately call onMonthTransitionEnd instead of
-    // waiting for the animation to complete
-    if (!this.isTransitionEndSupported && isAnimating) {
+    // waiting for the animation to complete. Similarly, if transitionDuration
+    // is set to 0, also immediately invoke the onMonthTransitionEnd callback
+    if ((!this.isTransitionEndSupported || !transitionDuration) && isAnimating) {
       onMonthTransitionEnd();
     }
 
@@ -232,6 +240,7 @@ class CalendarMonthGrid extends React.Component {
       styles,
       phrases,
       dayAriaLabelFormat,
+      transitionDuration,
     } = this.props;
 
     const { months } = this.state;
@@ -253,8 +262,8 @@ class CalendarMonthGrid extends React.Component {
           isVertical && styles.CalendarMonthGrid__vertical,
           isVerticalScrollable && styles.CalendarMonthGrid__vertical_scrollable,
           isAnimating && styles.CalendarMonthGrid__animating,
-          isAnimating && {
-            transition: 'transform 0.2s ease-in-out',
+          isAnimating && transitionDuration && {
+            transition: `transform ${transitionDuration}ms ease-in-out`,
           },
           {
             ...getTransformStyles(transformValue),

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -79,6 +79,7 @@ const defaultProps = {
   isRTL: false,
   firstDayOfWeek: null,
   verticalHeight: null,
+  transitionDuration: undefined,
 
   // navigation related props
   navPrev: null,
@@ -322,6 +323,7 @@ class DateRangePicker extends React.Component {
       weekDayFormat,
       styles,
       verticalHeight,
+      transitionDuration,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -389,6 +391,7 @@ class DateRangePicker extends React.Component {
           firstDayOfWeek={firstDayOfWeek}
           weekDayFormat={weekDayFormat}
           verticalHeight={verticalHeight}
+          transitionDuration={transitionDuration}
         />
 
         {withFullScreenPortal && (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -57,6 +57,7 @@ const propTypes = forbidExtraProps({
   isRTL: PropTypes.bool,
   verticalHeight: nonNegativeInteger,
   noBorder: PropTypes.bool,
+  transitionDuration: nonNegativeInteger,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -104,6 +105,7 @@ export const defaultProps = {
   isRTL: false,
   verticalHeight: null,
   noBorder: false,
+  transitionDuration: undefined,
 
   // navigation props
   navPrev: null,
@@ -691,6 +693,7 @@ class DayPicker extends React.Component {
       verticalHeight,
       dayAriaLabelFormat,
       noBorder,
+      transitionDuration,
     } = this.props;
 
     const numOfWeekHeaders = this.isVertical() ? 1 : numberOfMonths;
@@ -811,6 +814,7 @@ class DayPicker extends React.Component {
                 phrases={phrases}
                 isRTL={isRTL}
                 dayAriaLabelFormat={dayAriaLabelFormat}
+                transitionDuration={transitionDuration}
               />
               {verticalScrollable && this.renderNavigation()}
             </div>

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -71,6 +71,7 @@ const propTypes = forbidExtraProps({
   renderCalendarInfo: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
   verticalHeight: nonNegativeInteger,
+  transitionDuration: nonNegativeInteger,
 
   // accessibility
   onBlur: PropTypes.func,
@@ -123,6 +124,7 @@ const defaultProps = {
   firstDayOfWeek: null,
   verticalHeight: null,
   noBorder: false,
+  transitionDuration: undefined,
 
   // accessibility
   onBlur() {},
@@ -907,6 +909,7 @@ export default class DayPickerRangeController extends React.Component {
       dayAriaLabelFormat,
       verticalHeight,
       noBorder,
+      transitionDuration,
     } = this.props;
 
     const { currentMonth, phrases, visibleDays } = this.state;
@@ -947,6 +950,7 @@ export default class DayPickerRangeController extends React.Component {
         dayAriaLabelFormat={dayAriaLabelFormat}
         verticalHeight={verticalHeight}
         noBorder={noBorder}
+        transitionDuration={transitionDuration}
       />
     );
   }

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -55,6 +55,7 @@ const propTypes = forbidExtraProps({
   daySize: nonNegativeInteger,
   verticalHeight: nonNegativeInteger,
   noBorder: PropTypes.bool,
+  transitionDuration: nonNegativeInteger,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -104,6 +105,7 @@ const defaultProps = {
   daySize: DAY_SIZE,
   verticalHeight: null,
   noBorder: false,
+  transitionDuration: undefined,
 
   navPrev: null,
   navNext: null,
@@ -593,6 +595,7 @@ export default class DayPickerSingleDateController extends React.Component {
       weekDayFormat,
       verticalHeight,
       noBorder,
+      transitionDuration,
     } = this.props;
 
     const { currentMonth, visibleDays } = this.state;
@@ -630,6 +633,7 @@ export default class DayPickerSingleDateController extends React.Component {
         dayAriaLabelFormat={dayAriaLabelFormat}
         verticalHeight={verticalHeight}
         noBorder={noBorder}
+        transitionDuration={transitionDuration}
       />
     );
 

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -74,6 +74,7 @@ const defaultProps = {
   daySize: DAY_SIZE,
   isRTL: false,
   verticalHeight: null,
+  transitionDuration: undefined,
 
   // navigation related props
   navPrev: null,
@@ -359,6 +360,7 @@ class SingleDatePicker extends React.Component {
       weekDayFormat,
       styles,
       verticalHeight,
+      transitionDuration,
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -416,6 +418,7 @@ class SingleDatePicker extends React.Component {
           firstDayOfWeek={firstDayOfWeek}
           weekDayFormat={weekDayFormat}
           verticalHeight={verticalHeight}
+          transitionDuration={transitionDuration}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -59,6 +59,7 @@ export default {
   renderCalendarInfo: PropTypes.func,
   hideKeyboardShortcutsPanel: PropTypes.bool,
   verticalHeight: nonNegativeInteger,
+  transitionDuration: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -52,6 +52,7 @@ export default {
   daySize: nonNegativeInteger,
   isRTL: PropTypes.bool,
   verticalHeight: nonNegativeInteger,
+  transitionDuration: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -171,4 +171,10 @@ storiesOf('DRP - Calendar Props', module)
       onClose={({ startDate, endDate }) => alert(`onClose: startDate = ${startDate}, endDate = ${endDate}`)}
       autoFocus
     />
+  ))
+  .addWithInfo('with no animation', () => (
+    <DateRangePickerWrapper
+      transitionDuration={0}
+      autoFocus
+    />
   ));

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -122,6 +122,11 @@ storiesOf('DayPicker', module)
       weekDayFormat="ddd"
     />
   ))
+  .addWithInfo('with no animation', () => (
+    <DayPicker
+      transitionDuration={0}
+    />
+  ))
   .addWithInfo('noBorder', () => (
     <DayPicker noBorder />
   ));

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -235,4 +235,12 @@ storiesOf('DayPickerRangeController', module)
         <TestCustomInfoPanel />
       )}
     />
+  ))
+  .addWithInfo('with no animation', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      transitionDuration={0}
+    />
   ));

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -215,4 +215,12 @@ storiesOf('DayPickerSingleDateController', module)
         <TestCustomInfoPanel />
       )}
     />
+  ))
+  .addWithInfo('with no animation', () => (
+    <DayPickerSingleDateControllerWrapper
+      onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
+      transitionDuration={0}
+    />
   ));

--- a/stories/PresetDateRangePicker.js
+++ b/stories/PresetDateRangePicker.js
@@ -38,7 +38,7 @@ const presets = [{
   end: moment().add(1, 'month'),
 }];
 
-storiesOf('PresetDatePicker', module)
+storiesOf('PresetDateRangePicker', module)
   .addDecorator(InfoPanelDecorator(presetDateRangePickerControllerInfo))
   .addWithInfo('default', () => (
     <PresetDateRangePicker

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -152,5 +152,11 @@ storiesOf('SDP - Calendar Props', module)
       onClose={({ date }) => alert(`onClose: date = ${date}`)}
       autoFocus
     />
+  ))
+  .addWithInfo('with no animation', () => (
+    <SingleDatePickerWrapper
+      transitionDuration={0}
+      autoFocus
+    />
   ));
 


### PR DESCRIPTION
Fix for https://github.com/airbnb/react-dates/issues/834 and also for https://github.com/airbnb/react-dates/issues/849

This change allows you to set the `transitionDuration` manually (including setting it to 0).

to: @ljharb @erin-doyle @airbnb/webinfra 
FYI: @M-Willett @wachunga 