### PR TITLE
fix vertical width

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -816,7 +816,7 @@ class DayPicker extends React.Component {
     };
 
     const dayPickerWrapperStyle = {
-      width: wrapperHorizontalWidth,
+      width: isHorizontal && wrapperHorizontalWidth,
     };
 
     const dayPickerStyle = {
@@ -834,7 +834,6 @@ class DayPicker extends React.Component {
         {...css(
           styles.DayPicker,
           isHorizontal && styles.DayPicker__horizontal,
-          this.isVertical() && styles.DayPicker__vertical,
           verticalScrollable && styles.DayPicker__verticalScrollable,
           isHorizontal && withPortal && styles.DayPicker_portal__horizontal,
           this.isVertical() && withPortal && styles.DayPicker_portal__vertical,
@@ -849,7 +848,7 @@ class DayPicker extends React.Component {
           <div
             {...css(
               dayPickerWrapperStyle,
-              (calendarInfoIsInline) && styles.DayPicker_wrapper__horizontal,
+              calendarInfoIsInline && isHorizontal && styles.DayPicker_wrapper__horizontal,
             )}
           >
 


### PR DESCRIPTION
@mariepw's PR removed the condition that the calendar must be horizontal to apply width styling. This broke vertical calendar widths by forcing them to be the width that they would be if they were horizontal and also by making it `inline-block`.

Here's the problem line: https://github.com/airbnb/react-dates/pull/989/files#diff-883056b4b11263241c339f927e93411bR818

Also, I removed a style object that didn't exist, `DayPicker__vertical`.

Here's what the calendar looked like: 
![screen shot 2018-02-27 at 1 37 58 pm](https://user-images.githubusercontent.com/12832034/36759671-079adec0-1bcd-11e8-94a7-06a789b90e5e.png)

Here's what it should look like:
![screen shot 2018-02-27 at 2 47 04 pm](https://user-images.githubusercontent.com/12832034/36759749-47bca1aa-1bcd-11e8-923e-6660f3d27332.png)


reviewers: @majapw 