### PR TITLE
Fix styles not being applied to close button in SingleDatePicker

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -451,12 +451,12 @@ class SingleDatePicker extends React.Component {
 
         {withFullScreenPortal && (
           <button
+            {...css(styles.SingleDatePicker_closeButton)}
             aria-label={phrases.closeDatePicker}
-            className="SingleDatePicker__close"
             type="button"
             onClick={this.onClearFocus}
           >
-            <div className="SingleDatePicker__close-icon">
+            <div {...css(styles.SingleDatePicker_closeButton_svg)}>
               {closeIcon}
             </div>
           </button>


### PR DESCRIPTION
Before this change, the styles defined with `react-with-styles` weren't properly applied to the close button, which resulted in close button not being displayed for `SingleDatePicker`.

This change fixes that, by passing the styles as needed (just as done in `DateRangePicker`, where close button is displayed fine).

To see the problem this PR is fixing, compare the close buttons for DRP (works fine):
http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Calendar%20Props&selectedStory=vertical%20with%20full%20screen%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

...and SDP (close button not showing):
http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Calendar%20Props&selectedStory=vertical%20with%20full%20screen%20portal&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel