### PR TITLE
add verticalSpacing prop

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -20,6 +20,7 @@ const propTypes = forbidExtraProps({
   initialEndDate: momentPropTypes.momentObj,
   startDateOffset: PropTypes.func,
   endDateOffset: PropTypes.func,
+  showInputs: PropTypes.bool,
 
   keepOpenOnDateSelect: PropTypes.bool,
   minimumNights: PropTypes.number,
@@ -57,6 +58,7 @@ const defaultProps = {
   initialEndDate: null,
   startDateOffset: undefined,
   endDateOffset: undefined,
+  showInputs: false,
 
   // day presentation and interaction related props
   renderCalendarDay: undefined,
@@ -121,6 +123,7 @@ class DayPickerRangeControllerWrapper extends React.Component {
       'autoFocusEndDate',
       'initialStartDate',
       'initialEndDate',
+      'showInputs',
     ]);
 
     const startDateString = startDate && startDate.format('YYYY-MM-DD');

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -161,6 +161,7 @@ class CalendarMonth extends React.Component {
       styles,
       phrases,
       dayAriaLabelFormat,
+      verticalSpacing,
     } = this.props;
 
     const { weeks } = this.state;
@@ -189,7 +190,10 @@ class CalendarMonth extends React.Component {
         </div>
 
         <table
-          {...css(styles.CalendarMonth_table)}
+          {...css(
+            !verticalSpacing && styles.CalendarMonth_table,
+            { borderSpacing: `0px ${verticalSpacing}px` },
+          )}
           role="presentation"
         >
           <tbody ref={this.setGridRef}>

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -45,6 +45,7 @@ const propTypes = forbidExtraProps({
   renderDayContents: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
   setMonthHeight: PropTypes.func,
+  verticalBorderSpacing: nonNegativeInteger,
 
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
   isFocused: PropTypes.bool, // indicates whether or not to move focus to focusable day
@@ -78,6 +79,7 @@ const defaultProps = {
   monthFormat: 'MMMM YYYY', // english locale
   phrases: CalendarDayPhrases,
   dayAriaLabelFormat: undefined,
+  verticalBorderSpacing: undefined,
 };
 
 class CalendarMonth extends React.Component {
@@ -161,7 +163,7 @@ class CalendarMonth extends React.Component {
       styles,
       phrases,
       dayAriaLabelFormat,
-      verticalSpacing,
+      verticalBorderSpacing,
     } = this.props;
 
     const { weeks } = this.state;
@@ -191,8 +193,9 @@ class CalendarMonth extends React.Component {
 
         <table
           {...css(
-            !verticalSpacing && styles.CalendarMonth_table,
-            { borderSpacing: `0px ${verticalSpacing}px` },
+            !verticalBorderSpacing && styles.CalendarMonth_table,
+            verticalBorderSpacing && styles.CalendarMonth_verticalSpacing,
+            verticalBorderSpacing && { borderSpacing: `0px ${verticalBorderSpacing}px` },
           )}
           role="presentation"
         >
@@ -238,6 +241,10 @@ export default withStyles(({ reactDates: { color, font, spacing } }) => ({
   CalendarMonth_table: {
     borderCollapse: 'collapse',
     borderSpacing: 0,
+  },
+
+  CalendarMonth_verticalSpacing: {
+    borderCollapse: 'separate',
   },
 
   CalendarMonth_caption: {

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -52,6 +52,7 @@ const propTypes = forbidExtraProps({
   setCalendarMonthHeights: PropTypes.func,
   isRTL: PropTypes.bool,
   transitionDuration: nonNegativeInteger,
+  verticalSpacing: PropTypes.number,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -82,6 +83,7 @@ const defaultProps = {
   setCalendarMonthHeights() {},
   isRTL: false,
   transitionDuration: 200,
+  verticalSpacing: undefined,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -246,6 +248,7 @@ class CalendarMonthGrid extends React.Component {
       phrases,
       dayAriaLabelFormat,
       transitionDuration,
+      verticalSpacing,
     } = this.props;
 
     const { months } = this.state;
@@ -325,6 +328,7 @@ class CalendarMonthGrid extends React.Component {
                 phrases={phrases}
                 setMonthHeight={(height) => { this.setMonthHeight(height, i); }}
                 dayAriaLabelFormat={dayAriaLabelFormat}
+                verticalSpacing={verticalSpacing}
               />
             </div>
           );

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -52,7 +52,7 @@ const propTypes = forbidExtraProps({
   setCalendarMonthHeights: PropTypes.func,
   isRTL: PropTypes.bool,
   transitionDuration: nonNegativeInteger,
-  verticalSpacing: PropTypes.number,
+  verticalBorderSpacing: nonNegativeInteger,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -83,7 +83,7 @@ const defaultProps = {
   setCalendarMonthHeights() {},
   isRTL: false,
   transitionDuration: 200,
-  verticalSpacing: undefined,
+  verticalBorderSpacing: undefined,
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
@@ -248,7 +248,7 @@ class CalendarMonthGrid extends React.Component {
       phrases,
       dayAriaLabelFormat,
       transitionDuration,
-      verticalSpacing,
+      verticalBorderSpacing,
     } = this.props;
 
     const { months } = this.state;
@@ -328,7 +328,7 @@ class CalendarMonthGrid extends React.Component {
                 phrases={phrases}
                 setMonthHeight={(height) => { this.setMonthHeight(height, i); }}
                 dayAriaLabelFormat={dayAriaLabelFormat}
-                verticalSpacing={verticalSpacing}
+                verticalBorderSpacing={verticalBorderSpacing}
               />
             </div>
           );

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -66,6 +66,7 @@ const propTypes = forbidExtraProps({
   verticalHeight: nonNegativeInteger,
   noBorder: PropTypes.bool,
   transitionDuration: nonNegativeInteger,
+  verticalSpacing: PropTypes.number,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -116,6 +117,7 @@ export const defaultProps = {
   verticalHeight: null,
   noBorder: false,
   transitionDuration: undefined,
+  verticalSpacing: undefined,
 
   // navigation props
   navPrev: null,
@@ -753,6 +755,7 @@ class DayPicker extends React.Component {
       dayAriaLabelFormat,
       noBorder,
       transitionDuration,
+      verticalSpacing,
     } = this.props;
 
     const isHorizontal = this.isHorizontal();
@@ -910,6 +913,7 @@ class DayPicker extends React.Component {
                   isRTL={isRTL}
                   dayAriaLabelFormat={dayAriaLabelFormat}
                   transitionDuration={transitionDuration}
+                  verticalSpacing={verticalSpacing}
                 />
                 {verticalScrollable && this.renderNavigation()}
               </div>

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -66,7 +66,7 @@ const propTypes = forbidExtraProps({
   verticalHeight: nonNegativeInteger,
   noBorder: PropTypes.bool,
   transitionDuration: nonNegativeInteger,
-  verticalSpacing: PropTypes.number,
+  verticalBorderSpacing: nonNegativeInteger,
 
   // navigation props
   navPrev: PropTypes.node,
@@ -117,7 +117,7 @@ export const defaultProps = {
   verticalHeight: null,
   noBorder: false,
   transitionDuration: undefined,
-  verticalSpacing: undefined,
+  verticalBorderSpacing: undefined,
 
   // navigation props
   navPrev: null,
@@ -755,7 +755,7 @@ class DayPicker extends React.Component {
       dayAriaLabelFormat,
       noBorder,
       transitionDuration,
-      verticalSpacing,
+      verticalBorderSpacing,
     } = this.props;
 
     const isHorizontal = this.isHorizontal();
@@ -913,7 +913,7 @@ class DayPicker extends React.Component {
                   isRTL={isRTL}
                   dayAriaLabelFormat={dayAriaLabelFormat}
                   transitionDuration={transitionDuration}
-                  verticalSpacing={verticalSpacing}
+                  verticalBorderSpacing={verticalBorderSpacing}
                 />
                 {verticalScrollable && this.renderNavigation()}
               </div>

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -68,6 +68,7 @@ const propTypes = forbidExtraProps({
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
   noBorder: PropTypes.bool,
+  verticalSpacing: PropTypes.number,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -140,6 +141,7 @@ const defaultProps = {
   verticalHeight: null,
   noBorder: false,
   transitionDuration: undefined,
+  verticalSpacing: undefined,
 
   // accessibility
   onBlur() {},
@@ -1002,6 +1004,7 @@ export default class DayPickerRangeController extends React.Component {
       verticalHeight,
       noBorder,
       transitionDuration,
+      verticalSpacing,
     } = this.props;
 
     const { currentMonth, phrases, visibleDays } = this.state;
@@ -1043,6 +1046,7 @@ export default class DayPickerRangeController extends React.Component {
         weekDayFormat={weekDayFormat}
         dayAriaLabelFormat={dayAriaLabelFormat}
         verticalHeight={verticalHeight}
+        verticalSpacing={verticalSpacing}
         noBorder={noBorder}
         transitionDuration={transitionDuration}
       />

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -68,7 +68,7 @@ const propTypes = forbidExtraProps({
   hideKeyboardShortcutsPanel: PropTypes.bool,
   daySize: nonNegativeInteger,
   noBorder: PropTypes.bool,
-  verticalSpacing: PropTypes.number,
+  verticalBorderSpacing: nonNegativeInteger,
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
@@ -141,7 +141,7 @@ const defaultProps = {
   verticalHeight: null,
   noBorder: false,
   transitionDuration: undefined,
-  verticalSpacing: undefined,
+  verticalBorderSpacing: undefined,
 
   // accessibility
   onBlur() {},
@@ -1004,7 +1004,7 @@ export default class DayPickerRangeController extends React.Component {
       verticalHeight,
       noBorder,
       transitionDuration,
-      verticalSpacing,
+      verticalBorderSpacing,
     } = this.props;
 
     const { currentMonth, phrases, visibleDays } = this.state;
@@ -1046,7 +1046,7 @@ export default class DayPickerRangeController extends React.Component {
         weekDayFormat={weekDayFormat}
         dayAriaLabelFormat={dayAriaLabelFormat}
         verticalHeight={verticalHeight}
-        verticalSpacing={verticalSpacing}
+        verticalBorderSpacing={verticalBorderSpacing}
         noBorder={noBorder}
         transitionDuration={transitionDuration}
       />

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -284,6 +284,6 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      verticalSpacing={16}
+      verticalBorderSpacing={16}
     />
   ));

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -278,4 +278,12 @@ storiesOf('DayPickerRangeController', module)
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       transitionDuration={0}
     />
+  ))
+  .addWithInfo('with vertical spacing applied', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      verticalSpacing={16}
+    />
   ));


### PR DESCRIPTION
This adds a verticalSpacing prop to DayPickerRangeController, which is passed all the way to `CalendarMonth`. This will allow users to add spacing between the rows in the month table. 

@majapw should we also add `horizontalSpacing` while we're at it? I don't currently have a use for it, but seems odd to only add one of the two. Maybe I should just add a `tableBorderSpacing` prop with two values: `vertical` and `horizontal`? 

NB: I also added `showInputs` as a declared prop for the wrapper. This was previously throwing a linting error.

![screen shot 2018-04-02 at 5 05 58 pm](https://user-images.githubusercontent.com/12832034/38222283-9b595ed0-3698-11e8-9d4c-de64e5ac1b58.png)
