### PR TITLE
Added "module" field in package.json for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "16.0.1",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
+  "module":"esm/index.js",
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm run build:cjs && npm run build:esm && npm run build:css -- --optimize ",


### PR DESCRIPTION
Added "module" field in package.json to support default import to be ESM for bundlers like webpack and rollup, which enables tree shaking out of the box.