### PR TITLE
export CustomizableCalendarDay styles, add story

### DIFF
--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -74,6 +74,109 @@ const propTypes = forbidExtraProps({
   phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
 });
 
+export const defaultStyles = {
+  border: `1px solid ${color.core.borderLight}`,
+  color: color.text,
+  background: color.background,
+
+  hover: {
+    background: color.core.borderLight,
+    border: `1px double ${color.core.borderLight}`,
+    color: 'inherit',
+  },
+};
+
+export const outsideStyles = {
+  background: color.outside.backgroundColor,
+  border: 0,
+  color: color.outside.color,
+};
+
+export const highlightedCalendarStyles = {
+  background: color.highlighted.backgroundColor,
+  color: color.highlighted.color,
+
+  hover: {
+    background: color.highlighted.backgroundColor_hover,
+    color: color.highlighted.color_active,
+  },
+};
+
+export const blockedMinNightsStyles = {
+  background: color.minimumNights.backgroundColor,
+  border: `1px solid ${color.minimumNights.borderColor}`,
+  color: color.minimumNights.color,
+
+  hover: {
+    background: color.minimumNights.backgroundColor_hover,
+    color: color.minimumNights.color_active,
+  },
+};
+
+export const blockedCalendarStyles = {
+  background: color.blocked_calendar.backgroundColor,
+  border: `1px solid ${color.blocked_calendar.borderColor}`,
+  color: color.blocked_calendar.color,
+
+  hover: {
+    background: color.blocked_calendar.backgroundColor_hover,
+    border: `1px solid ${color.blocked_calendar.borderColor}`,
+    color: color.blocked_calendar.color_active,
+  },
+};
+
+export const blockedOutOfRangeStyles = {
+  background: color.blocked_out_of_range.backgroundColor,
+  border: `1px solid ${color.blocked_out_of_range.borderColor}`,
+  color: color.blocked_out_of_range.color,
+
+  hover: {
+    background: color.blocked_out_of_range.backgroundColor_hover,
+    border: `1px solid ${color.blocked_out_of_range.borderColor}`,
+    color: color.blocked_out_of_range.color_active,
+  },
+};
+
+export const hoveredSpanStyles = {
+  background: color.hoveredSpan.backgroundColor,
+  border: `1px solid ${color.hoveredSpan.borderColor}`,
+  color: color.hoveredSpan.color,
+
+  hover: {
+    background: color.hoveredSpan.backgroundColor_hover,
+    border: `1px solid ${color.hoveredSpan.borderColor}`,
+    color: color.hoveredSpan.color_active,
+  },
+};
+
+export const selectedSpanStyles = {
+  background: color.selectedSpan.backgroundColor,
+  border: `1px solid ${color.selectedSpan.borderColor}`,
+  color: color.selectedSpan.color,
+
+  hover: {
+    background: color.selectedSpan.backgroundColor_hover,
+    border: `1px solid ${color.selectedSpan.borderColor}`,
+    color: color.selectedSpan.color_active,
+  },
+};
+
+export const lastInRangeStyles = {
+  borderRight: color.core.primary,
+};
+
+export const selectedStyles = {
+  background: color.selected.backgroundColor,
+  border: `1px solid ${color.selected.borderColor}`,
+  color: color.selected.color,
+
+  hover: {
+    background: color.selected.backgroundColor_hover,
+    border: `1px solid ${color.selected.borderColor}`,
+    color: color.selected.color_active,
+  },
+};
+
 const defaultProps = {
   day: moment(),
   daySize: DAY_SIZE,
@@ -88,100 +191,17 @@ const defaultProps = {
   ariaLabelFormat: 'dddd, LL',
 
   // style defaults
-  defaultStyles: {
-    border: `1px solid ${color.core.borderLight}`,
-    color: color.text,
-    background: color.background,
-
-    hover: {
-      background: color.core.borderLight,
-      border: `1px double ${color.core.borderLight}`,
-      color: 'inherit',
-    },
-  },
-  outsideStyles: {
-    background: color.outside.backgroundColor,
-    border: 0,
-    color: color.outside.color,
-  },
+  defaultStyles,
+  outsideStyles,
   todayStyles: {},
-  highlightedCalendarStyles: {
-    background: color.highlighted.backgroundColor,
-    color: color.highlighted.color,
-
-    hover: {
-      background: color.highlighted.backgroundColor_hover,
-      color: color.highlighted.color_active,
-    },
-  },
-  blockedMinNightsStyles: {
-    background: color.minimumNights.backgroundColor,
-    border: `1px solid ${color.minimumNights.borderColor}`,
-    color: color.minimumNights.color,
-
-    hover: {
-      background: color.minimumNights.backgroundColor_hover,
-      color: color.minimumNights.color_active,
-    },
-  },
-  blockedCalendarStyles: {
-    background: color.blocked_calendar.backgroundColor,
-    border: `1px solid ${color.blocked_calendar.borderColor}`,
-    color: color.blocked_calendar.color,
-
-    hover: {
-      background: color.blocked_calendar.backgroundColor_hover,
-      border: `1px solid ${color.blocked_calendar.borderColor}`,
-      color: color.blocked_calendar.color_active,
-    },
-  },
-  blockedOutOfRangeStyles: {
-    background: color.blocked_out_of_range.backgroundColor,
-    border: `1px solid ${color.blocked_out_of_range.borderColor}`,
-    color: color.blocked_out_of_range.color,
-
-    hover: {
-      background: color.blocked_out_of_range.backgroundColor_hover,
-      border: `1px solid ${color.blocked_out_of_range.borderColor}`,
-      color: color.blocked_out_of_range.color_active,
-    },
-  },
-  hoveredSpanStyles: {
-    background: color.hoveredSpan.backgroundColor,
-    border: `1px solid ${color.hoveredSpan.borderColor}`,
-    color: color.hoveredSpan.color,
-
-    hover: {
-      background: color.hoveredSpan.backgroundColor_hover,
-      border: `1px solid ${color.hoveredSpan.borderColor}`,
-      color: color.hoveredSpan.color_active,
-    },
-  },
-  selectedSpanStyles: {
-    background: color.selectedSpan.backgroundColor,
-    border: `1px solid ${color.selectedSpan.borderColor}`,
-    color: color.selectedSpan.color,
-
-    hover: {
-      background: color.selectedSpan.backgroundColor_hover,
-      border: `1px solid ${color.selectedSpan.borderColor}`,
-      color: color.selectedSpan.color_active,
-    },
-  },
-  lastInRangeStyles: {
-    borderRight: color.core.primary,
-  },
-  selectedStyles: {
-    background: color.selected.backgroundColor,
-    border: `1px solid ${color.selected.borderColor}`,
-    color: color.selected.color,
-
-    hover: {
-      background: color.selected.backgroundColor_hover,
-      border: `1px solid ${color.selected.borderColor}`,
-      color: color.selected.color_active,
-    },
-  },
+  highlightedCalendarStyles,
+  blockedMinNightsStyles,
+  blockedCalendarStyles,
+  blockedOutOfRangeStyles,
+  hoveredSpanStyles,
+  selectedSpanStyles,
+  lastInRangeStyles,
+  selectedStyles,
   selectedStartStyles: {},
   selectedEndStyles: {},
   afterHoveredStartStyles: {},
@@ -291,45 +311,28 @@ class CustomizableCalendarDay extends React.Component {
       ariaLabel,
     } = getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases);
 
-    const defaultStyles = getStyles(defaultStylesWithHover, isHovered);
-    const outsideStyles = getStyles(outsideStylesWithHover, isHovered);
-    const todayStyles = getStyles(todayStylesWithHover, isHovered);
-    const firstDayOfWeekStyles = getStyles(firstDayOfWeekStylesWithHover, isHovered);
-    const lastDayOfWeekStyles = getStyles(lastDayOfWeekStylesWithHover, isHovered);
-    const highlightedCalendarStyles = getStyles(highlightedCalendarStylesWithHover, isHovered);
-    const blockedMinNightsStyles = getStyles(blockedMinNightsStylesWithHover, isHovered);
-    const blockedCalendarStyles = getStyles(blockedCalendarStylesWithHover, isHovered);
-    const blockedOutOfRangeStyles = getStyles(blockedOutOfRangeStylesWithHover, isHovered);
-    const hoveredSpanStyles = getStyles(hoveredSpanStylesWithHover, isHovered);
-    const selectedSpanStyles = getStyles(selectedSpanStylesWithHover, isHovered);
-    const lastInRangeStyles = getStyles(lastInRangeStylesWithHover, isHovered);
-    const selectedStartStyles = getStyles(selectedStartStylesWithHover, isHovered);
-    const selectedEndStyles = getStyles(selectedEndStylesWithHover, isHovered);
-    const selectedStyles = getStyles(selectedStylesWithHover, isHovered);
-    const afterHoveredStartStyles = getStyles(afterHoveredStartStylesWithHover, isHovered);
-
     return (
       <td
         {...css(
           styles.CalendarDay,
           useDefaultCursor && styles.CalendarDay__defaultCursor,
           daySizeStyles,
-          defaultStyles,
-          isOutsideDay && outsideStyles,
-          modifiers.has('today') && todayStyles,
-          modifiers.has('first-day-of-week') && firstDayOfWeekStyles,
-          modifiers.has('last-day-of-week') && lastDayOfWeekStyles,
-          modifiers.has('highlighted-calendar') && highlightedCalendarStyles,
-          modifiers.has('blocked-minimum-nights') && blockedMinNightsStyles,
-          modifiers.has('blocked-calendar') && blockedCalendarStyles,
-          hoveredSpan && hoveredSpanStyles,
-          modifiers.has('after-hovered-start') && afterHoveredStartStyles,
-          modifiers.has('selected-span') && selectedSpanStyles,
-          modifiers.has('last-in-range') && lastInRangeStyles,
-          selected && selectedStyles,
-          modifiers.has('selected-start') && selectedStartStyles,
-          modifiers.has('selected-end') && selectedEndStyles,
-          isOutsideRange && blockedOutOfRangeStyles,
+          getStyles(defaultStylesWithHover, isHovered),
+          isOutsideDay && getStyles(outsideStylesWithHover, isHovered),
+          modifiers.has('today') && getStyles(todayStylesWithHover, isHovered),
+          modifiers.has('first-day-of-week') && getStyles(firstDayOfWeekStylesWithHover, isHovered),
+          modifiers.has('last-day-of-week') && getStyles(lastDayOfWeekStylesWithHover, isHovered),
+          modifiers.has('highlighted-calendar') && getStyles(highlightedCalendarStylesWithHover, isHovered),
+          modifiers.has('blocked-minimum-nights') && getStyles(blockedMinNightsStylesWithHover, isHovered),
+          modifiers.has('blocked-calendar') && getStyles(blockedCalendarStylesWithHover, isHovered),
+          hoveredSpan && getStyles(hoveredSpanStylesWithHover, isHovered),
+          modifiers.has('after-hovered-start') && getStyles(afterHoveredStartStylesWithHover, isHovered),
+          modifiers.has('selected-span') && getStyles(selectedSpanStylesWithHover, isHovered),
+          modifiers.has('last-in-range') && getStyles(lastInRangeStylesWithHover, isHovered),
+          selected && getStyles(selectedStylesWithHover, isHovered),
+          modifiers.has('selected-start') && getStyles(selectedStartStylesWithHover, isHovered),
+          modifiers.has('selected-end') && getStyles(selectedEndStylesWithHover, isHovered),
+          isOutsideRange && getStyles(blockedOutOfRangeStylesWithHover, isHovered),
         )}
         role="button" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         ref={this.setButtonRef}

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -6,6 +6,7 @@ import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
 
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+import CustomizableCalendarDay, { defaultStyles, selectedStyles } from '../src/components/CustomizableCalendarDay';
 
 import { VERTICAL_ORIENTATION } from '../src/constants';
 
@@ -206,6 +207,32 @@ storiesOf('DayPickerSingleDateController', module)
       renderDayContents={day => day.format('ddd')}
     />
   ))
+  .addWithInfo('with custom day styles', () => {
+    const customDayStyles = {
+      // extend and update styles with es6 spread operators
+      defaultStyles: {
+        ...defaultStyles,
+        color: 'blue',
+        hover: {
+          ...defaultStyles.hover,
+          color: 'blue',
+        },
+      },
+    };
+    return (
+      <DayPickerSingleDateControllerWrapper
+        onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
+        onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
+        onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
+        renderCalendarDay={props => (
+          <CustomizableCalendarDay
+            {...props}
+            {...customDayStyles}
+          />
+        )}
+      />
+    );
+  })
   .addWithInfo('with info panel', () => (
     <DayPickerSingleDateControllerWrapper
       onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}


### PR DESCRIPTION
Previously if you wanted to update a single CSS style from CustomizableCalendarDay you'd need to (1) make the singular change and (2) duplicate all of the original CSS. 

With this change we can import the style definitions and update the single element using es6 spread operator or [update](https://github.com/kolodny/immutability-helper).

```
// before
const newDefaultStyles = {
  color: 'blue', // what we want to change
  // what we need to keep the same
  border: `1px solid ${color.core.borderLight}`,
  background: color.background,
  hover: {
    background: color.core.borderLight,
    border: `1px double ${color.core.borderLight}`,
    color: 'inherit',
  },
}


// after
import CustomizableCalendarDay, { defaultStyles, selectedStyles } from '../src/components/CustomizableCalendarDay';

const newDefaultStyles = {
  ...defaultStyles,
  color: 'blue',
};
```