### PR TITLE
Add `renderCalendarDay` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ onClose: PropTypes.func,
 transitionDuration: nonNegativeInteger, // milliseconds
 
 // day presentation and interaction related props
-renderDay: PropTypes.func,
+renderCalendarDay: PropTypes.func,
+renderDayContents: PropTypes.func,
 minimumNights: PropTypes.number,
 enableOutsideDays: PropTypes.bool,
 isDayBlocked: PropTypes.func,
@@ -228,7 +229,8 @@ onClose: PropTypes.func,
 transitionDuration: nonNegativeInteger, // milliseconds
 
 // day presentation and interaction related props
-renderDay: PropTypes.func,
+renderCalendarDay: PropTypes.func,
+renderDayContents: PropTypes.func,
 enableOutsideDays: PropTypes.bool,
 isDayBlocked: PropTypes.func,
 isOutsideRange: PropTypes.func,
@@ -278,7 +280,8 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
   transitionDuration: nonNegativeInteger, // milliseconds
 
   // day presentation and interaction related props
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   minimumNights: PropTypes.number,
   isOutsideRange: PropTypes.func,
   isDayBlocked: PropTypes.func,

--- a/css/storybook.scss
+++ b/css/storybook.scss
@@ -18,3 +18,7 @@ a {
   color: #008489;
   font-weight: bold;
 }
+
+.foo-bar {
+  background: red !important;
+}

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -71,7 +71,8 @@ const defaultProps = {
   onClose() {},
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   minimumNights: 1,
   enableOutsideDays: false,
   isDayBlocked: () => false,

--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -39,7 +39,8 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -54,7 +55,8 @@ const defaultProps = {
   initialEndDate: null,
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   minimumNights: 1,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),

--- a/examples/DayPickerSingleDateControllerWrapper.jsx
+++ b/examples/DayPickerSingleDateControllerWrapper.jsx
@@ -38,7 +38,8 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -53,7 +54,8 @@ const defaultProps = {
   showInput: false,
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,

--- a/examples/PresetDateRangePicker.jsx
+++ b/examples/PresetDateRangePicker.jsx
@@ -79,7 +79,7 @@ const defaultProps = {
   onClose() {},
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderDayContents: null,
   minimumNights: 0,
   enableOutsideDays: false,
   isDayBlocked: () => false,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -63,7 +63,8 @@ const defaultProps = {
   onClose() {},
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   enableOutsideDays: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
+import CalendarWeek from './CalendarWeek';
 import CalendarDay from './CalendarDay';
 
 import calculateDimension from '../utils/calculateDimension';
@@ -40,7 +41,8 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderMonth: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
   setMonthHeight: PropTypes.func,
 
@@ -64,7 +66,8 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   renderMonth: null,
-  renderDay: null,
+  renderCalendarDay: props => (<CalendarDay {...props} />),
+  renderDayContents: null,
   firstDayOfWeek: null,
   setMonthHeight() {},
 
@@ -149,7 +152,8 @@ class CalendarMonth extends React.Component {
       onDayMouseEnter,
       onDayMouseLeave,
       renderMonth,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       daySize,
       focusedDate,
       isFocused,
@@ -189,25 +193,23 @@ class CalendarMonth extends React.Component {
         >
           <tbody ref={this.setGridRef}>
             {weeks.map((week, i) => (
-              <tr key={i}>
-                {week.map((day, dayOfWeek) => (
-                  <CalendarDay
-                    day={day}
-                    daySize={daySize}
-                    isOutsideDay={!day || day.month() !== month.month()}
-                    tabIndex={isVisible && isSameDay(day, focusedDate) ? 0 : -1}
-                    isFocused={isFocused}
-                    key={dayOfWeek}
-                    onDayMouseEnter={onDayMouseEnter}
-                    onDayMouseLeave={onDayMouseLeave}
-                    onDayClick={onDayClick}
-                    renderDay={renderDay}
-                    phrases={phrases}
-                    modifiers={modifiers[toISODateString(day)]}
-                    ariaLabelFormat={dayAriaLabelFormat}
-                  />
-                ))}
-              </tr>
+              <CalendarWeek key={i}>
+                {week.map((day, dayOfWeek) => renderCalendarDay({
+                  key: dayOfWeek,
+                  day,
+                  daySize,
+                  isOutsideDay: !day || day.month() !== month.month(),
+                  tabIndex: isVisible && isSameDay(day, focusedDate) ? 0 : -1,
+                  isFocused,
+                  onDayMouseEnter,
+                  onDayMouseLeave,
+                  onDayClick,
+                  renderDayContents,
+                  phrases,
+                  modifiers: modifiers[toISODateString(day)],
+                  ariaLabelFormat: dayAriaLabelFormat,
+                }))}
+              </CalendarWeek>
             ))}
           </tbody>
         </table>

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -42,7 +42,8 @@ const propTypes = forbidExtraProps({
   onDayMouseLeave: PropTypes.func,
   onMonthTransitionEnd: PropTypes.func,
   renderMonth: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   transformValue: PropTypes.string,
   daySize: nonNegativeInteger,
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
@@ -71,7 +72,8 @@ const defaultProps = {
   onDayMouseLeave() {},
   onMonthTransitionEnd() {},
   renderMonth: null,
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   transformValue: 'none',
   daySize: DAY_SIZE,
   focusedDate: null,
@@ -231,7 +233,8 @@ class CalendarMonthGrid extends React.Component {
       onDayMouseLeave,
       onDayClick,
       renderMonth,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       onMonthTransitionEnd,
       firstDayOfWeek,
       focusedDate,
@@ -310,7 +313,8 @@ class CalendarMonthGrid extends React.Component {
                 onDayMouseLeave={onDayMouseLeave}
                 onDayClick={onDayClick}
                 renderMonth={renderMonth}
-                renderDay={renderDay}
+                renderCalendarDay={renderCalendarDay}
+                renderDayContents={renderDayContents}
                 firstDayOfWeek={firstDayOfWeek}
                 daySize={daySize}
                 focusedDate={isVisible ? focusedDate : null}

--- a/src/components/CalendarWeek.jsx
+++ b/src/components/CalendarWeek.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { forbidExtraProps, or, childrenOfType } from 'airbnb-prop-types';
+
+import CalendarDay from './CalendarDay';
+import CustomizableCalendarDay from './CustomizableCalendarDay';
+
+const propTypes = forbidExtraProps({
+  children: or([childrenOfType(CalendarDay), childrenOfType(CustomizableCalendarDay)]).isRequired,
+});
+
+export default function CalendarWeek({ children }) {
+  return (
+    <tr>
+      {children}
+    </tr>
+  );
+}
+
+CalendarWeek.propTypes = propTypes;

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -96,7 +96,8 @@ const defaultProps = {
   onClose() {},
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   minimumNights: 1,
   enableOutsideDays: false,
   isDayBlocked: () => false,
@@ -316,7 +317,8 @@ class DateRangePicker extends React.Component {
       endDate,
       minimumNights,
       keepOpenOnDateSelect,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       renderCalendarInfo,
       firstDayOfWeek,
       initialVisibleMonth,
@@ -395,7 +397,8 @@ class DateRangePicker extends React.Component {
           isDayHighlighted={isDayHighlighted}
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
-          renderDay={renderDay}
+          renderCalendarDay={renderCalendarDay}
+          renderDayContents={renderDayContents}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}
           showKeyboardShortcuts={showKeyboardShortcuts}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -71,7 +71,8 @@ const propTypes = forbidExtraProps({
 
   // day props
   modifiers: PropTypes.object,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
@@ -119,7 +120,8 @@ export const defaultProps = {
 
   // day props
   modifiers: {},
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   onDayClick() {},
   onDayMouseEnter() {},
   onDayMouseLeave() {},
@@ -680,7 +682,8 @@ class DayPicker extends React.Component {
       onDayMouseLeave,
       firstDayOfWeek,
       renderMonth,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       renderCalendarInfo,
       hideKeyboardShortcutsPanel,
       onOutsideClick,
@@ -804,7 +807,8 @@ class DayPicker extends React.Component {
                 onDayMouseEnter={onDayMouseEnter}
                 onDayMouseLeave={onDayMouseLeave}
                 renderMonth={renderMonth}
-                renderDay={renderDay}
+                renderCalendarDay={renderCalendarDay}
+                renderDayContents={renderDayContents}
                 onMonthTransitionEnd={this.updateStateAfterMonthTransition}
                 monthFormat={monthFormat}
                 daySize={daySize}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -67,7 +67,8 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
   verticalHeight: nonNegativeInteger,
@@ -119,7 +120,8 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick() {},
 
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   renderCalendarInfo: null,
   firstDayOfWeek: null,
   verticalHeight: null,
@@ -899,7 +901,8 @@ export default class DayPickerRangeController extends React.Component {
       hideKeyboardShortcutsPanel,
       daySize,
       focusedInput,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       renderCalendarInfo,
       onBlur,
       isFocused,
@@ -936,7 +939,8 @@ export default class DayPickerRangeController extends React.Component {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
-        renderDay={renderDay}
+        renderCalendarDay={renderCalendarDay}
+        renderDayContents={renderDayContents}
         renderCalendarInfo={renderCalendarInfo}
         firstDayOfWeek={firstDayOfWeek}
         hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -63,7 +63,8 @@ const propTypes = forbidExtraProps({
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onOutsideClick: PropTypes.func,
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
 
   // accessibility
@@ -114,7 +115,8 @@ const defaultProps = {
   onNextMonthClick() {},
   onOutsideClick: null,
 
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   renderCalendarInfo: null,
 
   // accessibility
@@ -583,7 +585,8 @@ export default class DayPickerSingleDateController extends React.Component {
       hideKeyboardShortcutsPanel,
       daySize,
       firstDayOfWeek,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       renderCalendarInfo,
       isFocused,
       isRTL,
@@ -620,7 +623,8 @@ export default class DayPickerSingleDateController extends React.Component {
         navPrev={navPrev}
         navNext={navNext}
         renderMonth={renderMonth}
-        renderDay={renderDay}
+        renderCalendarDay={renderCalendarDay}
+        renderDayContents={renderDayContents}
         renderCalendarInfo={renderCalendarInfo}
         isFocused={isFocused}
         getFirstFocusableDay={this.getFirstFocusableDay}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -93,7 +93,8 @@ const defaultProps = {
   renderMonth: null,
 
   // day presentation and interaction related props
-  renderDay: null,
+  renderCalendarDay: undefined,
+  renderDayContents: null,
   enableOutsideDays: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
@@ -351,7 +352,8 @@ class SingleDatePicker extends React.Component {
       keepOpenOnDateSelect,
       initialVisibleMonth,
       renderMonth,
-      renderDay,
+      renderCalendarDay,
+      renderDayContents,
       renderCalendarInfo,
       hideKeyboardShortcutsPanel,
       firstDayOfWeek,
@@ -420,7 +422,8 @@ class SingleDatePicker extends React.Component {
           onNextMonthClick={onNextMonthClick}
           onClose={onClose}
           renderMonth={renderMonth}
-          renderDay={renderDay}
+          renderCalendarDay={renderCalendarDay}
+          renderDayContents={renderDayContents}
           renderCalendarInfo={renderCalendarInfo}
           isFocused={isDayPickerFocused}
           showKeyboardShortcuts={showKeyboardShortcuts}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -70,7 +70,8 @@ export default {
   onNextMonthClick: PropTypes.func,
 
   // day presentation and interaction related props
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   minimumNights: PropTypes.number,
   enableOutsideDays: PropTypes.bool,
   isDayBlocked: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -65,7 +65,8 @@ export default {
   onClose: PropTypes.func,
 
   // day presentation and interaction related props
-  renderDay: PropTypes.func,
+  renderCalendarDay: PropTypes.func,
+  renderDayContents: PropTypes.func,
   enableOutsideDays: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -87,7 +87,7 @@ storiesOf('DateRangePicker (DRP)', module)
     return (
       <DateRangePickerWrapper
         renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
-        renderDay={day => momentJalaali(day).format('jD')}
+        renderDayContents={day => momentJalaali(day).format('jD')}
       />
     );
   })

--- a/stories/DateRangePicker_day.js
+++ b/stories/DateRangePicker_day.js
@@ -5,6 +5,8 @@ import { storiesOf } from '@storybook/react';
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
+import CustomizableCalendarDay from '../src/components/CustomizableCalendarDay';
+
 import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
 
 const datesList = [
@@ -17,6 +19,43 @@ const datesList = [
   moment().add(12, 'days'),
   moment().add(13, 'days'),
 ];
+
+const selectedStyles = {
+  background: '#590098',
+  border: '1px solid #590098',
+  color: '#fff',
+
+  hover: {
+    background: '#7A32AC',
+    border: '1px solid #7A32AC',
+    color: '#fff',
+  },
+};
+
+const hoveredStyles = {
+  background: '#cd99d0',
+  border: '1px solid #cd99d0',
+  color: '#fff',
+};
+
+const customDayStyles = {
+  selectedStartStyles: selectedStyles,
+  selectedEndStyles: selectedStyles,
+  hoveredSpanStyles: hoveredStyles,
+  afterHoveredStartStyles: hoveredStyles,
+
+  selectedSpanStyles: {
+    background: '#9b32a2',
+    border: '1px solid #9b32a2',
+    color: '#fff',
+
+    hover: {
+      background: '#83008b',
+      border: '1px solid #83008b',
+      color: '#fff',
+    },
+  },
+};
 
 storiesOf('DRP - Day Props', module)
   .addWithInfo('default', () => (
@@ -71,7 +110,13 @@ storiesOf('DRP - Day Props', module)
   ))
   .addWithInfo('with custom daily details', () => (
     <DateRangePickerWrapper
-      renderDay={day => day.format('ddd')}
+      renderDayContents={day => <td className="foo-bar">{day.format('ddd')}</td>}
+      autoFocus
+    />
+  ))
+  .addWithInfo('one-off custom styling', () => (
+    <DateRangePickerWrapper
+      renderCalendarDay={props => <CustomizableCalendarDay {...props} {...customDayStyles} />}
       autoFocus
     />
   ));

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -99,7 +99,7 @@ storiesOf('DayPicker', module)
   ))
   .addWithInfo('with custom details', () => (
     <DayPicker
-      renderDay={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}
+      renderDayContents={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}
     />
   ))
   .addWithInfo('vertical with fixed-width container', () => (

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -223,7 +223,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      renderDay={day => day.format('ddd')}
+      renderDayContents={day => day.format('ddd')}
     />
   ))
   .addWithInfo('with info panel', () => (

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -203,7 +203,7 @@ storiesOf('DayPickerSingleDateController', module)
       onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
-      renderDay={day => day.format('ddd')}
+      renderDayContents={day => day.format('ddd')}
     />
   ))
   .addWithInfo('with info panel', () => (

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -55,7 +55,7 @@ storiesOf('SingleDatePicker (SDP)', module)
       <SingleDatePickerWrapper
         placeholder="تقویم فارسی"
         renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
-        renderDay={day => momentJalaali(day).format('jD')}
+        renderDayContents={day => momentJalaali(day).format('jD')}
       />
     );
   })

--- a/stories/SingleDatePicker_day.js
+++ b/stories/SingleDatePicker_day.js
@@ -58,7 +58,7 @@ storiesOf('SDP - Day Props', module)
   .addWithInfo('with custom daily details', () => (
     <SingleDatePickerWrapper
       numberOfMonths={1}
-      renderDay={day => day.format('ddd')}
+      renderDayContents={day => day.format('ddd')}
       autoFocus
     />
   ));

--- a/stories/withStyles.js
+++ b/stories/withStyles.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { action, storiesOf } from '@storybook/react';
 
 import CalendarDay from '../src/components/CalendarDay';
+import CustomizableCalendarDay from '../src/components/CustomizableCalendarDay';
 import CalendarMonth from '../src/components/CalendarMonth';
 import CalendarMonthGrid from '../src/components/CalendarMonthGrid';
 import DayPickerNavigation from '../src/components/DayPickerNavigation';
@@ -13,23 +14,53 @@ import DateRangePickerInput from '../src/components/DateRangePickerInput';
 
 import { VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE } from '../constants';
 
+const customStyles = {
+  background: '#5f4b8b',
+  border: '2px solid #5f4b8b',
+  color: '#fff',
+
+  hover: {
+    background: '#c3b5e3',
+    border: '2px solid #c3b5e3',
+    color: '#402b70',
+    fontWeight: 'bold',
+  },
+};
+
 storiesOf('withStyles', module)
   .addWithInfo('CalendarDay', () => (
     <table>
-      <tr>
-        <CalendarDay />
-        <CalendarDay isOutsideDay />
-        <CalendarDay modifiers={new Set(['highlighted-calendar'])} />
-        <CalendarDay modifiers={new Set(['blocked-minimum-nights'])} />
-        <CalendarDay modifiers={new Set(['selected-span'])} />
-        <CalendarDay modifiers={new Set(['selected'])} />
-        <CalendarDay modifiers={new Set(['selected-start'])} />
-        <CalendarDay modifiers={new Set(['selected-end'])} />
-        <CalendarDay modifiers={new Set(['hovered-span'])} />
-        <CalendarDay modifiers={new Set(['after-hovered-start'])} />
-        <CalendarDay modifiers={new Set(['blocked-calendar'])} />
-        <CalendarDay modifiers={new Set(['blocked-out-of-range'])} />
-      </tr>
+      <tbody>
+        <tr>
+          <CalendarDay />
+          <CalendarDay isOutsideDay />
+          <CalendarDay modifiers={new Set(['highlighted-calendar'])} />
+          <CalendarDay modifiers={new Set(['blocked-minimum-nights'])} />
+          <CalendarDay modifiers={new Set(['selected-span'])} />
+          <CalendarDay modifiers={new Set(['selected'])} />
+          <CalendarDay modifiers={new Set(['selected-start'])} />
+          <CalendarDay modifiers={new Set(['selected-end'])} />
+          <CalendarDay modifiers={new Set(['hovered-span'])} />
+          <CalendarDay modifiers={new Set(['after-hovered-start'])} />
+          <CalendarDay modifiers={new Set(['blocked-calendar'])} />
+          <CalendarDay modifiers={new Set(['blocked-out-of-range'])} />
+        </tr>
+
+        <tr>
+          <CustomizableCalendarDay defaultStyles={customStyles} />
+          <CustomizableCalendarDay isOutsideDay outsideStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['highlighted-calendar'])} highlightedCalendarStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['blocked-minimum-nights'])} blockedMinNightsStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['selected-span'])} selectedSpanStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['selected'])} selectedStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['selected-start'])} selectedStartStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['selected-end'])} selectedEndStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['hovered-span'])} hoveredSpanStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['after-hovered-start'])} afterHoveredStartStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['blocked-calendar'])} blockedCalendarStyles={customStyles} />
+          <CustomizableCalendarDay modifiers={new Set(['blocked-out-of-range'])} blockedOutOfRangeStyles={customStyles} />
+        </tr>
+      </tbody>
     </table>
   ))
   .addWithInfo('CalendarMonth', () => (

--- a/test/components/CalendarWeek_spec.jsx
+++ b/test/components/CalendarWeek_spec.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import CalendarWeek from '../../src/components/CalendarWeek';
+
+import CalendarDay from '../../src/components/CalendarDay';
+
+describe('CalendarWeek', () => {
+  it('renders a tr', () => {
+    const wrapper = shallow((
+      <CalendarWeek>
+        <CalendarDay />
+      </CalendarWeek>
+    ));
+    expect(wrapper.is('tr')).to.equal(true);
+  });
+});

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -5,46 +5,48 @@ import { shallow } from 'enzyme';
 import moment from 'moment';
 
 import { BLOCKED_MODIFIER } from '../../src/constants';
-import CalendarDay, { PureCalendarDay } from '../../src/components/CalendarDay';
+import CustomizableCalendarDay, { PureCustomizableCalendarDay } from '../../src/components/CustomizableCalendarDay';
 
-describe('CalendarDay', () => {
+describe('CustomizableCalendarDay', () => {
   describe('#render', () => {
     it('contains formatted day for single digit days', () => {
       const firstOfMonth = moment().startOf('month');
-      const wrapper = shallow(<CalendarDay day={firstOfMonth} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay day={firstOfMonth} />).dive();
       expect(wrapper.text()).to.equal(firstOfMonth.format('D'));
     });
 
     it('contains formatted day for double digit days', () => {
       const lastOfMonth = moment().endOf('month');
-      const wrapper = shallow(<CalendarDay day={lastOfMonth} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay day={lastOfMonth} />).dive();
       expect(wrapper.text()).to.equal(lastOfMonth.format('D'));
     });
 
     it('contains arbitrary content if renderDay is provided', () => {
       const dayName = moment().format('dddd');
       const renderDay = day => day.format('dddd');
-      const wrapper = shallow(<CalendarDay renderDayContents={renderDay} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay renderDayContents={renderDay} />).dive();
       expect(wrapper.text()).to.equal(dayName);
     });
 
-    it('passes modifiers to renderDayContents', () => {
+    it('passes modifiers to renderDay', () => {
       const modifiers = new Set().add(BLOCKED_MODIFIER);
-      const renderDayContents = (day, mods) => `${day.format('dddd')}${mods.has(BLOCKED_MODIFIER) ? 'BLOCKED' : ''}`;
+      const renderDay = (day, mods) => `${day.format('dddd')}${mods.has(BLOCKED_MODIFIER) ? 'BLOCKED' : ''}`;
       const expected = `${moment().format('dddd')}BLOCKED`;
-      const wrapper =
-        shallow(<CalendarDay renderDayContents={renderDayContents} modifiers={modifiers} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay
+        renderDayContents={renderDay}
+        modifiers={modifiers}
+      />).dive();
       expect(wrapper.text()).to.equal(expected);
     });
 
     it('has button role', () => {
-      const wrapper = shallow(<CalendarDay />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
       expect(wrapper.props().role).to.equal('button');
     });
 
     it('has tabIndex equal to props.tabIndex', () => {
       const tabIndex = -1;
-      const wrapper = shallow(<CalendarDay tabIndex={tabIndex} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay tabIndex={tabIndex} />).dive();
       expect(wrapper.props().tabIndex).to.equal(tabIndex);
     });
 
@@ -65,7 +67,7 @@ describe('CalendarDay', () => {
       it('is formatted with the chooseAvailableDate phrase function when day is available', () => {
         const modifiers = new Set();
 
-        const wrapper = shallow(<CalendarDay
+        const wrapper = shallow(<CustomizableCalendarDay
           modifiers={modifiers}
           phrases={phrases}
           day={day}
@@ -78,7 +80,7 @@ describe('CalendarDay', () => {
       it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER);
 
-        const wrapper = shallow(<CalendarDay
+        const wrapper = shallow(<CustomizableCalendarDay
           modifiers={modifiers}
           phrases={phrases}
           day={day}
@@ -91,7 +93,7 @@ describe('CalendarDay', () => {
       it('should set aria-label with a value pass through ariaLabelFormat prop if it exists', () => {
         const modifiers = new Set();
 
-        const wrapper = shallow(<CalendarDay
+        const wrapper = shallow(<CustomizableCalendarDay
           modifiers={modifiers}
           day={day}
           ariaLabelFormat="MMMM Do YYYY"
@@ -105,7 +107,7 @@ describe('CalendarDay', () => {
   describe('#onDayClick', () => {
     let onDayClickSpy;
     beforeEach(() => {
-      onDayClickSpy = sinon.spy(PureCalendarDay.prototype, 'onDayClick');
+      onDayClickSpy = sinon.spy(PureCustomizableCalendarDay.prototype, 'onDayClick');
     });
 
     afterEach(() => {
@@ -113,14 +115,14 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by click', () => {
-      const wrapper = shallow(<CalendarDay />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
       wrapper.simulate('click');
       expect(onDayClickSpy).to.have.property('callCount', 1);
     });
 
     it('calls props.onDayClick', () => {
       const onDayClickStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayClick={onDayClickStub} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay onDayClick={onDayClickStub} />).dive();
       wrapper.instance().onDayClick();
       expect(onDayClickStub).to.have.property('callCount', 1);
     });
@@ -129,7 +131,7 @@ describe('CalendarDay', () => {
   describe('#onDayMouseEnter', () => {
     let onDayMouseEnterSpy;
     beforeEach(() => {
-      onDayMouseEnterSpy = sinon.spy(PureCalendarDay.prototype, 'onDayMouseEnter');
+      onDayMouseEnterSpy = sinon.spy(PureCustomizableCalendarDay.prototype, 'onDayMouseEnter');
     });
 
     afterEach(() => {
@@ -137,14 +139,23 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by mouseenter', () => {
-      const wrapper = shallow(<CalendarDay />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
       wrapper.simulate('mouseenter');
       expect(onDayMouseEnterSpy).to.have.property('callCount', 1);
     });
 
+    it('sets state.isHovered to false', () => {
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
+      wrapper.setState({ isHovered: false });
+      wrapper.instance().onDayMouseEnter();
+      expect(wrapper.state().isHovered).to.equal(true);
+    });
+
     it('calls props.onDayMouseEnter', () => {
       const onMouseEnterStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayMouseEnter={onMouseEnterStub} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay
+        onDayMouseEnter={onMouseEnterStub}
+      />).dive();
       wrapper.instance().onDayMouseEnter();
       expect(onMouseEnterStub).to.have.property('callCount', 1);
     });
@@ -153,7 +164,7 @@ describe('CalendarDay', () => {
   describe('#onDayMouseLeave', () => {
     let onDayMouseLeaveSpy;
     beforeEach(() => {
-      onDayMouseLeaveSpy = sinon.spy(PureCalendarDay.prototype, 'onDayMouseLeave');
+      onDayMouseLeaveSpy = sinon.spy(PureCustomizableCalendarDay.prototype, 'onDayMouseLeave');
     });
 
     afterEach(() => {
@@ -161,14 +172,23 @@ describe('CalendarDay', () => {
     });
 
     it('gets triggered by mouseleave', () => {
-      const wrapper = shallow(<CalendarDay />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
       wrapper.simulate('mouseleave');
       expect(onDayMouseLeaveSpy).to.have.property('callCount', 1);
     });
 
+    it('sets state.isHovered to false', () => {
+      const wrapper = shallow(<CustomizableCalendarDay />).dive();
+      wrapper.setState({ isHovered: true });
+      wrapper.instance().onDayMouseLeave();
+      expect(wrapper.state().isHovered).to.equal(false);
+    });
+
     it('calls props.onDayMouseLeave', () => {
       const onMouseLeaveStub = sinon.stub();
-      const wrapper = shallow(<CalendarDay onDayMouseLeave={onMouseLeaveStub} />).dive();
+      const wrapper = shallow(<CustomizableCalendarDay
+        onDayMouseLeave={onMouseLeaveStub}
+      />).dive();
       wrapper.instance().onDayMouseLeave();
       expect(onMouseLeaveStub).to.have.property('callCount', 1);
     });


### PR DESCRIPTION
Here are the breaking changes in this PR:
- `renderDay` is now named `renderDayContents`
- `CalendarDay` no longer consists of a button inside of a td. It is instead a td with a button `role`. The related styles have been simplified accordingly. FYI @backwardok 

Here is what's new:
- `renderCalendarDay`, a prop that takes a props arg and expects either a `CalendarDay` or `CustomizableCalendarDay` node with those props spread onto it to be returned. More details below.

===

This is for one-off, no-good, hacky customization of `CalendarDay` styling within the frame of the react-with-styles ecosystem. This PR isn't quite done, but it is close. 

SO IN AN IDEAL WORLD, you only modify `CalendarDay` styles on an app-wide level, which `react-with-styles` themes allow you to do easily. After all, why would you have multiple datepickers that all look dramatically different on your site (especially with their color scheme). But sometimes, ya gotta do what ya gotta do. To solve this, we have a new beautiful `renderCalendarDay` prop.

The `renderCalendarDay` prop takes in an object (specifically, with the following keys---`key`, `dayOfWeek`, `day`, `daySize`, `isOutsideDay`, `tabIndex`, `isFocused`, `onDayMouseEnter`, `onDayMouseLeave`, `onDayClick`, `renderDayContents`, `phrases`, `modifiers`, `ariaLabelFormat`) as an argument.  What it expects as a return is an instance of either `CalendarDay` (the default) or `CustomizableCalendarDay`. The reason the arg doesn't really matter is because you are kind of expected just to spread it onto the `CalendarDay` instance to get a fully functional datepicker. 

The default `renderCalendarDay` prop looks as follow:
```
renderCalendarDay: props => <CalendarDay {...props} />
```

The `CalendarDay` is fairly restricted so you can't really do much more than that (as an aside, you could probably use this to hack into the day interaction methods from the DRP or SDP or the controllers). However, let's say you are trying to implement the following design:
<img width="509" alt="screen shot 2017-12-08 at 7 54 41 pm" src="https://user-images.githubusercontent.com/1383861/33792353-a9a027e0-dc51-11e7-8411-b2ed41a04f9c.png">
#PantoneUltraViolet

More importantly, let's say you are trying to implement the above design on one page of your app, AND EVERY OTHER PAGE HAS THE STANDARD TEAL. Well, if you're using `react-with-styles-interface-aphrodite` you might think you're kind of fucked. Aphrodite does not allow for arbitrary CSS overrides, and we have not before had any APIs that would allow for this. Now, you would just leverage the `renderCalendarDay` prop and the `CustomizableCalendarDay` component like so:
```
const selectedStyles = {
  background: '#590098',
  border: '1px solid #590098',
  color: '#fff',

  hover: {
    background: '#7A32AC',
    border: '1px solid #7A32AC',
    color: '#fff',
  },
};

const hoveredStyles = {
  background: '#cd99d0',
  border: '1px solid #cd99d0',
  color: '#fff',
};

const customDayStyles = {
  selectedStartStyles: selectedStyles,
  selectedEndStyles: selectedStyles,
  hoveredSpanStyles: hoveredStyles,
  afterHoveredStartStyles: hoveredStyles,

  selectedSpanStyles: {
    background: '#9b32a2',
    border: '1px solid #9b32a2',
    color: '#fff',

    hover: {
      background: '#83008b',
      border: '1px solid #83008b',
      color: '#fff',
    },
  },
};

function(props) {
  return (
    <DateRangePicker
      {...props}
      renderCalendarDay={props => <CustomizableCalendarDay {...props} {...customStyles} />}
    />
  );
}

```
And voila, you have a one-off, random ultraviolet datepicker in your app.

@ljharb Taylor Swift's "Look what you made me do"  is now stuck in my head because that is how I feel about this PR and the unfortunate circumstances that have led to its necessity.

@airbnb/webinfra @amhunt if you feel like taking a gander at what I expect the customization API to look like