### PR TITLE
The min-nights modifiers should get cleared according to the previous prop value not the new one

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -345,25 +345,32 @@ export default class DayPickerRangeController extends React.Component {
       modifiers = this.addModifierToRange(modifiers, startSpan, endSpan, 'after-hovered-start');
     }
 
-    if (minimumNights > 0 || minimumNights !== prevMinimumNights) {
-      if (didFocusChange || didStartDateChange) {
+    if (prevMinimumNights > 0) {
+      if (didFocusChange || didStartDateChange || minimumNights !== prevMinimumNights) {
         const startSpan = prevStartDate || this.today;
         modifiers = this.deleteModifierFromRange(
           modifiers,
           startSpan,
-          startSpan.clone().add(minimumNights, 'days'),
+          startSpan.clone().add(prevMinimumNights, 'days'),
           'blocked-minimum-nights',
         );
-      }
 
-      if (startDate && focusedInput === END_DATE) {
-        modifiers = this.addModifierToRange(
+        modifiers = this.deleteModifierFromRange(
           modifiers,
-          startDate,
-          startDate.clone().add(minimumNights, 'days'),
-          'blocked-minimum-nights',
+          startSpan,
+          startSpan.clone().add(prevMinimumNights, 'days'),
+          'blocked',
         );
       }
+    }
+
+    if (minimumNights > 0 && startDate && focusedInput === END_DATE) {
+      modifiers = this.addModifierToRange(
+        modifiers,
+        startDate,
+        startDate.clone().add(minimumNights, 'days'),
+        'blocked-minimum-nights',
+      );
     }
 
     if (didFocusChange || recomputePropModifiers) {
@@ -834,7 +841,6 @@ export default class DayPickerRangeController extends React.Component {
   deleteModifier(updatedDays, day, modifier) {
     const { numberOfMonths: numberOfVisibleMonths, enableOutsideDays, orientation } = this.props;
     const { currentMonth: firstVisibleMonth, visibleDays } = this.state;
-
     let currentMonth = firstVisibleMonth;
     let numberOfMonths = numberOfVisibleMonths;
     if (orientation !== VERTICAL_SCROLLABLE) {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -696,6 +696,31 @@ describe('DayPickerRangeController', () => {
               expect(isSameDay(minimumNightsCalls[0].args[2], minimumNightsEndSpan)).to.equal(true);
             });
           });
+
+          describe('minimumNights changed', () => {
+            it('calls deleteModifierFromRange with start date + old min nights, and `blocked-minimum-nights`', () => {
+              const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
+              const startDate = today;
+              const focusedInput = START_DATE;
+              const minimumNights = 5;
+              const wrapper = shallow(<DayPickerRangeController
+                startDate={startDate}
+                focusedInput={focusedInput}
+                minimumNights={minimumNights}
+              />);
+              wrapper.instance().componentWillReceiveProps({
+                ...props,
+                focusedInput,
+                startDate,
+                minimumNights: 1,
+              });
+              const minimumNightsEndSpan = startDate.clone().add(minimumNights, 'days');
+              const minimumNightsCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'blocked-minimum-nights');
+              expect(minimumNightsCalls.length).to.equal(1);
+              expect(minimumNightsCalls[0].args[1]).to.equal(startDate);
+              expect(isSameDay(minimumNightsCalls[0].args[2], minimumNightsEndSpan)).to.equal(true);
+            });
+          });
         });
 
         describe('new startDate exists', () => {
@@ -798,10 +823,16 @@ describe('DayPickerRangeController', () => {
           it('if isBlocked(day) is false calls deleteModifier with day and `blocked`', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
             sinon.stub(DayPickerRangeController.prototype, 'isBlocked').returns(false);
-            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            const wrapper = shallow((
+              <DayPickerRangeController
+                {...props}
+                minimumNights={0}
+              />
+            ));
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
+              minimumNights: 0,
               focusedInput: END_DATE,
             });
             const blockedCalendarCalls = getCallsByModifier(deleteModifierSpy, 'blocked');


### PR DESCRIPTION
In addition, we don't seem to be removing the `blocked` modifier from these days at all. Whoops!

Here is a gif of the bug in action (not this only happens when you change the min nights value from a bigger value to a smaller value). 
![min_nights](https://user-images.githubusercontent.com/1383861/39717586-0dbe04f6-5234-11e8-8a10-51179e79fa91.gif)

Now we will remove min nights blocking according to the previous value and also, any time the value changes (and reapply it for new >0 values). 

to: @amhunt @ljharb @erin-doyle 