### PR TITLE
Patch onOutsideClick default value in the DayPickerSingleDateController

### DIFF
--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -117,7 +117,7 @@ const defaultProps = {
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
-  onOutsideClick: null,
+  onOutsideClick() {},
 
   renderCalendarDay: undefined,
   renderDayContents: null,


### PR DESCRIPTION
Fixes #1114 

Whoops, I changed the way the `DayPickerSingleDateController` `onOutsideClick` prop looked to better match the `DayPickerRangeController`, but did not update the default prop value. 

to: @ljharb @ricardobrandao 