### PR TITLE
Add missing onKeyDown function to CalendarDay

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -82,6 +82,17 @@ class CalendarDay extends React.Component {
     onDayMouseLeave(day, e);
   }
 
+  onKeyDown(day, e) {
+    const {
+      onDayClick,
+    } = this.props;
+
+    const { key } = e;
+    if (key === 'Enter' || key === ' ') {
+      onDayClick(day, e);
+    }
+  }
+
   setButtonRef(ref) {
     this.buttonRef = ref;
   }


### PR DESCRIPTION
Eep.

Fixes https://github.com/airbnb/react-dates/issues/899

@ljharb 