### PR TITLE
Remove unused style in KeyboardShortcutRow.jsx

### DIFF
--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -72,7 +72,6 @@ export default withStyles(({ reactDates: { color } }) => ({
   },
 
   KeyboardShortcutRow_keyContainer__block: {
-    width: 'auto',
     textAlign: 'left',
     display: 'inline',
   },


### PR DESCRIPTION
`width: auto` is ignored due to display.