### PR TITLE
[Fix] Keyboard nav issues

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -128,7 +128,7 @@ class DateInput extends React.Component {
 
   onKeyDown(e) {
     e.stopPropagation();
-    if (!MODIFIER_KEY_NAMES.includes(e.key)) {
+    if (!MODIFIER_KEY_NAMES.has(e.key)) {
       this.throttledKeyDown(e);
     }
   }

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -13,14 +13,13 @@ import {
   FANG_HEIGHT_PX,
   FANG_WIDTH_PX,
   DEFAULT_VERTICAL_SPACING,
+  MODIFIER_KEY_NAMES,
 } from '../constants';
 
 const FANG_PATH_TOP = `M0,${FANG_HEIGHT_PX} ${FANG_WIDTH_PX},${FANG_HEIGHT_PX} ${FANG_WIDTH_PX / 2},0z`;
 const FANG_STROKE_TOP = `M0,${FANG_HEIGHT_PX} ${FANG_WIDTH_PX / 2},0 ${FANG_WIDTH_PX},${FANG_HEIGHT_PX}`;
 const FANG_PATH_BOTTOM = `M0,0 ${FANG_WIDTH_PX},0 ${FANG_WIDTH_PX / 2},${FANG_HEIGHT_PX}z`;
 const FANG_STROKE_BOTTOM = `M0,0 ${FANG_WIDTH_PX / 2},${FANG_HEIGHT_PX} ${FANG_WIDTH_PX},0`;
-
-const MODIFIER_NAMES = ['Shift', 'Control', 'Alt', 'Meta'];
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -129,7 +128,7 @@ class DateInput extends React.Component {
 
   onKeyDown(e) {
     e.stopPropagation();
-    if (!MODIFIER_NAMES.includes(e.key)) {
+    if (!MODIFIER_KEY_NAMES.includes(e.key)) {
       this.throttledKeyDown(e);
     }
   }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -253,7 +253,7 @@ class DayPicker extends React.Component {
 
   onKeyDown(e) {
     e.stopPropagation();
-    if (!MODIFIER_KEY_NAMES.includes(e.key)) {
+    if (!MODIFIER_KEY_NAMES.has(e.key)) {
       this.throttledKeyDown(e);
     }
   }

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -32,6 +32,7 @@ import {
   VERTICAL_ORIENTATION,
   VERTICAL_SCROLLABLE,
   DAY_SIZE,
+  MODIFIER_KEY_NAMES,
 } from '../constants';
 
 const MONTH_PADDING = 23;
@@ -173,6 +174,7 @@ class DayPicker extends React.Component {
     this.calendarMonthGridHeight = 0;
 
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.throttledKeyDown = throttle(this.onFinalKeyDown, 200, { trailing: false });
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.multiplyScrollableMonths = this.multiplyScrollableMonths.bind(this);
@@ -251,7 +253,12 @@ class DayPicker extends React.Component {
 
   onKeyDown(e) {
     e.stopPropagation();
+    if (!MODIFIER_KEY_NAMES.includes(e.key)) {
+      this.throttledKeyDown(e);
+    }
+  }
 
+  onFinalKeyDown(e) {
     this.setState({ withMouseInteractions: false });
 
     const { onBlur, isRTL } = this.props;
@@ -778,7 +785,7 @@ class DayPicker extends React.Component {
             {...css(styles.DayPicker_focusRegion)}
             ref={this.setContainerRef}
             onClick={(e) => { e.stopPropagation(); }}
-            onKeyDown={throttle(this.onKeyDown, 300)}
+            onKeyDown={this.onKeyDown}
             onMouseUp={() => { this.setState({ withMouseInteractions: true }); }}
             role="region"
             tabIndex={-1}

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
-import KeyboardShortcutRow from './KeyboardShortcutRow';
-
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
+import KeyboardShortcutRow from './KeyboardShortcutRow';
 import CloseButton from './CloseButton';
 
 export const TOP_LEFT = 'top-left';
@@ -97,35 +96,35 @@ class DayPickerKeyboardShortcuts extends React.Component {
   }
 
   onKeyDown(e) {
+    e.stopPropagation();
+
     const { closeKeyboardShortcutsPanel } = this.props;
     // Because the close button is the only focusable element inside of the panel, this
-    // amount to a very basic focus trap. The user can exit the panel by "pressing" the
+    // amounts to a very basic focus trap. The user can exit the panel by "pressing" the
     // close button or hitting escape
     switch (e.key) {
-      case 'Space':
+      case 'Enter':
+      case ' ':
+      case 'Spacebar': // for older browsers
       case 'Escape':
-        e.stopPropagation();
         closeKeyboardShortcutsPanel();
         break;
 
-      // only stopPropagation here - this allows the up and down arrows continue their
+      // do nothing - this allows the up and down arrows continue their
       // default behavior of scrolling the content of the Keyboard Shortcuts Panel
       // which is needed when only a single month is shown for instance.
       case 'ArrowUp':
       case 'ArrowDown':
-        e.stopPropagation();
         break;
 
       // completely block the rest of the keys that have functionality outside of this panel
       case 'Tab':
-      case 'Enter':
       case 'Home':
       case 'End':
       case 'PageUp':
       case 'PageDown':
       case 'ArrowLeft':
       case 'ArrowRight':
-        e.stopPropagation();
         e.preventDefault();
         break;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -26,4 +26,4 @@ export const FANG_WIDTH_PX = 20;
 export const FANG_HEIGHT_PX = 10;
 export const DEFAULT_VERTICAL_SPACING = 22;
 
-export const MODIFIER_KEY_NAMES = ['Shift', 'Control', 'Alt', 'Meta'];
+export const MODIFIER_KEY_NAMES = new Set(['Shift', 'Control', 'Alt', 'Meta']);

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,3 +25,5 @@ export const WEEKDAYS = [0, 1, 2, 3, 4, 5, 6];
 export const FANG_WIDTH_PX = 20;
 export const FANG_HEIGHT_PX = 10;
 export const DEFAULT_VERTICAL_SPACING = 22;
+
+export const MODIFIER_KEY_NAMES = ['Shift', 'Control', 'Alt', 'Meta'];

--- a/test/components/DayPickerKeyboardShortcuts_spec.jsx
+++ b/test/components/DayPickerKeyboardShortcuts_spec.jsx
@@ -216,7 +216,7 @@ describe('DayPickerKeyboardShortcuts', () => {
         });
 
         it('onKeyDown Space calls e.stopPropagation and onShowKeyboardShortcutsButtonClick', () => {
-          closeButton.prop('onKeyDown')({ ...event, key: 'Space' });
+          closeButton.prop('onKeyDown')({ ...event, key: ' ' });
           expect(event.stopPropagation.callCount).to.equal(1);
           expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
@@ -227,11 +227,10 @@ describe('DayPickerKeyboardShortcuts', () => {
           expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
 
-        it('onKeyDown Enter calls e.stopPropagation and e.preventDefault and NOT onShowKeyboardShortcutsButtonClick', () => {
+        it('onKeyDown Enter calls e.stopPropagation and onShowKeyboardShortcutsButtonClick', () => {
           closeButton.prop('onKeyDown')({ ...event, key: 'Enter' });
           expect(event.stopPropagation.callCount).to.equal(1);
-          expect(event.preventDefault.callCount).to.equal(1);
-          expect(closeKeyboardShortcutsPanelStub.notCalled).to.equal(true);
+          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
 
         it('onKeyDown Tab calls e.stopPropagation and e.preventDefault and NOT onShowKeyboardShortcutsButtonClick', () => {


### PR DESCRIPTION
This is a combination of a few things:

- making the change requested in Issue #557 where we need the Enter key to be able to close the Keyboard Shortcuts Panel when open
- I found that the event.key value for the spacebar key is _not_ 'Space' at all 😳 but is either ' ' or 'Spacebar' on older browsers
- Added the throttle enhancements to the DayPicker that had been made to the DateInput in Pull Request #682 (fixing Issue #514)