### PR TITLE
Fix selective disabling of DateRangePicker

### DIFF
--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -201,8 +201,8 @@ function DateRangePickerInput({
       {calendarIcon}
     </button>
   );
-  const startDateDisabled = disabled === START_DATE || disabled;
-  const endDateDisabled = disabled === END_DATE || disabled;
+  const startDateDisabled = disabled === START_DATE || disabled === true;
+  const endDateDisabled = disabled === END_DATE || disabled === true;
 
   return (
     <div

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -772,14 +772,61 @@ describe('DateRangePickerInputController', () => {
       expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
     });
 
-    describe('props.disabled = true', () => {
-      it('does not call props.onFocusChange', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <DateRangePickerInputController disabled onFocusChange={onFocusChangeStub} />
-        ));
-        wrapper.instance().onStartDateFocus();
-        expect(onFocusChangeStub).to.have.property('callCount', 0);
+    describe('props.disabled', () => {
+      describe('props.disabled=START_DATE', () => {
+        it('does not call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={START_DATE}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onStartDateFocus();
+          expect(onFocusChangeStub).to.have.property('callCount', 0);
+        });
+      });
+
+      describe('props.disabled=END_DATE', () => {
+        it('does call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={END_DATE}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onStartDateFocus();
+          expect(onFocusChangeStub).to.have.property('callCount', 1);
+        });
+      });
+
+      describe('props.disabled=true', () => {
+        it('does not call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onStartDateFocus();
+          expect(onFocusChangeStub).to.have.property('callCount', 0);
+        });
+      });
+
+      describe('props.disabled=false', () => {
+        it('does call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={false}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onStartDateFocus();
+          expect(onFocusChangeStub).to.have.property('callCount', 1);
+        });
       });
     });
   });
@@ -840,14 +887,61 @@ describe('DateRangePickerInputController', () => {
       });
     });
 
-    describe('props.disabled = true', () => {
-      it('does not call props.onFocusChange', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <DateRangePickerInputController disabled onFocusChange={onFocusChangeStub} />
-        ));
-        wrapper.instance().onEndDateFocus();
-        expect(onFocusChangeStub.callCount).to.equal(0);
+    describe('props.disabled', () => {
+      describe('props.disabled=START_DATE', () => {
+        it('does call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={START_DATE}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onEndDateFocus();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
+      });
+
+      describe('props.disabled=END_DATE', () => {
+        it('does not call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={END_DATE}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onEndDateFocus();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
+      });
+
+      describe('props.disabled=true', () => {
+        it('does not call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onEndDateFocus();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
+      });
+
+      describe('props.disabled=false', () => {
+        it('does call props.onFocusChange', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              disabled={false}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().onEndDateFocus();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
       });
     });
   });

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -3,6 +3,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 import React from 'react';
 
+import { START_DATE, END_DATE } from '../../src/constants';
+
 import DateInput from '../../src/components/DateInput';
 import DateRangePickerInput from '../../src/components/DateRangePickerInput';
 
@@ -102,6 +104,45 @@ describe('DateRangePickerInput', () => {
         const calendarIconWrapper = wrapper.find('button').at(0);
         calendarIconWrapper.simulate('click');
         expect(onArrowDownSpy.callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('props.disabled', () => {
+    describe('props.disabled=START_DATE', () => {
+      it('First DateInput gets disabled prop, second does not', () => {
+        const wrapper = shallow(<DateRangePickerInput disabled={START_DATE} />).dive();
+        const [startDateInput, endDateInput] = wrapper.find(DateInput);
+        expect(startDateInput.props.disabled).to.equal(true);
+        expect(endDateInput.props.disabled).to.equal(false);
+      });
+    });
+
+    describe('props.disabled=END_DATE', () => {
+      it('First DateInput gets disabled prop, second does not', () => {
+        const wrapper = shallow(<DateRangePickerInput disabled={END_DATE} />).dive();
+        const [startDateInput, endDateInput] = wrapper.find(DateInput);
+        expect(startDateInput.props.disabled).to.equal(false);
+        expect(endDateInput.props.disabled).to.equal(true);
+      });
+    });
+
+    describe('props.disabled=true', () => {
+      it('First DateInput gets disabled prop, second does not', () => {
+        const wrapper = shallow(<DateRangePickerInput disabled />).dive();
+        const [startDateInput, endDateInput] = wrapper.find(DateInput);
+        expect(startDateInput.props.disabled).to.equal(true);
+        expect(endDateInput.props.disabled).to.equal(true);
+      });
+    });
+
+
+    describe('props.disabled=false', () => {
+      it('First DateInput gets disabled prop, second does not', () => {
+        const wrapper = shallow(<DateRangePickerInput disabled={false} />).dive();
+        const [startDateInput, endDateInput] = wrapper.find(DateInput);
+        expect(startDateInput.props.disabled).to.equal(false);
+        expect(endDateInput.props.disabled).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
From @ajwild: 
> @majapw some refactoring of pull request #606 caused a problem here. If disabled is used directly then it causes an error because the individual date pickers still expect a boolean but they can end up with the string values. If you use !!disabled then the endDate string can disable the start date and vice versa. I've reverted this part back to checking equality with true. If you have a suggestion for a better way to handle this let me know.

Git went all weird for me, but this is a version of https://github.com/airbnb/react-dates/pull/1112 with regression tests.

Thanks @ajwild. Sorry for the weirdness. :/

@ljharb 