### PR TITLE
Add verticalSpacing prop

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -11,6 +11,7 @@ import { DateRangePickerPhrases } from '../defaultPhrases';
 
 import OutsideClickHandler from './OutsideClickHandler';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
+import getInputHeight from '../utils/getInputHeight';
 
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 
@@ -32,6 +33,8 @@ import {
   OPEN_UP,
   DAY_SIZE,
   ICON_BEFORE_POSITION,
+  FANG_HEIGHT_PX,
+  DEFAULT_VERTICAL_SPACING,
 } from '../constants';
 
 const propTypes = forbidExtraProps({
@@ -80,6 +83,7 @@ const defaultProps = {
   firstDayOfWeek: null,
   verticalHeight: null,
   transitionDuration: undefined,
+  verticalSpacing: DEFAULT_VERTICAL_SPACING,
 
   // navigation related props
   navPrev: null,
@@ -324,6 +328,8 @@ class DateRangePicker extends React.Component {
       styles,
       verticalHeight,
       transitionDuration,
+      verticalSpacing,
+      theme: { reactDates },
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
@@ -338,6 +344,12 @@ class DateRangePicker extends React.Component {
       <CloseButton {...css(styles.DateRangePicker_closeButton_svg)} />
     );
 
+    const {
+      font: { input: { lineHeight } },
+      spacing: { inputPadding, displayTextPaddingVertical },
+    } = reactDates;
+    const inputHeight = getInputHeight({ lineHeight, inputPadding, displayTextPaddingVertical });
+
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
         ref={this.setDayPickerContainerRef}
@@ -346,14 +358,18 @@ class DateRangePicker extends React.Component {
           anchorDirection === ANCHOR_LEFT && styles.DateRangePicker_picker__directionLeft,
           anchorDirection === ANCHOR_RIGHT && styles.DateRangePicker_picker__directionRight,
           orientation === HORIZONTAL_ORIENTATION && styles.DateRangePicker_picker__horizontal,
-          openDirection === OPEN_DOWN && styles.DateRangePicker_picker__openDown,
-          openDirection === OPEN_UP && styles.DateRangePicker_picker__openUp,
           orientation === VERTICAL_ORIENTATION && styles.DateRangePicker_picker__vertical,
+          openDirection === OPEN_DOWN && {
+            top: inputHeight + verticalSpacing,
+          },
+          openDirection === OPEN_UP && {
+            bottom: inputHeight + verticalSpacing,
+          },
           (withPortal || withFullScreenPortal) && styles.DateRangePicker_picker__portal,
           withFullScreenPortal && styles.DateRangePicker_picker__fullScreenPortal,
           isRTL && styles.DateRangePicker_picker__rtl,
+          dayPickerContainerStyles,
         )}
-        style={dayPickerContainerStyles}
         onClick={onOutsideClick}
       >
         <DayPickerRangeController
@@ -441,12 +457,15 @@ class DateRangePicker extends React.Component {
       isRTL,
       noBorder,
       block,
+      verticalSpacing,
       styles,
     } = this.props;
 
     const { isDateRangePickerInputFocused } = this.state;
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onOutsideClick : undefined;
+
+    const hideFang = verticalSpacing < FANG_HEIGHT_PX;
 
     return (
       <div
@@ -467,7 +486,7 @@ class DateRangePicker extends React.Component {
             isEndDateFocused={focusedInput === END_DATE}
             displayFormat={displayFormat}
             showClearDates={showClearDates}
-            showCaret={!withPortal && !withFullScreenPortal}
+            showCaret={!withPortal && !withFullScreenPortal && !hideFang}
             showDefaultInputIcon={showDefaultInputIcon}
             inputIconPosition={inputIconPosition}
             customInputIcon={customInputIcon}
@@ -493,6 +512,7 @@ class DateRangePicker extends React.Component {
             isRTL={isRTL}
             noBorder={noBorder}
             block={block}
+            verticalSpacing={verticalSpacing}
           />
 
           {this.maybeRenderDayPickerWithPortal()}
@@ -506,7 +526,7 @@ DateRangePicker.propTypes = propTypes;
 DateRangePicker.defaultProps = defaultProps;
 
 export { DateRangePicker as PureDateRangePicker };
-export default withStyles(({ reactDates: { color, zIndex, spacing } }) => ({
+export default withStyles(({ reactDates: { color, zIndex } }) => ({
   DateRangePicker: {
     position: 'relative',
     display: 'inline-block',
@@ -532,14 +552,6 @@ export default withStyles(({ reactDates: { color, zIndex, spacing } }) => ({
 
   DateRangePicker_picker__directionRight: {
     right: 0,
-  },
-
-  DateRangePicker_picker__openDown: {
-    top: spacing.inputMarginBottom,
-  },
-
-  DateRangePicker_picker__openUp: {
-    bottom: spacing.inputMarginBottom,
   },
 
   DateRangePicker_picker__portal: {

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
@@ -60,6 +60,7 @@ const propTypes = forbidExtraProps({
   customCloseIcon: PropTypes.node,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  verticalSpacing: nonNegativeInteger,
 
   // accessibility
   isFocused: PropTypes.bool, // describes actual DOM focus
@@ -104,6 +105,7 @@ const defaultProps = {
   customCloseIcon: null,
   noBorder: false,
   block: false,
+  verticalSpacing: undefined,
 
   // accessibility
   isFocused: false,
@@ -149,6 +151,7 @@ function DateRangePickerInput({
   isRTL,
   noBorder,
   block,
+  verticalSpacing,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -204,6 +207,7 @@ function DateRangePickerInput({
         onKeyDownShiftTab={onStartDateShiftTab}
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
+        verticalSpacing={verticalSpacing}
       />
 
       <div
@@ -231,6 +235,7 @@ function DateRangePickerInput({
         onKeyDownTab={onEndDateTab}
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
+        verticalSpacing={verticalSpacing}
       />
 
       {showClearDates && (

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -43,6 +43,7 @@ const propTypes = forbidExtraProps({
   openDirection: openDirectionShape,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  verticalSpacing: nonNegativeInteger,
 
   keepOpenOnDateSelect: PropTypes.bool,
   reopenPickerOnClearDates: PropTypes.bool,
@@ -92,6 +93,7 @@ const defaultProps = {
   openDirection: OPEN_DOWN,
   noBorder: false,
   block: false,
+  verticalSpacing: undefined,
 
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
@@ -267,6 +269,7 @@ export default class DateRangePickerInputController extends React.Component {
       isRTL,
       noBorder,
       block,
+      verticalSpacing,
     } = this.props;
 
     const startDateString = this.getDateString(startDate);
@@ -308,6 +311,7 @@ export default class DateRangePickerInputController extends React.Component {
         isRTL={isRTL}
         noBorder={noBorder}
         block={block}
+        verticalSpacing={verticalSpacing}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -13,6 +13,7 @@ import OutsideClickHandler from './OutsideClickHandler';
 import toMomentObject from '../utils/toMomentObject';
 import toLocalizedDateString from '../utils/toLocalizedDateString';
 import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
+import getInputHeight from '../utils/getInputHeight';
 
 import SingleDatePickerInput from './SingleDatePickerInput';
 import DayPickerSingleDateController from './DayPickerSingleDateController';
@@ -30,6 +31,8 @@ import {
   OPEN_UP,
   DAY_SIZE,
   ICON_BEFORE_POSITION,
+  FANG_HEIGHT_PX,
+  DEFAULT_VERTICAL_SPACING,
 } from '../constants';
 
 const propTypes = forbidExtraProps({
@@ -56,6 +59,7 @@ const defaultProps = {
   customCloseIcon: null,
   noBorder: false,
   block: false,
+  verticalSpacing: DEFAULT_VERTICAL_SPACING,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -361,11 +365,19 @@ class SingleDatePicker extends React.Component {
       styles,
       verticalHeight,
       transitionDuration,
+      verticalSpacing,
+      theme: { reactDates },
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
     const closeIcon = customCloseIcon || (<CloseButton />);
+
+    const {
+      font: { input: { lineHeight } },
+      spacing: { inputPadding, displayTextPaddingVertical },
+    } = reactDates;
+    const inputHeight = getInputHeight({ lineHeight, inputPadding, displayTextPaddingVertical });
 
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -376,13 +388,19 @@ class SingleDatePicker extends React.Component {
           anchorDirection === ANCHOR_RIGHT && styles.SingleDatePicker_picker__directionRight,
           openDirection === OPEN_DOWN && styles.SingleDatePicker_picker__openDown,
           openDirection === OPEN_UP && styles.SingleDatePicker_picker__openUp,
+          openDirection === OPEN_DOWN && {
+            top: inputHeight + verticalSpacing,
+          },
+          openDirection === OPEN_UP && {
+            bottom: inputHeight + verticalSpacing,
+          },
           orientation === HORIZONTAL_ORIENTATION && styles.SingleDatePicker_picker__horizontal,
           orientation === VERTICAL_ORIENTATION && styles.SingleDatePicker_picker__vertical,
           (withPortal || withFullScreenPortal) && styles.SingleDatePicker_picker__portal,
           withFullScreenPortal && styles.SingleDatePicker_picker__fullScreenPortal,
           isRTL && styles.SingleDatePicker_picker__rtl,
+          dayPickerContainerStyles,
         )}
-        style={dayPickerContainerStyles}
         onClick={onOutsideClick}
       >
         <DayPickerSingleDateController
@@ -459,6 +477,7 @@ class SingleDatePicker extends React.Component {
       isRTL,
       noBorder,
       block,
+      verticalSpacing,
       styles,
     } = this.props;
 
@@ -467,6 +486,8 @@ class SingleDatePicker extends React.Component {
     const displayValue = this.getDateString(date);
 
     const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onClearFocus : undefined;
+
+    const hideFang = verticalSpacing < FANG_HEIGHT_PX;
 
     return (
       <div
@@ -485,7 +506,7 @@ class SingleDatePicker extends React.Component {
             required={required}
             readOnly={readOnly}
             openDirection={openDirection}
-            showCaret={!withPortal && !withFullScreenPortal}
+            showCaret={!withPortal && !withFullScreenPortal && !hideFang}
             onClearDate={this.clearDate}
             showClearDate={showClearDate}
             showDefaultInputIcon={showDefaultInputIcon}
@@ -504,6 +525,7 @@ class SingleDatePicker extends React.Component {
             isRTL={isRTL}
             noBorder={noBorder}
             block={block}
+            verticalSpacing={verticalSpacing}
           />
 
           {this.maybeRenderDayPickerWithPortal()}
@@ -517,7 +539,7 @@ SingleDatePicker.propTypes = propTypes;
 SingleDatePicker.defaultProps = defaultProps;
 
 export { SingleDatePicker as PureSingleDatePicker };
-export default withStyles(({ reactDates: { color, spacing, zIndex } }) => ({
+export default withStyles(({ reactDates: { color, zIndex } }) => ({
   SingleDatePicker: {
     position: 'relative',
     display: 'inline-block',
@@ -543,14 +565,6 @@ export default withStyles(({ reactDates: { color, spacing, zIndex } }) => ({
 
   SingleDatePicker_picker__directionRight: {
     right: 0,
-  },
-
-  SingleDatePicker_picker__openDown: {
-    top: spacing.inputMarginBottom,
-  },
-
-  SingleDatePicker_picker__openUp: {
-    bottom: spacing.inputMarginBottom,
   },
 
   SingleDatePicker_picker__portal: {

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { forbidExtraProps } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
@@ -36,6 +36,7 @@ const propTypes = forbidExtraProps({
   isRTL: PropTypes.bool,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  verticalSpacing: nonNegativeInteger,
 
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
@@ -68,6 +69,7 @@ const defaultProps = {
   isRTL: false,
   noBorder: false,
   block: false,
+  verticalSpacing: undefined,
 
   onChange() {},
   onClearDate() {},
@@ -109,6 +111,7 @@ function SingleDatePickerInput({
   isRTL,
   noBorder,
   block,
+  verticalSpacing,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
@@ -162,6 +165,7 @@ function SingleDatePickerInput({
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         openDirection={openDirection}
+        verticalSpacing={verticalSpacing}
       />
 
       {showClearDate && (

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,3 +21,7 @@ export const OPEN_UP = 'up';
 export const DAY_SIZE = 39;
 export const BLOCKED_MODIFIER = 'blocked';
 export const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
+
+export const FANG_WIDTH_PX = 20;
+export const FANG_HEIGHT_PX = 10;
+export const DEFAULT_VERTICAL_SPACING = 22;

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -60,6 +60,7 @@ export default {
   hideKeyboardShortcutsPanel: PropTypes.bool,
   verticalHeight: nonNegativeInteger,
   transitionDuration: nonNegativeInteger,
+  verticalSpacing: nonNegativeInteger,
 
   // navigation related props
   navPrev: PropTypes.node,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -33,6 +33,7 @@ export default {
   customInputIcon: PropTypes.node,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  verticalSpacing: nonNegativeInteger,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -148,14 +148,12 @@ export default {
       captionPaddingTop: 22,
       captionPaddingBottom: 37,
       inputPadding: 0,
-      inputMarginBottom: 72, // spacing in between the input and the picker
       displayTextPaddingVertical: 12,
       displayTextPaddingHorizontal: 12,
     },
 
     sizing: {
       inputWidth: 130,
-      tooltipArrowWidth: 20,
       arrowWidth: 24,
     },
 

--- a/src/utils/getInputHeight.js
+++ b/src/utils/getInputHeight.js
@@ -1,0 +1,9 @@
+export default function getInputHeight({
+  lineHeight,
+  inputPadding,
+  displayTextPaddingVertical,
+}) {
+  return parseInt(lineHeight, 10)
+    + (2 * inputPadding)
+    + (2 * displayTextPaddingVertical);
+}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -177,4 +177,11 @@ storiesOf('DRP - Calendar Props', module)
       transitionDuration={0}
       autoFocus
     />
+  ))
+  .addWithInfo('with custom vertical spacing', () => (
+    <DateRangePickerWrapper
+      verticalSpacing={0}
+      autoFocus
+    />
   ));
+

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -158,5 +158,11 @@ storiesOf('SDP - Calendar Props', module)
       transitionDuration={0}
       autoFocus
     />
+  ))
+  .addWithInfo('with custom vertical spacing', () => (
+    <SingleDatePickerWrapper
+      verticalSpacing={0}
+      autoFocus
+    />
   ));
 

--- a/test/utils/getInputHeight_spec.js
+++ b/test/utils/getInputHeight_spec.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import getInputHeight from '../../src/utils/getInputHeight';
+
+describe('#getInputHeight', () => {
+  it('returns the expected value', () => {
+    const inputHeight = getInputHeight({
+      lineHeight: 7,
+      inputPadding: 13,
+      displayTextPaddingVertical: 91,
+    });
+    expect(inputHeight).to.equal(215);
+  });
+});


### PR DESCRIPTION
This prop allows for greater customization of the space in between the picker and the inputs. Additionally, if that value is less than the height of the fang then we hide the fang. To accomplish this, I ended up revamping the fang so that it would use an svg instead of pseudo-selectors. The reasoning for this is that because I had to dynamically position the fang relative to the inputs (based on a prop), I had to leverage inline styles to do so. Unfortunately, the `::before` and `::after` selectors don't allow for that. 

I also renamed caret to fang everywhere... which is like ¯\\\_(ツ)_/¯ but consistency? 

This does not, however, solve https://github.com/airbnb/react-dates/issues/538... so maybe expanding the prop to allow for `em` values as well would be useful. However, this would maybe make the fang show/hide logic a bit more complicated (and have to be manual???). What are your thoughts? Maybe that belongs in a follow-up PR?

to: @airbnb/webinfra @ljharb @noratarano @ethanresnick @gabergg @erin-doyle 
