### PR TITLE
Add small (input) variant of the DRP/SDP

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -47,6 +47,8 @@ const defaultProps = {
   customInputIcon: null,
   customArrowIcon: null,
   customCloseIcon: null,
+  block: false,
+  small: false,
 
   // calendar presentation and interaction related props
   renderMonth: null,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -38,6 +38,9 @@ const defaultProps = {
   showClearDate: false,
   showDefaultInputIcon: false,
   customInputIcon: null,
+  block: false,
+  small: false,
+  verticalSpacing: undefined,
 
   // calendar presentation and interaction related props
   renderMonth: null,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -33,6 +33,7 @@ const propTypes = forbidExtraProps({
   openDirection: openDirectionShape,
   showCaret: PropTypes.bool,
   verticalSpacing: nonNegativeInteger,
+  small: PropTypes.bool,
 
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
@@ -57,6 +58,7 @@ const defaultProps = {
   openDirection: OPEN_DOWN,
   showCaret: false,
   verticalSpacing: DEFAULT_VERTICAL_SPACING,
+  small: false,
 
   onChange() {},
   onFocus() {},
@@ -169,6 +171,7 @@ class DateInput extends React.Component {
       readOnly,
       openDirection,
       verticalSpacing,
+      small,
       styles,
       theme: { reactDates },
     } = this.props;
@@ -178,16 +181,13 @@ class DateInput extends React.Component {
 
     const withFang = showCaret && focused;
 
-    const {
-      font: { input: { lineHeight } },
-      spacing: { inputPadding, displayTextPaddingVertical },
-    } = reactDates;
-    const inputHeight = getInputHeight({ lineHeight, inputPadding, displayTextPaddingVertical });
+    const inputHeight = getInputHeight(reactDates, small);
 
     return (
       <div
         {...css(
           styles.DateInput,
+          small && styles.DateInput__small,
           withFang && styles.DateInput__withFang,
           disabled && styles.DateInput__disabled,
           withFang && openDirection === OPEN_DOWN && styles.DateInput__openDown,
@@ -197,6 +197,7 @@ class DateInput extends React.Component {
         <input
           {...css(
             styles.DateInput_input,
+            small && styles.DateInput_input__small,
             readOnly && styles.DateInput_input__readOnly,
             focused && styles.DateInput_input__focused,
             disabled && styles.DateInput_input__disabled,
@@ -262,18 +263,17 @@ export default withStyles(({
   },
 }) => ({
   DateInput: {
-    fontWeight: 200,
-    fontSize: font.input.size,
-    lineHeight: font.input.lineHeight,
-    color: color.placeholderText,
     margin: 0,
     padding: spacing.inputPadding,
-
     background: color.background,
     position: 'relative',
     display: 'inline-block',
     width: sizing.inputWidth,
     verticalAlign: 'middle',
+  },
+
+  DateInput__small: {
+    width: sizing.inputWidth_small,
   },
 
   DateInput__disabled: {
@@ -284,15 +284,30 @@ export default withStyles(({
   DateInput_input: {
     fontWeight: 200,
     fontSize: font.input.size,
+    lineHeight: font.input.lineHeight,
     color: color.text,
     backgroundColor: color.background,
     width: '100%',
     padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
+    paddingTop: spacing.displayTextPaddingTop,
+    paddingBottom: spacing.displayTextPaddingBottom,
+    paddingLeft: spacing.displayTextPaddingLeft,
+    paddingRight: spacing.displayTextPaddingRight,
     border: border.input.border,
     borderTop: border.input.borderTop,
     borderRight: border.input.borderRight,
     borderBottom: border.input.borderBottom,
     borderLeft: border.input.borderLeft,
+  },
+
+  DateInput_input__small: {
+    fontSize: font.input.size_small,
+    lineHeight: font.input.lineHeight_small,
+    padding: `${spacing.displayTextPaddingVertical_small}px ${spacing.displayTextPaddingHorizontal_small}px`,
+    paddingTop: spacing.displayTextPaddingTop_small,
+    paddingBottom: spacing.displayTextPaddingBottom_small,
+    paddingLeft: spacing.displayTextPaddingLeft_small,
+    paddingRight: spacing.displayTextPaddingRight_small,
   },
 
   DateInput_input__readOnly: {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -63,6 +63,7 @@ const defaultProps = {
   customCloseIcon: null,
   noBorder: false,
   block: false,
+  small: false,
 
   // calendar presentation and interaction related props
   renderMonth: null,
@@ -329,6 +330,7 @@ class DateRangePicker extends React.Component {
       verticalHeight,
       transitionDuration,
       verticalSpacing,
+      small,
       theme: { reactDates },
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
@@ -344,11 +346,7 @@ class DateRangePicker extends React.Component {
       <CloseButton {...css(styles.DateRangePicker_closeButton_svg)} />
     );
 
-    const {
-      font: { input: { lineHeight } },
-      spacing: { inputPadding, displayTextPaddingVertical },
-    } = reactDates;
-    const inputHeight = getInputHeight({ lineHeight, inputPadding, displayTextPaddingVertical });
+    const inputHeight = getInputHeight(reactDates, small);
 
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -458,6 +456,7 @@ class DateRangePicker extends React.Component {
       noBorder,
       block,
       verticalSpacing,
+      small,
       styles,
     } = this.props;
 
@@ -512,6 +511,7 @@ class DateRangePicker extends React.Component {
             isRTL={isRTL}
             noBorder={noBorder}
             block={block}
+            small={small}
             verticalSpacing={verticalSpacing}
           />
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -60,6 +60,7 @@ const propTypes = forbidExtraProps({
   customCloseIcon: PropTypes.node,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  small: PropTypes.bool,
   verticalSpacing: nonNegativeInteger,
 
   // accessibility
@@ -105,6 +106,7 @@ const defaultProps = {
   customCloseIcon: null,
   noBorder: false,
   block: false,
+  small: false,
   verticalSpacing: undefined,
 
   // accessibility
@@ -152,17 +154,36 @@ function DateRangePickerInput({
   noBorder,
   block,
   verticalSpacing,
+  small,
   styles,
 }) {
   const calendarIcon = customInputIcon || (
     <CalendarIcon {...css(styles.DateRangePickerInput_calendarIcon_svg)} />
   );
   const arrowIcon = customArrowIcon || (isRTL
-    ? <LeftArrow {...css(styles.DateRangePickerInput_arrow_svg)} />
-    : <RightArrow {...css(styles.DateRangePickerInput_arrow_svg)} />
+    ? (
+      <LeftArrow
+        {...css(
+          styles.DateRangePickerInput_arrow_svg,
+          small && styles.DateRangePickerInput_arrow_svg__small,
+        )}
+      />
+    ) : (
+      <RightArrow
+        {...css(
+          styles.DateRangePickerInput_arrow_svg,
+          small && styles.DateRangePickerInput_arrow_svg__small,
+        )}
+      />
+    )
   );
   const closeIcon = customCloseIcon || (
-    <CloseButton {...css(styles.DateRangePickerInput_clearDates_svg)} />
+    <CloseButton
+      {...css(
+        styles.DateRangePickerInput_clearDates_svg,
+        small && styles.DateRangePickerInput_clearDates_svg__small,
+      )}
+    />
   );
   const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
@@ -208,6 +229,7 @@ function DateRangePickerInput({
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         verticalSpacing={verticalSpacing}
+        small={small}
       />
 
       <div
@@ -236,6 +258,7 @@ function DateRangePickerInput({
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         verticalSpacing={verticalSpacing}
+        small={small}
       />
 
       {showClearDates && (
@@ -244,6 +267,7 @@ function DateRangePickerInput({
           aria-label={phrases.clearDates}
           {...css(
             styles.DateRangePickerInput_clearDates,
+            small && styles.DateRangePickerInput_clearDates__small,
             !customCloseIcon && styles.DateRangePickerInput_clearDates_default,
             !(startDate || endDate) && styles.DateRangePickerInput_clearDates__hide,
           )}
@@ -301,6 +325,11 @@ export default withStyles(({ reactDates: { color, sizing } }) => ({
     width: sizing.arrowWidth,
   },
 
+  DateRangePickerInput_arrow_svg__small: {
+    height: sizing.arrowWidth_small,
+    width: sizing.arrowWidth_small,
+  },
+
   DateRangePickerInput_clearDates: {
     background: 'none',
     border: 0,
@@ -316,6 +345,10 @@ export default withStyles(({ reactDates: { color, sizing } }) => ({
     right: 0,
     top: '50%',
     transform: 'translateY(-50%)',
+  },
+
+  DateRangePickerInput_clearDates__small: {
+    padding: 6,
   },
 
   DateRangePickerInput_clearDates_default: {
@@ -339,6 +372,10 @@ export default withStyles(({ reactDates: { color, sizing } }) => ({
     height: 12,
     width: 15,
     verticalAlign: 'middle',
+  },
+
+  DateRangePickerInput_clearDates_svg__small: {
+    height: 9,
   },
 
   DateRangePickerInput_calendarIcon: {

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -43,6 +43,7 @@ const propTypes = forbidExtraProps({
   openDirection: openDirectionShape,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  small: PropTypes.bool,
   verticalSpacing: nonNegativeInteger,
 
   keepOpenOnDateSelect: PropTypes.bool,
@@ -93,6 +94,7 @@ const defaultProps = {
   openDirection: OPEN_DOWN,
   noBorder: false,
   block: false,
+  small: false,
   verticalSpacing: undefined,
 
   keepOpenOnDateSelect: false,
@@ -269,6 +271,7 @@ export default class DateRangePickerInputController extends React.Component {
       isRTL,
       noBorder,
       block,
+      small,
       verticalSpacing,
     } = this.props;
 
@@ -311,6 +314,7 @@ export default class DateRangePickerInputController extends React.Component {
         isRTL={isRTL}
         noBorder={noBorder}
         block={block}
+        small={small}
         verticalSpacing={verticalSpacing}
       />
     );

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -59,6 +59,7 @@ const defaultProps = {
   customCloseIcon: null,
   noBorder: false,
   block: false,
+  small: false,
   verticalSpacing: DEFAULT_VERTICAL_SPACING,
 
   // calendar presentation and interaction related props
@@ -366,6 +367,7 @@ class SingleDatePicker extends React.Component {
       verticalHeight,
       transitionDuration,
       verticalSpacing,
+      small,
       theme: { reactDates },
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
@@ -373,11 +375,7 @@ class SingleDatePicker extends React.Component {
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
     const closeIcon = customCloseIcon || (<CloseButton />);
 
-    const {
-      font: { input: { lineHeight } },
-      spacing: { inputPadding, displayTextPaddingVertical },
-    } = reactDates;
-    const inputHeight = getInputHeight({ lineHeight, inputPadding, displayTextPaddingVertical });
+    const inputHeight = getInputHeight(reactDates, small);
 
     return (
       <div // eslint-disable-line jsx-a11y/no-static-element-interactions
@@ -477,6 +475,7 @@ class SingleDatePicker extends React.Component {
       isRTL,
       noBorder,
       block,
+      small,
       verticalSpacing,
       styles,
     } = this.props;
@@ -525,6 +524,7 @@ class SingleDatePicker extends React.Component {
             isRTL={isRTL}
             noBorder={noBorder}
             block={block}
+            small={small}
             verticalSpacing={verticalSpacing}
           />
 

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -36,6 +36,7 @@ const propTypes = forbidExtraProps({
   isRTL: PropTypes.bool,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  small: PropTypes.bool,
   verticalSpacing: nonNegativeInteger,
 
   onChange: PropTypes.func,
@@ -111,6 +112,7 @@ function SingleDatePickerInput({
   isRTL,
   noBorder,
   block,
+  small,
   verticalSpacing,
   styles,
 }) {
@@ -118,7 +120,12 @@ function SingleDatePickerInput({
     <CalendarIcon {...css(styles.SingleDatePickerInput_calendarIcon_svg)} />
   );
   const closeIcon = customCloseIcon || (
-    <CloseButton {...css(styles.SingleDatePickerInput_clearDate_svg)} />
+    <CloseButton
+      {...css(
+        styles.SingleDatePickerInput_clearDate_svg,
+        styles.SingleDatePickerInput_clearDate_svg__small,
+      )}
+    />
   );
 
   const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
@@ -166,12 +173,14 @@ function SingleDatePickerInput({
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         openDirection={openDirection}
         verticalSpacing={verticalSpacing}
+        small={small}
       />
 
       {showClearDate && (
         <button
           {...css(
             styles.SingleDatePickerInput_clearDate,
+            small && styles.SingleDatePickerInput_clearDate__small,
             !customCloseIcon && styles.SingleDatePickerInput_clearDate__default,
             !displayValue && styles.SingleDatePickerInput_clearDate__hide,
           )}
@@ -250,6 +259,10 @@ export default withStyles(({ reactDates: { color } }) => ({
     },
   },
 
+  SingleDatePickerInput_clearDate__small: {
+    padding: 6,
+  },
+
   SingleDatePickerInput_clearDate__hide: {
     visibility: 'hidden',
   },
@@ -259,6 +272,10 @@ export default withStyles(({ reactDates: { color } }) => ({
     height: 12,
     width: 15,
     verticalAlign: 'middle',
+  },
+
+  SingleDatePickerInput_clearDate_svg__small: {
+    height: 9,
   },
 
   SingleDatePickerInput_calendarIcon: {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -40,6 +40,7 @@ export default {
   customCloseIcon: PropTypes.node,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  small: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonth: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -33,6 +33,7 @@ export default {
   customInputIcon: PropTypes.node,
   noBorder: PropTypes.bool,
   block: PropTypes.bool,
+  small: PropTypes.bool,
   verticalSpacing: nonNegativeInteger,
 
   // calendar presentation and interaction related props

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -148,13 +148,25 @@ export default {
       captionPaddingTop: 22,
       captionPaddingBottom: 37,
       inputPadding: 0,
-      displayTextPaddingVertical: 12,
-      displayTextPaddingHorizontal: 12,
+      displayTextPaddingVertical: undefined,
+      displayTextPaddingTop: 13,
+      displayTextPaddingBottom: 11,
+      displayTextPaddingHorizontal: undefined,
+      displayTextPaddingLeft: 12,
+      displayTextPaddingRight: 12,
+      displayTextPaddingVertical_small: undefined,
+      displayTextPaddingTop_small: 9,
+      displayTextPaddingBottom_small: 7,
+      displayTextPaddingHorizontal_small: undefined,
+      displayTextPaddingLeft_small: 8,
+      displayTextPaddingRight_small: 8,
     },
 
     sizing: {
       inputWidth: 130,
+      inputWidth_small: 90,
       arrowWidth: 24,
+      arrowWidth_small: 19,
     },
 
     font: {
@@ -163,6 +175,8 @@ export default {
       input: {
         size: 18,
         lineHeight: '24px',
+        size_small: 14,
+        lineHeight_small: '18px',
         styleDisabled: 'italic',
       },
     },

--- a/src/utils/getInputHeight.js
+++ b/src/utils/getInputHeight.js
@@ -1,9 +1,67 @@
+/* eslint-disable camelcase */
+
+function getPadding(vertical, top, bottom) {
+  const isTopDefined = typeof top === 'number';
+  const isBottomDefined = typeof bottom === 'number';
+  const isVerticalDefined = typeof vertical === 'number';
+
+  if (isTopDefined && isBottomDefined) {
+    return top + bottom;
+  }
+
+  if (isTopDefined && isVerticalDefined) {
+    return top + vertical;
+  }
+
+  if (isTopDefined) {
+    return top;
+  }
+
+  if (isBottomDefined && isVerticalDefined) {
+    return bottom + vertical;
+  }
+
+  if (isBottomDefined) {
+    return bottom;
+  }
+
+  if (isVerticalDefined) {
+    return 2 * vertical;
+  }
+
+  return 0;
+}
+
 export default function getInputHeight({
-  lineHeight,
-  inputPadding,
-  displayTextPaddingVertical,
-}) {
-  return parseInt(lineHeight, 10)
-    + (2 * inputPadding)
-    + (2 * displayTextPaddingVertical);
+  font: {
+    input: {
+      lineHeight,
+      lineHeight_small,
+    },
+  },
+  spacing: {
+    inputPadding,
+    displayTextPaddingVertical,
+    displayTextPaddingTop,
+    displayTextPaddingBottom,
+    displayTextPaddingVertical_small,
+    displayTextPaddingTop_small,
+    displayTextPaddingBottom_small,
+  },
+}, small) {
+  const calcLineHeight = small ? lineHeight_small : lineHeight;
+
+  const padding = small ?
+    getPadding(
+      displayTextPaddingVertical_small,
+      displayTextPaddingTop_small,
+      displayTextPaddingBottom_small,
+    ) :
+    getPadding(
+      displayTextPaddingVertical,
+      displayTextPaddingTop,
+      displayTextPaddingBottom,
+    );
+
+  return parseInt(calcLineHeight, 10) + (2 * inputPadding) + padding;
 }

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -134,4 +134,12 @@ storiesOf('DRP - Input Props', module)
       showClearDates
       block
     />
+  ))
+  .addWithInfo('small styling', () => (
+    <DateRangePickerWrapper
+      initialStartDate={moment().add(3, 'days')}
+      initialEndDate={moment().add(10, 'days')}
+      showClearDates
+      small
+    />
   ));

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -84,4 +84,11 @@ storiesOf('SDP - Input Props', module)
       showClearDate
       block
     />
+  ))
+  .addWithInfo('small styling', () => (
+    <SingleDatePickerWrapper
+      initialDate={moment().add(3, 'days')}
+      showClearDate
+      small
+    />
   ));

--- a/test/utils/getInputHeight_spec.js
+++ b/test/utils/getInputHeight_spec.js
@@ -1,13 +1,32 @@
 import { expect } from 'chai';
 import getInputHeight from '../../src/utils/getInputHeight';
 
+const theme = {
+  font: {
+    input: {
+      lineHeight: 13,
+      lineHeight_small: 7,
+    },
+  },
+  spacing: {
+    inputPadding: 10,
+    displayTextPaddingVertical: 8,
+    displayTextPaddingTop: 10,
+    displayTextPaddingBottom: 12,
+    displayTextPaddingVertical_small: 2,
+    displayTextPaddingTop_small: 4,
+    displayTextPaddingBottom_small: 6,
+  },
+};
+
 describe('#getInputHeight', () => {
-  it('returns the expected value', () => {
-    const inputHeight = getInputHeight({
-      lineHeight: 7,
-      inputPadding: 13,
-      displayTextPaddingVertical: 91,
-    });
-    expect(inputHeight).to.equal(215);
+  it('returns the expected value with falsey second arg', () => {
+    const inputHeight = getInputHeight(theme);
+    expect(inputHeight).to.equal(55);
+  });
+
+  it('returns the expected value with truthy second arg', () => {
+    const inputHeight = getInputHeight(theme, true);
+    expect(inputHeight).to.equal(37);
   });
 });


### PR DESCRIPTION
Sometimes your app needs two variants of your input size. 

There are a lot of things to customize as part of "size" in the react-dates inputs and in general, we don't expect for consumers to need to change all of these things on a one-by-one basis for every instance of the datepicker in their app. HOWEVER, it does make sense to have 2 different variants (one for more compact variants and one for less compact situations). This allows for that. 

![screen shot 2017-12-07 at 12 23 19 pm](https://user-images.githubusercontent.com/1383861/33739053-74a9eb2c-db50-11e7-8475-93a159cd8bc2.png)

This is *not* breaking but the `getInputHeight` method is more complex (the small variant looked really weird with equal top/bottom padding what with the bottom border and all). 

@ljharb @erin-doyle @airbnb/webinfra 