### PR TITLE
Ensuring callbacks will execute after new state is ready.

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -648,7 +648,6 @@ export default class DayPickerRangeController extends React.Component {
     }, () => {
       onNextMonthClick(newCurrentMonth.clone());
     });
-
   }
 
   onMultiplyScrollableMonths() {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -621,9 +621,9 @@ export default class DayPickerRangeController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
+    }, () => {
+      onPrevMonthClick(newCurrentMonth.clone());
     });
-
-    onPrevMonthClick(newCurrentMonth.clone());
   }
 
   onNextMonthClick() {
@@ -645,9 +645,10 @@ export default class DayPickerRangeController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
+    }, () => {
+      onNextMonthClick(newCurrentMonth.clone());
     });
 
-    onNextMonthClick(newCurrentMonth.clone());
   }
 
   onMultiplyScrollableMonths() {

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -362,10 +362,9 @@ export default class DayPickerSingleDateController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
-    },()=>{
+    }, () => {
       onPrevMonthClick(prevMonth.clone());
     });
-
   }
 
   onNextMonthClick() {
@@ -387,7 +386,7 @@ export default class DayPickerSingleDateController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
-    },() => {
+    }, () => {
       onNextMonthClick(newCurrentMonth.clone());
     });
   }

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -362,9 +362,10 @@ export default class DayPickerSingleDateController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
+    },()=>{
+      onPrevMonthClick(prevMonth.clone());
     });
 
-    onPrevMonthClick(prevMonth.clone());
   }
 
   onNextMonthClick() {
@@ -386,9 +387,9 @@ export default class DayPickerSingleDateController extends React.Component {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
+    },() => {
+      onNextMonthClick(newCurrentMonth.clone());
     });
-
-    onNextMonthClick(newCurrentMonth.clone());
   }
 
 


### PR DESCRIPTION
`onNextMonthClick` and `onPrevMonthClick` callbacks were seemingly executing right after updating the state of `DayPickerSingleDateController.jsx`.

However, It is not ensured and might cause some unexpected behavior caused by callbacks executing before the state update was completed (happened in my work project).

it is also a documented pitfall on [react documentations](https://reactjs.org/docs/react-component.html#setstate).

> setState() does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling setState() a potential pitfall.