### PR TITLE
Bump react-portal to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "prop-types": "^15.5.10",
     "react-addons-shallow-compare": "^15.5.2",
     "react-moment-proptypes": "^1.5.0",
-    "react-portal": "^3.1.0",
+    "react-portal": "^4.1.0",
     "react-with-styles": "^2.2.0",
     "react-with-styles-interface-css": "^3.0.0"
   },

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
 import isTouchDevice from 'is-touch-device';
@@ -280,7 +280,7 @@ class DateRangePicker extends React.Component {
 
     if (withPortal || withFullScreenPortal) {
       return (
-        <Portal isOpened>
+        <Portal>
           {this.renderDayPicker()}
         </Portal>
       );

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
 import isTouchDevice from 'is-touch-device';
@@ -319,7 +319,7 @@ class SingleDatePicker extends React.Component {
 
     if (withPortal || withFullScreenPortal) {
       return (
-        <Portal isOpened>
+        <Portal>
           {this.renderDayPicker()}
         </Portal>
       );

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 
 import DateRangePicker, { PureDateRangePicker } from '../../src/components/DateRangePicker';
 
@@ -76,17 +76,6 @@ describe('DateRangePicker', () => {
           )).dive();
           expect(wrapper.find(Portal)).to.have.length(0);
         });
-
-        it('isOpened prop is true if props.focusedInput !== null', () => {
-          const wrapper = shallow((
-            <DateRangePicker
-              {...requiredProps}
-              withPortal
-              focusedInput={START_DATE}
-            />
-          )).dive();
-          expect(wrapper.find(Portal).props().isOpened).to.equal(true);
-        });
       });
     });
 
@@ -113,17 +102,6 @@ describe('DateRangePicker', () => {
             />
           )).dive();
           expect(wrapper.find(Portal)).to.have.length(0);
-        });
-
-        it('isOpened prop is true if props.focusedInput !== null', () => {
-          const wrapper = shallow((
-            <DateRangePicker
-              {...requiredProps}
-              withFullScreenPortal
-              focusedInput={START_DATE}
-            />
-          )).dive();
-          expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
     });

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 import moment from 'moment';
-import Portal from 'react-portal';
+import { Portal } from 'react-portal';
 
 import CloseButton from '../../src/components/CloseButton';
 import DayPickerSingleDateController from '../../src/components/DayPickerSingleDateController';
@@ -115,18 +115,6 @@ describe('SingleDatePicker', () => {
           )).dive();
           expect(wrapper.find(Portal)).to.have.length(0);
         });
-
-        it('isOpened prop is true if props.focused is true', () => {
-          const wrapper = shallow((
-            <SingleDatePicker
-              onDateChange={() => {}}
-              onFocusChange={() => {}}
-              withPortal
-              focused
-            />
-          )).dive();
-          expect(wrapper.find(Portal).props().isOpened).to.equal(true);
-        });
       });
     });
 
@@ -165,18 +153,6 @@ describe('SingleDatePicker', () => {
             />
           )).dive();
           expect(wrapper.find(Portal)).to.have.length(0);
-        });
-
-        it('isOpened prop is true if props.focused is truthy', () => {
-          const wrapper = shallow((
-            <SingleDatePicker
-              onDateChange={() => {}}
-              onFocusChange={() => {}}
-              withFullScreenPortal
-              focused
-            />
-          )).dive();
-          expect(wrapper.find(Portal).props().isOpened).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
I removed 2 tests since `isOpened` prop doesn't exist anymore.

Closes #887.