### PR TITLE
Add borderless option for inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ showDefaultInputIcon: PropTypes.bool,
 customInputIcon: PropTypes.node,
 customArrowIcon: PropTypes.node,
 customCloseIcon: PropTypes.node,
+noBorder: PropTypes.bool,
 
 // calendar presentation and interaction related props
 renderMonth: PropTypes.func,
@@ -196,6 +197,7 @@ showClearDate: PropTypes.bool,
 customCloseIcon: PropTypes.node,
 showDefaultInputIcon: PropTypes.bool,
 customInputIcon: PropTypes.node,
+noBorder: PropTypes.bool,
 
 // calendar presentation and interaction related props
 renderMonth: PropTypes.func,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -60,6 +60,7 @@ const defaultProps = {
   customInputIcon: null,
   customArrowIcon: null,
   customCloseIcon: null,
+  noBorder: false,
 
   // calendar presentation and interaction related props
   renderMonth: null,
@@ -436,6 +437,7 @@ class DateRangePicker extends React.Component {
       onDatesChange,
       onClose,
       isRTL,
+      noBorder,
       styles,
     } = this.props;
 
@@ -481,6 +483,7 @@ class DateRangePicker extends React.Component {
             screenReaderMessage={screenReaderInputMessage}
             isFocused={isDateRangePickerInputFocused}
             isRTL={isRTL}
+            noBorder={noBorder}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -58,6 +58,7 @@ const propTypes = forbidExtraProps({
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
+  noBorder: PropTypes.bool,
 
   // accessibility
   isFocused: PropTypes.bool, // describes actual DOM focus
@@ -100,6 +101,7 @@ const defaultProps = {
   customInputIcon: null,
   customArrowIcon: null,
   customCloseIcon: null,
+  noBorder: false,
 
   // accessibility
   isFocused: false,
@@ -143,6 +145,7 @@ function DateRangePickerInput({
   isFocused,
   phrases,
   isRTL,
+  noBorder,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -174,6 +177,7 @@ function DateRangePickerInput({
         styles.DateRangePickerInput,
         disabled && styles.DateRangePickerInput__disabled,
         isRTL && styles.DateRangePickerInput__rtl,
+        !noBorder && styles.DateRangePickerInput__withBorder,
       )}
     >
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
@@ -251,12 +255,15 @@ DateRangePickerInput.defaultProps = defaultProps;
 export default withStyles(({ reactDates: { color, sizing } }) => ({
   DateRangePickerInput: {
     backgroundColor: color.background,
-    border: `1px solid ${color.core.grayLighter}`,
     display: 'inline-block',
   },
 
   DateRangePickerInput__disabled: {
     background: color.disabled,
+  },
+
+  DateRangePickerInput__withBorder: {
+    border: `1px solid ${color.core.grayLighter}`,
   },
 
   DateRangePickerInput__rtl: {

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -41,6 +41,7 @@ const propTypes = forbidExtraProps({
   required: PropTypes.bool,
   readOnly: PropTypes.bool,
   openDirection: openDirectionShape,
+  noBorder: PropTypes.bool,
 
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
@@ -88,6 +89,7 @@ const defaultProps = {
   required: false,
   readOnly: false,
   openDirection: OPEN_DOWN,
+  noBorder: false,
 
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
@@ -261,6 +263,7 @@ export default class DateRangePickerInputController extends React.Component {
       onKeyDownArrowDown,
       onKeyDownQuestionMark,
       isRTL,
+      noBorder,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -300,6 +303,7 @@ export default class DateRangePickerInputController extends React.Component {
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         isRTL={isRTL}
+        noBorder={noBorder}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -54,6 +54,7 @@ const defaultProps = {
   inputIconPosition: ICON_BEFORE_POSITION,
   customInputIcon: null,
   customCloseIcon: null,
+  noBorder: false,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -452,6 +453,7 @@ class SingleDatePicker extends React.Component {
       withFullScreenPortal,
       screenReaderInputMessage,
       isRTL,
+      noBorder,
       styles,
     } = this.props;
 
@@ -490,6 +492,7 @@ class SingleDatePicker extends React.Component {
             screenReaderMessage={screenReaderInputMessage}
             phrases={phrases}
             isRTL={isRTL}
+            noBorder={noBorder}
           />
 
           {this.maybeRenderDayPickerWithPortal()}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -34,6 +34,8 @@ const propTypes = forbidExtraProps({
   inputIconPosition: IconPositionShape,
   customInputIcon: PropTypes.node,
   isRTL: PropTypes.bool,
+  noBorder: PropTypes.bool,
+
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
@@ -63,6 +65,7 @@ const defaultProps = {
   customCloseIcon: null,
   customInputIcon: null,
   isRTL: false,
+  noBorder: false,
 
   onChange() {},
   onClearDate() {},
@@ -102,6 +105,7 @@ function SingleDatePickerInput({
   customInputIcon,
   openDirection,
   isRTL,
+  noBorder,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -130,6 +134,7 @@ function SingleDatePickerInput({
         styles.SingleDatePickerInput,
         disabled && styles.SingleDatePickerInput__disabled,
         isRTL && styles.SingleDatePickerInput__rtl,
+        !noBorder && styles.SingleDatePickerInput__withBorder,
       )}
     >
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
@@ -183,6 +188,9 @@ SingleDatePickerInput.defaultProps = defaultProps;
 export default withStyles(({ reactDates: { color } }) => ({
   SingleDatePickerInput: {
     backgroundColor: color.background,
+  },
+
+  SingleDatePickerInput__withBorder: {
     border: `1px solid ${color.core.border}`,
   },
 

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -38,6 +38,7 @@ export default {
   customInputIcon: PropTypes.node,
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
+  noBorder: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -31,6 +31,7 @@ export default {
   showDefaultInputIcon: PropTypes.bool,
   inputIconPosition: IconPositionShape,
   customInputIcon: PropTypes.node,
+  noBorder: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -119,4 +119,11 @@ storiesOf('DRP - Input Props', module)
       initialEndDate={moment().add(10, 'days')}
       screenReaderInputMessage="Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc"
     />
+  ))
+  .addWithInfo('noBorder', () => (
+    <DateRangePickerWrapper
+      initialStartDate={moment().add(3, 'days')}
+      initialEndDate={moment().add(10, 'days')}
+      noBorder
+    />
   ));

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -71,4 +71,10 @@ storiesOf('SDP - Input Props', module)
       initialDate={moment().add(3, 'days')}
       screenReaderInputMessage="Here you could inform screen reader users of the date format, minimum nights, blocked out dates, etc"
     />
+  ))
+  .addWithInfo('noBorder', () => (
+    <SingleDatePickerWrapper
+      initialDate={moment().add(3, 'days')}
+      noBorder
+    />
   ));


### PR DESCRIPTION
Related to https://github.com/airbnb/react-dates/pull/869

Sometimes you don't want your inputs to have a border! This solves for that option.

to: @ljharb @erin-doyle @noratarano @airbnb/webinfra