### PR TITLE
update persian example - use jalali date in inputs - change direction to RTL

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
 import omit from 'lodash/omit';
 
 import DateRangePicker from '../src/components/DateRangePicker';
@@ -15,6 +16,7 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   autoFocusEndDate: PropTypes.bool,
+  isPersianDateRangePicker: PropTypes.bool,
   initialStartDate: momentPropTypes.momentObj,
   initialEndDate: momentPropTypes.momentObj,
 
@@ -31,6 +33,7 @@ const defaultProps = {
   // example props for the demo
   autoFocus: false,
   autoFocusEndDate: false,
+  isPersianDateRangePicker: false,
   initialStartDate: null,
   initialEndDate: null,
 
@@ -108,7 +111,14 @@ class DateRangePickerWrapper extends React.Component {
   }
 
   onDatesChange({ startDate, endDate }) {
-    this.setState({ startDate, endDate });
+    if (this.props.isPersianDateRangePicker) {
+      this.setState({
+        startDate: startDate && momentJalaali(startDate),
+        endDate: endDate && momentJalaali(endDate),
+      });
+    } else {
+      this.setState({ startDate, endDate });
+    }
   }
 
   onFocusChange(focusedInput) {
@@ -126,6 +136,7 @@ class DateRangePickerWrapper extends React.Component {
       'autoFocusEndDate',
       'initialStartDate',
       'initialEndDate',
+      'isPersianDateRangePicker',
     ]);
 
     return (

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
-import momentJalaali from 'moment-jalaali';
 import omit from 'lodash/omit';
 
 import DateRangePicker from '../src/components/DateRangePicker';
@@ -16,7 +15,7 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   autoFocusEndDate: PropTypes.bool,
-  isPersianDateRangePicker: PropTypes.bool,
+  stateDateWrapper: PropTypes.func,
   initialStartDate: momentPropTypes.momentObj,
   initialEndDate: momentPropTypes.momentObj,
 
@@ -33,7 +32,6 @@ const defaultProps = {
   // example props for the demo
   autoFocus: false,
   autoFocusEndDate: false,
-  isPersianDateRangePicker: false,
   initialStartDate: null,
   initialEndDate: null,
 
@@ -87,6 +85,8 @@ const defaultProps = {
   displayFormat: () => moment.localeData().longDateFormat('L'),
   monthFormat: 'MMMM YYYY',
   phrases: DateRangePickerPhrases,
+
+  stateDateWrapper: date => date,
 };
 
 class DateRangePickerWrapper extends React.Component {
@@ -111,14 +111,11 @@ class DateRangePickerWrapper extends React.Component {
   }
 
   onDatesChange({ startDate, endDate }) {
-    if (this.props.isPersianDateRangePicker) {
-      this.setState({
-        startDate: startDate && momentJalaali(startDate),
-        endDate: endDate && momentJalaali(endDate),
-      });
-    } else {
-      this.setState({ startDate, endDate });
-    }
+    const { stateDateWrapper } = this.props;
+    this.setState({
+      startDate: startDate && stateDateWrapper(startDate),
+      endDate: endDate && stateDateWrapper(endDate),
+    });
   }
 
   onFocusChange(focusedInput) {
@@ -136,7 +133,7 @@ class DateRangePickerWrapper extends React.Component {
       'autoFocusEndDate',
       'initialStartDate',
       'initialEndDate',
-      'isPersianDateRangePicker',
+      'stateDateWrapper',
     ]);
 
     return (

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -89,6 +89,8 @@ storiesOf('DateRangePicker (DRP)', module)
       <DateRangePickerWrapper
         isRTL
         isPersianDateRangePicker
+        startDatePlaceholderText="تاریخ شروع"
+        endDatePlaceholderText="تاریخ پایان"
         renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
         renderDayContents={day => momentJalaali(day).format('jD')}
       />

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -84,8 +84,11 @@ storiesOf('DateRangePicker (DRP)', module)
   })
   .addWithInfo('non-english locale (Persian)', () => {
     moment.locale('fa');
+    momentJalaali.loadPersian({ dialect: 'persian-modern', usePersianDigits: true });
     return (
       <DateRangePickerWrapper
+        isRTL
+        isPersianDateRangePicker
         renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}
         renderDayContents={day => momentJalaali(day).format('jD')}
       />

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -88,7 +88,7 @@ storiesOf('DateRangePicker (DRP)', module)
     return (
       <DateRangePickerWrapper
         isRTL
-        isPersianDateRangePicker
+        stateDateWrapper={momentJalaali}
         startDatePlaceholderText="تاریخ شروع"
         endDatePlaceholderText="تاریخ پایان"
         renderMonth={month => momentJalaali(month).format('jMMMM jYYYY')}


### PR DESCRIPTION
![screen shot 2018-02-15 at 10 45 50 am](https://user-images.githubusercontent.com/14992757/36244881-73014cc4-123d-11e8-862b-fc805dd29f09.png)
