### PR TITLE
[Issue 349] Add single-click range picker

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -18,6 +18,8 @@ const propTypes = forbidExtraProps({
   autoFocusEndDate: PropTypes.bool,
   initialStartDate: momentPropTypes.momentObj,
   initialEndDate: momentPropTypes.momentObj,
+  startDateOffset: PropTypes.func,
+  endDateOffset: PropTypes.func,
 
   keepOpenOnDateSelect: PropTypes.bool,
   minimumNights: PropTypes.number,
@@ -53,6 +55,8 @@ const defaultProps = {
   autoFocusEndDate: false,
   initialStartDate: null,
   initialEndDate: null,
+  startDateOffset: undefined,
+  endDateOffset: undefined,
 
   // day presentation and interaction related props
   renderCalendarDay: undefined,

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -129,6 +129,7 @@ class CalendarDay extends React.Component {
           styles.CalendarDay__default,
           isOutsideDay && styles.CalendarDay__outside,
           modifiers.has('today') && styles.CalendarDay__today,
+          modifiers.has('hovered-offset') && styles.CalendarDay__hovered_offset,
           modifiers.has('highlighted-calendar') && styles.CalendarDay__highlighted_calendar,
           modifiers.has('blocked-minimum-nights') && styles.CalendarDay__blocked_minimum_nights,
           modifiers.has('blocked-calendar') && styles.CalendarDay__blocked_calendar,
@@ -187,6 +188,12 @@ export default withStyles(({ reactDates: { color, font } }) => ({
       border: `1px double ${color.core.borderLight}`,
       color: 'inherit',
     },
+  },
+
+  CalendarDay__hovered_offset: {
+    background: color.core.borderBright,
+    border: `1px double ${color.core.borderLight}`,
+    color: 'inherit',
   },
 
   CalendarDay__outside: {

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -9,6 +9,7 @@ const core = {
   border: '#dbdbdb',
   borderLight: '#e4e7e7',
   borderLighter: '#eceeee',
+  borderBright: '#f4f5f5',
 
   primary: '#00a699',
   primaryShade_1: '#33dacd',

--- a/src/utils/getSelectedDateOffset.js
+++ b/src/utils/getSelectedDateOffset.js
@@ -1,0 +1,6 @@
+const defaultModifier = day => day;
+
+export default function getSelectedDateOffset(fn, day, modifier = defaultModifier) {
+  if (!fn) return day;
+  return modifier(fn(day.clone()));
+}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -86,6 +86,41 @@ storiesOf('DayPickerRangeController', module)
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
     />
   ))
+  .addWithInfo('with 7 days range selection', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      startDateOffset={day => day.subtract(3, 'days')}
+      endDateOffset={day => day.add(3, 'days')}
+    />
+  ))
+  .addWithInfo('with 45 days range selection', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      startDateOffset={day => day.subtract(22, 'days')}
+      endDateOffset={day => day.add(22, 'days')}
+    />
+  ))
+  .addWithInfo('with 4 days after today range selection', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      endDateOffset={day => day.add(4, 'days')}
+    />
+  ))
+  .addWithInfo('with current week range selection', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      startDateOffset={day => day.startOf('week')}
+      endDateOffset={day => day.endOf('week')}
+    />
+  ))
   .addWithInfo('with custom inputs', () => (
     <DayPickerRangeControllerWrapper
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1476,6 +1476,54 @@ describe('DayPickerRangeController', () => {
         );
       });
     });
+
+    describe('props.startDateOffset / props.endDateOffset', () => {
+      it('calls props.onDatesChange with startDate === startDateOffset(date) and endDate === endDateOffset(date)', () => {
+        const clickDate = moment(today).clone().add(2, 'days');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            startDateOffset={day => day.subtract(2, 'days')}
+            endDateOffset={day => day.add(4, 'days')}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().subtract(2, 'days').format());
+        expect(args.endDate.format()).to.equal(clickDate.clone().add(4, 'days').format());
+      });
+
+      it('calls props.onDatesChange with startDate === startDateOffset(date) and endDate === selectedDate when endDateOffset not provided', () => {
+        const clickDate = moment(today).clone().add(2, 'days');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            startDateOffset={day => day.subtract(5, 'days')}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().subtract(5, 'days').format());
+        expect(args.endDate.format()).to.equal(clickDate.format());
+      });
+
+      it('calls props.onDatesChange with startDate === selectedDate and endDate === endDateOffset(date) when startDateOffset not provided', () => {
+        const clickDate = moment(today).clone().add(12, 'days');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            endDateOffset={day => day.add(12, 'days')}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.format());
+        expect(args.endDate.format()).to.equal(clickDate.clone().add(12, 'days').format());
+      });
+    });
   });
 
   describe('#onDayMouseEnter', () => {
@@ -1483,6 +1531,18 @@ describe('DayPickerRangeController', () => {
       const wrapper = shallow(<DayPickerRangeController focusedInput={START_DATE} />);
       wrapper.instance().onDayMouseEnter(today);
       expect(wrapper.state().hoverDate).to.equal(today);
+    });
+
+    it('sets state.dateOffset to the start and end date range when range included', () => {
+      const wrapper = shallow((
+        <DayPickerRangeController
+          focusedInput={START_DATE}
+          endDateOffset={day => day.add(2, 'days')}
+        />
+      ));
+      wrapper.instance().onDayMouseEnter(today);
+      expect(wrapper.state().dateOffset.start.format()).to.equal(today.format());
+      expect(wrapper.state().dateOffset.end.format()).to.equal(today.clone().add(3, 'days').format());
     });
 
     describe('modifiers', () => {

--- a/test/utils/getSelectedDateOffset_spec.js
+++ b/test/utils/getSelectedDateOffset_spec.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import getSelectedDateOffset from '../../src/utils/getSelectedDateOffset';
+
+const today = moment();
+
+describe('#getSelectedDateOffset', () => {
+  it('returns a function modified moment object', () => {
+    const fn = day => day.add(2, 'days');
+    const modifiedDay = getSelectedDateOffset(fn, today);
+    expect(modifiedDay.format()).to.equal(today.clone().add(2, 'days').format());
+  });
+
+  it('returns the passed day when function is undefined', () => {
+    const modifiedDay = getSelectedDateOffset(undefined, today);
+    expect(modifiedDay.format()).to.equal(today.format());
+  });
+
+  it('modifies the returned day using the modifier callback', () => {
+    const fn = day => day.add(2, 'days');
+    const modifier = day => day.subtract(2, 'days');
+    const modifiedDay = getSelectedDateOffset(fn, today, modifier);
+    expect(modifiedDay.format()).to.equal(today.clone().format());
+  });
+
+  it('does not apply the modifier if function is undefined', () => {
+    const modifier = day => day.subtract(2, 'days');
+    const modifiedDay = getSelectedDateOffset(undefined, today, modifier);
+    expect(modifiedDay.format()).to.equal(today.format());
+  });
+});


### PR DESCRIPTION
This adds the feature requested in #349 by allowing a range prop to be added to the DayPickerRangeController.
The range prop requires an object with optional before / after keys, these expect a function that is passed a moment object of the hovered day.
Return a moment object from each function to specify the range.

Eg. Selecting 5 days (hovered day is not inclusive)
```js
range = {
  before: day => day.subtract(2, 'days'),
  after: day => day.add(2, 'days')
}
```

I've added storybook examples to show how this works across a couple of scenarios.
I'm happy to hear feedback on this and make changes to ensure it fits within your project

![single-click range picker demo](https://media.giphy.com/media/3oxHQGVC6mIawpHOmI/giphy.gif)
