### PR TITLE
Fixed unexpected blur call

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -594,7 +594,11 @@ class DayPicker extends React.Component {
       // if the user is navigating around using a mouse
       if (withMouseInteractions) {
         const activeElement = getActiveElement();
-        if (activeElement && activeElement !== document.body) {
+        if (
+          activeElement &&
+          activeElement !== document.body &&
+          this.container.contains(activeElement)
+        ) {
           activeElement.blur();
         }
       }


### PR DESCRIPTION
I'm using react-dates inside a Drop. This drop is triggered by an input. As of now, when I transition months the drop is getting closed unexpectedly. My drop closes on input blur, and react-dates calls `activeElement.blur()` after the month transition. I'm not entirely sure why this is there, but I believe it should only be done if the activeElement is a child of your container.

Hopefully this PR looks good to you, otherwise let me know what needs to be changed.

FYI. I added .vscode to .gitignore so that editor files are not accidentally added.