### PR TITLE
Add block styling to the SDP/DRP inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ customInputIcon: PropTypes.node,
 customArrowIcon: PropTypes.node,
 customCloseIcon: PropTypes.node,
 noBorder: PropTypes.bool,
+block: PropTypes.bool,
 
 // calendar presentation and interaction related props
 renderMonth: PropTypes.func,
@@ -198,6 +199,7 @@ customCloseIcon: PropTypes.node,
 showDefaultInputIcon: PropTypes.bool,
 customInputIcon: PropTypes.node,
 noBorder: PropTypes.bool,
+block: PropTypes.bool,
 
 // calendar presentation and interaction related props
 renderMonth: PropTypes.func,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -61,6 +61,7 @@ const defaultProps = {
   customArrowIcon: null,
   customCloseIcon: null,
   noBorder: false,
+  block: false,
 
   // calendar presentation and interaction related props
   renderMonth: null,
@@ -438,6 +439,7 @@ class DateRangePicker extends React.Component {
       onClose,
       isRTL,
       noBorder,
+      block,
       styles,
     } = this.props;
 
@@ -446,7 +448,12 @@ class DateRangePicker extends React.Component {
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
 
     return (
-      <div {...css(styles.DateRangePicker)}>
+      <div
+        {...css(
+          styles.DateRangePicker,
+          block && styles.DateRangePicker__block,
+        )}
+      >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
           <DateRangePickerInputController
             startDate={startDate}
@@ -484,6 +491,7 @@ class DateRangePicker extends React.Component {
             isFocused={isDateRangePickerInputFocused}
             isRTL={isRTL}
             noBorder={noBorder}
+            block={block}
           />
 
           {this.maybeRenderDayPickerWithPortal()}
@@ -501,6 +509,10 @@ export default withStyles(({ reactDates: { color, zIndex, spacing } }) => ({
   DateRangePicker: {
     position: 'relative',
     display: 'inline-block',
+  },
+
+  DateRangePicker__block: {
+    display: 'block',
   },
 
   DateRangePicker_picker: {

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -59,6 +59,7 @@ const propTypes = forbidExtraProps({
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
   noBorder: PropTypes.bool,
+  block: PropTypes.bool,
 
   // accessibility
   isFocused: PropTypes.bool, // describes actual DOM focus
@@ -102,6 +103,7 @@ const defaultProps = {
   customArrowIcon: null,
   customCloseIcon: null,
   noBorder: false,
+  block: false,
 
   // accessibility
   isFocused: false,
@@ -146,6 +148,7 @@ function DateRangePickerInput({
   phrases,
   isRTL,
   noBorder,
+  block,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -178,6 +181,8 @@ function DateRangePickerInput({
         disabled && styles.DateRangePickerInput__disabled,
         isRTL && styles.DateRangePickerInput__rtl,
         !noBorder && styles.DateRangePickerInput__withBorder,
+        block && styles.DateRangePickerInput__block,
+        showClearDates && styles.DateRangePickerInput__showClearDates,
       )}
     >
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
@@ -234,6 +239,7 @@ function DateRangePickerInput({
           aria-label={phrases.clearDates}
           {...css(
             styles.DateRangePickerInput_clearDates,
+            !customCloseIcon && styles.DateRangePickerInput_clearDates_default,
             !(startDate || endDate) && styles.DateRangePickerInput_clearDates__hide,
           )}
           onClick={onClearDates}
@@ -270,6 +276,14 @@ export default withStyles(({ reactDates: { color, sizing } }) => ({
     direction: 'rtl',
   },
 
+  DateRangePickerInput__block: {
+    display: 'block',
+  },
+
+  DateRangePickerInput__showClearDates: {
+    paddingRight: 30,
+  },
+
   DateRangePickerInput_arrow: {
     display: 'inline-block',
     verticalAlign: 'middle',
@@ -291,11 +305,15 @@ export default withStyles(({ reactDates: { color, sizing } }) => ({
     overflow: 'visible',
 
     cursor: 'pointer',
-    display: 'inline-block',
-    verticalAlign: 'middle',
     padding: 10,
     margin: '0 10px 0 5px',
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
 
+  DateRangePickerInput_clearDates_default: {
     ':focus': {
       background: color.core.border,
       borderRadius: '50%',

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -42,6 +42,7 @@ const propTypes = forbidExtraProps({
   readOnly: PropTypes.bool,
   openDirection: openDirectionShape,
   noBorder: PropTypes.bool,
+  block: PropTypes.bool,
 
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
@@ -90,6 +91,7 @@ const defaultProps = {
   readOnly: false,
   openDirection: OPEN_DOWN,
   noBorder: false,
+  block: false,
 
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
@@ -264,6 +266,7 @@ export default class DateRangePickerInputController extends React.Component {
       onKeyDownQuestionMark,
       isRTL,
       noBorder,
+      block,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -304,6 +307,7 @@ export default class DateRangePickerInputController extends React.Component {
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         isRTL={isRTL}
         noBorder={noBorder}
+        block={block}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -55,6 +55,7 @@ const defaultProps = {
   customInputIcon: null,
   customCloseIcon: null,
   noBorder: false,
+  block: false,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -454,6 +455,7 @@ class SingleDatePicker extends React.Component {
       screenReaderInputMessage,
       isRTL,
       noBorder,
+      block,
       styles,
     } = this.props;
 
@@ -464,7 +466,12 @@ class SingleDatePicker extends React.Component {
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onClearFocus : undefined;
 
     return (
-      <div {...css(styles.SingleDatePicker)}>
+      <div
+        {...css(
+          styles.SingleDatePicker,
+          block && styles.SingleDatePicker__block,
+        )}
+      >
         <OutsideClickHandler onOutsideClick={onOutsideClick}>
           <SingleDatePickerInput
             id={id}
@@ -493,6 +500,7 @@ class SingleDatePicker extends React.Component {
             phrases={phrases}
             isRTL={isRTL}
             noBorder={noBorder}
+            block={block}
           />
 
           {this.maybeRenderDayPickerWithPortal()}
@@ -510,6 +518,10 @@ export default withStyles(({ reactDates: { color, spacing, zIndex } }) => ({
   SingleDatePicker: {
     position: 'relative',
     display: 'inline-block',
+  },
+
+  SingleDatePicker__block: {
+    display: 'block',
   },
 
   SingleDatePicker_picker: {

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -35,6 +35,7 @@ const propTypes = forbidExtraProps({
   customInputIcon: PropTypes.node,
   isRTL: PropTypes.bool,
   noBorder: PropTypes.bool,
+  block: PropTypes.bool,
 
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
@@ -66,6 +67,7 @@ const defaultProps = {
   customInputIcon: null,
   isRTL: false,
   noBorder: false,
+  block: false,
 
   onChange() {},
   onClearDate() {},
@@ -106,6 +108,7 @@ function SingleDatePickerInput({
   openDirection,
   isRTL,
   noBorder,
+  block,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -135,6 +138,8 @@ function SingleDatePickerInput({
         disabled && styles.SingleDatePickerInput__disabled,
         isRTL && styles.SingleDatePickerInput__rtl,
         !noBorder && styles.SingleDatePickerInput__withBorder,
+        block && styles.SingleDatePickerInput__block,
+        showClearDate && styles.SingleDatePickerInput__showClearDate,
       )}
     >
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
@@ -163,6 +168,7 @@ function SingleDatePickerInput({
         <button
           {...css(
             styles.SingleDatePickerInput_clearDate,
+            !customCloseIcon && styles.SingleDatePickerInput_clearDate__default,
             !displayValue && styles.SingleDatePickerInput_clearDate__hide,
           )}
           type="button"
@@ -187,6 +193,7 @@ SingleDatePickerInput.defaultProps = defaultProps;
 
 export default withStyles(({ reactDates: { color } }) => ({
   SingleDatePickerInput: {
+    display: 'inline-block',
     backgroundColor: color.background,
   },
 
@@ -202,6 +209,14 @@ export default withStyles(({ reactDates: { color } }) => ({
     backgroundColor: color.disabled,
   },
 
+  SingleDatePickerInput__block: {
+    display: 'block',
+  },
+
+  SingleDatePickerInput__showClearDate: {
+    paddingRight: 30,
+  },
+
   SingleDatePickerInput_clearDate: {
     background: 'none',
     border: 0,
@@ -211,11 +226,15 @@ export default withStyles(({ reactDates: { color } }) => ({
     overflow: 'visible',
 
     cursor: 'pointer',
-    display: 'inline-block',
-    verticalAlign: 'middle',
     padding: 10,
     margin: '0 10px 0 5px',
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
 
+  SingleDatePickerInput_clearDate__default: {
     ':focus': {
       background: color.core.border,
       borderRadius: '50%',

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -39,6 +39,7 @@ export default {
   customArrowIcon: PropTypes.node,
   customCloseIcon: PropTypes.node,
   noBorder: PropTypes.bool,
+  block: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -32,6 +32,7 @@ export default {
   inputIconPosition: IconPositionShape,
   customInputIcon: PropTypes.node,
   noBorder: PropTypes.bool,
+  block: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -126,4 +126,12 @@ storiesOf('DRP - Input Props', module)
       initialEndDate={moment().add(10, 'days')}
       noBorder
     />
+  ))
+  .addWithInfo('block styling', () => (
+    <DateRangePickerWrapper
+      initialStartDate={moment().add(3, 'days')}
+      initialEndDate={moment().add(10, 'days')}
+      showClearDates
+      block
+    />
   ));

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -77,4 +77,11 @@ storiesOf('SDP - Input Props', module)
       initialDate={moment().add(3, 'days')}
       noBorder
     />
+  ))
+  .addWithInfo('block styling', () => (
+    <SingleDatePickerWrapper
+      initialDate={moment().add(3, 'days')}
+      showClearDate
+      block
+    />
   ));


### PR DESCRIPTION
Previous style-options PRs:
https://github.com/airbnb/react-dates/pull/869
https://github.com/airbnb/react-dates/pull/870

This is a pretty common pattern across the airbnb site where we often want the input to fill the width of a parent container! We accomplish this mostly by adding `display: block` to the main container and the inputs. I also tweaked the clear dates button a bit to float it to the right instead of having it coming immediately after the inputs. This looks a bit nicer with block styling (and looks the same without it).

to: @ljharb @airbnb/webinfra @erin-doyle @noratarano