### PR TITLE
Move all styles in the CCD (custom and default) to rely on custom styles

### DIFF
--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
-import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
+import { forbidExtraProps, nonNegativeInteger, or } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
@@ -11,6 +11,9 @@ import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
 
 import { DAY_SIZE } from '../constants';
+import DefaultTheme from '../theme/DefaultTheme';
+
+const { reactDates: { color } } = DefaultTheme;
 
 function getStyles(stylesObj, isHovered) {
   if (!stylesObj) return null;
@@ -25,12 +28,12 @@ function getStyles(stylesObj, isHovered) {
 
 const DayStyleShape = PropTypes.shape({
   background: PropTypes.string,
-  border: PropTypes.string,
+  border: or([PropTypes.string, PropTypes.number]),
   color: PropTypes.string,
 
   hover: PropTypes.shape({
     background: PropTypes.string,
-    border: PropTypes.string,
+    border: or([PropTypes.string, PropTypes.number]),
     color: PropTypes.string,
   }),
 });
@@ -81,6 +84,105 @@ const defaultProps = {
   onDayMouseLeave() {},
   renderDayContents: null,
   ariaLabelFormat: 'dddd, LL',
+
+  // style defaults
+  defaultStyles: {
+    border: `1px solid ${color.core.borderLight}`,
+    color: color.text,
+    background: color.background,
+
+    hover: {
+      background: color.core.borderLight,
+      border: `1px double ${color.core.borderLight}`,
+      color: 'inherit',
+    },
+  },
+  outsideStyles: {
+    background: color.outside.backgroundColor,
+    border: 0,
+    color: color.outside.color,
+  },
+  todayStyles: {},
+  highlightedCalendarStyles: {
+    background: color.highlighted.backgroundColor,
+    color: color.highlighted.color,
+
+    hover: {
+      background: color.highlighted.backgroundColor_hover,
+      color: color.highlighted.color_active,
+    },
+  },
+  blockedMinNightsStyles: {
+    background: color.minimumNights.backgroundColor,
+    border: `1px solid ${color.minimumNights.borderColor}`,
+    color: color.minimumNights.color,
+
+    hover: {
+      background: color.minimumNights.backgroundColor_hover,
+      color: color.minimumNights.color_active,
+    },
+  },
+  blockedCalendarStyles: {
+    background: color.blocked_calendar.backgroundColor,
+    border: `1px solid ${color.blocked_calendar.borderColor}`,
+    color: color.blocked_calendar.color,
+
+    hover: {
+      background: color.blocked_calendar.backgroundColor_hover,
+      border: `1px solid ${color.blocked_calendar.borderColor}`,
+      color: color.blocked_calendar.color_active,
+    },
+  },
+  blockedOutOfRangeStyles: {
+    background: color.blocked_out_of_range.backgroundColor,
+    border: `1px solid ${color.blocked_out_of_range.borderColor}`,
+    color: color.blocked_out_of_range.color,
+
+    hover: {
+      background: color.blocked_out_of_range.backgroundColor_hover,
+      border: `1px solid ${color.blocked_out_of_range.borderColor}`,
+      color: color.blocked_out_of_range.color_active,
+    },
+  },
+  hoveredSpanStyles: {
+    background: color.hoveredSpan.backgroundColor,
+    border: `1px solid ${color.hoveredSpan.borderColor}`,
+    color: color.hoveredSpan.color,
+
+    hover: {
+      background: color.hoveredSpan.backgroundColor_hover,
+      border: `1px solid ${color.hoveredSpan.borderColor}`,
+      color: color.hoveredSpan.color_active,
+    },
+  },
+  selectedSpanStyles: {
+    background: color.selectedSpan.backgroundColor,
+    border: `1px solid ${color.selectedSpan.borderColor}`,
+    color: color.selectedSpan.color,
+
+    hover: {
+      background: color.selectedSpan.backgroundColor_hover,
+      border: `1px solid ${color.selectedSpan.borderColor}`,
+      color: color.selectedSpan.color_active,
+    },
+  },
+  lastInRangeStyles: {
+    borderRight: color.core.primary,
+  },
+  selectedStartStyles: {},
+  selectedEndStyles: {},
+  selectedStyles: {
+    background: color.selected.backgroundColor,
+    border: `1px solid ${color.selected.borderColor}`,
+    color: color.selected.color,
+
+    hover: {
+      background: color.selected.backgroundColor_hover,
+      border: `1px solid ${color.selected.borderColor}`,
+      color: color.selected.color_active,
+    },
+  },
+  afterHoveredStartStyles: {},
 
   // internationalization
   phrases: CalendarDayPhrases,
@@ -198,64 +300,26 @@ class CustomizableCalendarDay extends React.Component {
     const selectedStyles = getStyles(selectedStylesWithHover, isHovered);
     const afterHoveredStartStyles = getStyles(afterHoveredStartStylesWithHover, isHovered);
 
-    const hasCustomSelectedStyles =
-      defaultStyles ||
-      (selected && selectedStyles) ||
-      (modifiers.has('selected-start') && selectedStartStyles) ||
-      (modifiers.has('selected-end') && selectedEndStyles);
-    const hasCustomHoveredStyles =
-      (modifiers.has('hovered-span') && hoveredSpanStyles) ||
-      (modifiers.has('after-hovered-start') && afterHoveredStartStyles);
-    const hasCustomStyles =
-      (isOutsideDay && outsideStyles) ||
-      (modifiers.has('today') && todayStyles) ||
-      (modifiers.has('highlighted-calendar') && highlightedCalendarStyles) ||
-      (modifiers.has('blocked-minimum-nights') && blockedMinNightsStyles) ||
-      (modifiers.has('blocked-calendar') && blockedCalendarStyles) ||
-      (modifiers.has('last-in-range') && lastInRangeStyles) ||
-      (modifiers.has('selected-span') && selectedSpanStyles) ||
-      (isOutsideRange && blockedOutOfRangeStyles) ||
-      hasCustomSelectedStyles ||
-      hasCustomHoveredStyles;
-
     return (
       <td
         {...css(
           styles.CalendarDay,
           useDefaultCursor && styles.CalendarDay__defaultCursor,
           daySizeStyles,
-          ...!!hasCustomStyles && [
-            defaultStyles,
-            isOutsideDay && outsideStyles,
-            modifiers.has('today') && todayStyles,
-            modifiers.has('highlighted-calendar') && highlightedCalendarStyles,
-            modifiers.has('blocked-minimum-nights') && blockedMinNightsStyles,
-            modifiers.has('blocked-calendar') && blockedCalendarStyles,
-            hoveredSpan && hoveredSpanStyles,
-            modifiers.has('after-hovered-start') && afterHoveredStartStyles,
-            modifiers.has('selected-span') && selectedSpanStyles,
-            modifiers.has('last-in-range') && lastInRangeStyles,
-            modifiers.has('selected-start') && selectedStartStyles,
-            modifiers.has('selected-end') && selectedEndStyles,
-            selected && selectedStyles,
-            isOutsideRange && blockedOutOfRangeStyles,
-          ],
-
-          ...!hasCustomStyles && [
-            styles.CalendarDay__default,
-            isOutsideDay && styles.CalendarDay__outside,
-            modifiers.has('today') && styles.CalendarDay__today,
-            modifiers.has('highlighted-calendar') && styles.CalendarDay__highlighted_calendar,
-            modifiers.has('blocked-minimum-nights') && styles.CalendarDay__blocked_minimum_nights,
-            modifiers.has('blocked-calendar') && styles.CalendarDay__blocked_calendar,
-            hoveredSpan && styles.CalendarDay__hovered_span,
-            modifiers.has('selected-span') && styles.CalendarDay__selected_span,
-            modifiers.has('last-in-range') && styles.CalendarDay__last_in_range,
-            modifiers.has('selected-start') && styles.CalendarDay__selected_start,
-            modifiers.has('selected-end') && styles.CalendarDay__selected_end,
-            selected && styles.CalendarDay__selected,
-            isOutsideRange && (blockedOutOfRangeStyles || styles.CalendarDay__blocked_out_of_range),
-          ],
+          defaultStyles,
+          isOutsideDay && outsideStyles,
+          modifiers.has('today') && todayStyles,
+          modifiers.has('highlighted-calendar') && highlightedCalendarStyles,
+          modifiers.has('blocked-minimum-nights') && blockedMinNightsStyles,
+          modifiers.has('blocked-calendar') && blockedCalendarStyles,
+          hoveredSpan && hoveredSpanStyles,
+          modifiers.has('after-hovered-start') && afterHoveredStartStyles,
+          modifiers.has('selected-span') && selectedSpanStyles,
+          modifiers.has('last-in-range') && lastInRangeStyles,
+          modifiers.has('selected-start') && selectedStartStyles,
+          modifiers.has('selected-end') && selectedEndStyles,
+          selected && selectedStyles,
+          isOutsideRange && blockedOutOfRangeStyles,
         )}
         role="button" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         ref={this.setButtonRef}
@@ -277,7 +341,7 @@ CustomizableCalendarDay.propTypes = propTypes;
 CustomizableCalendarDay.defaultProps = defaultProps;
 
 export { CustomizableCalendarDay as PureCustomizableCalendarDay };
-export default withStyles(({ reactDates: { color, font } }) => ({
+export default withStyles(({ reactDates: { font } }) => ({
   CalendarDay: {
     boxSizing: 'border-box',
     cursor: 'pointer',
@@ -292,152 +356,4 @@ export default withStyles(({ reactDates: { color, font } }) => ({
   CalendarDay__defaultCursor: {
     cursor: 'default',
   },
-
-  CalendarDay__default: {
-    border: `1px solid ${color.core.borderLight}`,
-    color: color.text,
-    background: color.background,
-
-    ':hover': {
-      background: color.core.borderLight,
-      border: `1px double ${color.core.borderLight}`,
-      color: 'inherit',
-    },
-  },
-
-  CalendarDay__outside: {
-    border: 0,
-
-    background: color.outside.backgroundColor,
-    color: color.outside.color,
-  },
-
-  CalendarDay__blocked_minimum_nights: {
-    background: color.minimumNights.backgroundColor,
-    border: `1px solid ${color.minimumNights.borderColor}`,
-    color: color.minimumNights.color,
-
-    ':hover': {
-      background: color.minimumNights.backgroundColor_hover,
-      color: color.minimumNights.color_active,
-    },
-
-    ':active': {
-      background: color.minimumNights.backgroundColor_active,
-      color: color.minimumNights.color_active,
-    },
-  },
-
-  CalendarDay__highlighted_calendar: {
-    background: color.highlighted.backgroundColor,
-    color: color.highlighted.color,
-
-    ':hover': {
-      background: color.highlighted.backgroundColor_hover,
-      color: color.highlighted.color_active,
-    },
-
-    ':active': {
-      background: color.highlighted.backgroundColor_active,
-      color: color.highlighted.color_active,
-    },
-  },
-
-  CalendarDay__selected_span: {
-    background: color.selectedSpan.backgroundColor,
-    border: `1px solid ${color.selectedSpan.borderColor}`,
-    color: color.selectedSpan.color,
-
-    ':hover': {
-      background: color.selectedSpan.backgroundColor_hover,
-      border: `1px solid ${color.selectedSpan.borderColor}`,
-      color: color.selectedSpan.color_active,
-    },
-
-    ':active': {
-      background: color.selectedSpan.backgroundColor_active,
-      border: `1px solid ${color.selectedSpan.borderColor}`,
-      color: color.selectedSpan.color_active,
-    },
-  },
-
-  CalendarDay__last_in_range: {
-    borderRight: color.core.primary,
-  },
-
-  CalendarDay__selected: {
-    background: color.selected.backgroundColor,
-    border: `1px solid ${color.selected.borderColor}`,
-    color: color.selected.color,
-
-    ':hover': {
-      background: color.selected.backgroundColor_hover,
-      border: `1px solid ${color.selected.borderColor}`,
-      color: color.selected.color_active,
-    },
-
-    ':active': {
-      background: color.selected.backgroundColor_active,
-      border: `1px solid ${color.selected.borderColor}`,
-      color: color.selected.color_active,
-    },
-  },
-
-  CalendarDay__hovered_span: {
-    background: color.hoveredSpan.backgroundColor,
-    border: `1px solid ${color.hoveredSpan.borderColor}`,
-    color: color.hoveredSpan.color,
-
-    ':hover': {
-      background: color.hoveredSpan.backgroundColor_hover,
-      border: `1px solid ${color.hoveredSpan.borderColor}`,
-      color: color.hoveredSpan.color_active,
-    },
-
-    ':active': {
-      background: color.hoveredSpan.backgroundColor_active,
-      border: `1px solid ${color.hoveredSpan.borderColor}`,
-      color: color.hoveredSpan.color_active,
-    },
-  },
-
-  CalendarDay__blocked_calendar: {
-    background: color.blocked_calendar.backgroundColor,
-    border: `1px solid ${color.blocked_calendar.borderColor}`,
-    color: color.blocked_calendar.color,
-
-    ':hover': {
-      background: color.blocked_calendar.backgroundColor_hover,
-      border: `1px solid ${color.blocked_calendar.borderColor}`,
-      color: color.blocked_calendar.color_active,
-    },
-
-    ':active': {
-      background: color.blocked_calendar.backgroundColor_active,
-      border: `1px solid ${color.blocked_calendar.borderColor}`,
-      color: color.blocked_calendar.color_active,
-    },
-  },
-
-  CalendarDay__blocked_out_of_range: {
-    background: color.blocked_out_of_range.backgroundColor,
-    border: `1px solid ${color.blocked_out_of_range.borderColor}`,
-    color: color.blocked_out_of_range.color,
-
-    ':hover': {
-      background: color.blocked_out_of_range.backgroundColor_hover,
-      border: `1px solid ${color.blocked_out_of_range.borderColor}`,
-      color: color.blocked_out_of_range.color_active,
-    },
-
-    ':active': {
-      background: color.blocked_out_of_range.backgroundColor_active,
-      border: `1px solid ${color.blocked_out_of_range.borderColor}`,
-      color: color.blocked_out_of_range.color_active,
-    },
-  },
-
-  CalendarDay__selected_start: {},
-  CalendarDay__selected_end: {},
-  CalendarDay__today: {},
 }))(CustomizableCalendarDay);


### PR DESCRIPTION
As I have started using the CustomizableCalendarDay (again, not recommended but a very specific way of doing a very specific thing), I have found an issue where custom styles always override default styles. So, if you happen to have a day that is both blocked by minimum nights and selected (which happens all the time for a selected-start day with a minimum nights value greater than 0), if you have customized the minimum nights but *not* the selection, the minimum nights styling will always win.

We do not want this. 

By moving the default stylings out of the StyleSheet and into props as default values, we address this issue.

to: @ljharb @erin-doyle @gabergg @noratarano @airbnb/webinfra 