### PR TITLE
New component: SingleDateRangeEndPicker

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -64,6 +64,7 @@ function loadStories() {
   require('../stories/SingleDatePicker_input');
   require('../stories/SingleDatePicker_calendar');
   require('../stories/SingleDatePicker_day');
+  require('../stories/SingleDateRangeEndPicker');
   require('../stories/DayPickerRangeController');
   require('../stories/DayPickerSingleDateController');
   require('../stories/DayPicker');

--- a/examples/SingleDateRangeEndPickerWrapper.jsx
+++ b/examples/SingleDateRangeEndPickerWrapper.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import momentPropTypes from 'react-moment-proptypes';
+import moment from 'moment';
+import omit from 'lodash/omit';
+
+import SingleDateRangeEndPicker from '../src/components/SingleDateRangeEndPicker';
+
+import { SingleDatePickerPhrases } from '../src/defaultPhrases';
+import SingleDateRangeEndPickerShape from '../src/shapes/SingleDateRangeEndPickerShape';
+import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../src/constants';
+import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
+
+const propTypes = {
+  // example props for the demo
+  autoFocus: PropTypes.bool,
+  initialStartDate: momentPropTypes.momentObj,
+  initialEndDate: momentPropTypes.momentObj,
+
+  ...omit(SingleDateRangeEndPickerShape, [
+    'startDate',
+    'endDate',
+    'onDateChange',
+    'focused',
+    'onFocusChange',
+  ]),
+};
+
+const defaultProps = {
+  // example props for the demo
+  autoFocus: false,
+  initialStartDate: moment(),
+  initialEndDate: null,
+
+  // input related props
+  id: 'end-date',
+  placeholder: 'End Date',
+  disabled: false,
+  required: false,
+  screenReaderInputMessage: '',
+  showClearDate: false,
+  showDefaultInputIcon: false,
+  customInputIcon: null,
+  block: false,
+  small: false,
+  regular: false,
+  verticalSpacing: undefined,
+  keepFocusOnInput: false,
+
+  // calendar presentation and interaction related props
+  renderMonthText: null,
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
+  isRTL: false,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+  onClose() {},
+
+  // day presentation and interaction related props
+  renderCalendarDay: undefined,
+  renderDayContents: null,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => {},
+
+  // internationalization props
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  phrases: SingleDatePickerPhrases,
+};
+
+class SingleDateRangeEndPickerWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      focused: props.autoFocus,
+      startDate: props.initialStartDate,
+      endDate: props.initialEndDate,
+    };
+
+    this.onDateChange = this.onDateChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+  }
+
+  onDateChange(date) {
+    this.setState({ endDate: date });
+  }
+
+  onFocusChange({ focused }) {
+    this.setState({ focused });
+  }
+
+  render() {
+    const { focused, startDate, endDate } = this.state;
+
+    // autoFocus, initialStartDate, and initialEndDate are helper props for
+    // the example wrapper but are not props on the SingleDateRangeEndPicker
+    // itself and thus, have to be omitted.
+    const props = omit(this.props, [
+      'autoFocus',
+      'initialStartDate',
+      'initialEndDate',
+    ]);
+
+    return (
+      <SingleDateRangeEndPicker
+        {...props}
+        id="date_input"
+        startDate={startDate}
+        endDate={endDate}
+        focused={focused}
+        onDateChange={this.onDateChange}
+        onFocusChange={this.onFocusChange}
+      />
+    );
+  }
+}
+
+SingleDateRangeEndPickerWrapper.propTypes = propTypes;
+SingleDateRangeEndPickerWrapper.defaultProps = defaultProps;
+
+export default SingleDateRangeEndPickerWrapper;

--- a/src/components/SingleDateRangeEndPicker.jsx
+++ b/src/components/SingleDateRangeEndPicker.jsx
@@ -1,0 +1,648 @@
+import React from 'react';
+import moment from 'moment';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { Portal } from 'react-portal';
+import { forbidExtraProps } from 'airbnb-prop-types';
+import { addEventListener } from 'consolidated-events';
+import isTouchDevice from 'is-touch-device';
+import OutsideClickHandler from 'react-outside-click-handler';
+
+import SingleDateRangeEndPickerShape from '../shapes/SingleDateRangeEndPickerShape';
+import { SingleDatePickerPhrases } from '../defaultPhrases';
+
+import toMomentObject from '../utils/toMomentObject';
+import toLocalizedDateString from '../utils/toLocalizedDateString';
+import getResponsiveContainerStyles from '../utils/getResponsiveContainerStyles';
+import getInputHeight from '../utils/getInputHeight';
+
+import SingleDatePickerInput from './SingleDatePickerInput';
+import DayPickerRangeController from './DayPickerRangeController';
+
+import CloseButton from './CloseButton';
+
+import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
+
+import {
+  HORIZONTAL_ORIENTATION,
+  VERTICAL_ORIENTATION,
+  ANCHOR_LEFT,
+  ANCHOR_RIGHT,
+  OPEN_DOWN,
+  OPEN_UP,
+  DAY_SIZE,
+  ICON_BEFORE_POSITION,
+  INFO_POSITION_BOTTOM,
+  FANG_HEIGHT_PX,
+  DEFAULT_VERTICAL_SPACING,
+  END_DATE,
+} from '../constants';
+
+const propTypes = forbidExtraProps({
+  ...withStylesPropTypes,
+  ...SingleDateRangeEndPickerShape,
+});
+
+const defaultProps = {
+  // required props for a functional interactive SingleDatePicker
+  endDate: null,
+  focused: false,
+
+  // input related props
+  id: 'end-date',
+  placeholder: 'End Date',
+  disabled: false,
+  required: false,
+  readOnly: false,
+  screenReaderInputMessage: '',
+  showClearDate: false,
+  showDefaultInputIcon: false,
+  inputIconPosition: ICON_BEFORE_POSITION,
+  customInputIcon: null,
+  customCloseIcon: null,
+  noBorder: false,
+  block: false,
+  small: false,
+  regular: false,
+  verticalSpacing: DEFAULT_VERTICAL_SPACING,
+  keepFocusOnInput: false,
+
+  // calendar presentation and interaction related props
+  orientation: HORIZONTAL_ORIENTATION,
+  anchorDirection: ANCHOR_LEFT,
+  openDirection: OPEN_DOWN,
+  horizontalMargin: 0,
+  withPortal: false,
+  withFullScreenPortal: false,
+  initialVisibleMonth: null,
+  firstDayOfWeek: null,
+  numberOfMonths: 2,
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
+  renderCalendarInfo: null,
+  calendarInfoPosition: INFO_POSITION_BOTTOM,
+  hideKeyboardShortcutsPanel: false,
+  daySize: DAY_SIZE,
+  isRTL: false,
+  verticalHeight: null,
+  transitionDuration: undefined,
+
+  // navigation related props
+  navPrev: null,
+  navNext: null,
+
+  onPrevMonthClick() {},
+  onNextMonthClick() {},
+  onClose() {},
+
+  // month presentation and interaction related props
+  renderMonthText: null,
+
+  // day presentation and interaction related props
+  renderCalendarDay: undefined,
+  renderDayContents: null,
+  enableOutsideDays: false,
+  isDayBlocked: () => false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isDayHighlighted: () => {},
+
+  // internationalization props
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+  monthFormat: 'MMMM YYYY',
+  weekDayFormat: 'dd',
+  phrases: SingleDatePickerPhrases,
+  dayAriaLabelFormat: undefined,
+};
+
+class SingleDateRangeEndPicker extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.isTouchDevice = false;
+
+    this.state = {
+      dayPickerContainerStyles: {},
+      isDayPickerFocused: false,
+      isInputFocused: false,
+      showKeyboardShortcuts: false,
+    };
+
+    this.onDayPickerFocus = this.onDayPickerFocus.bind(this);
+    this.onDayPickerBlur = this.onDayPickerBlur.bind(this);
+    this.showKeyboardShortcutsPanel = this.showKeyboardShortcutsPanel.bind(this);
+
+    this.onChange = this.onChange.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.onClearFocus = this.onClearFocus.bind(this);
+    this.clearDate = this.clearDate.bind(this);
+
+    this.responsivizePickerPosition = this.responsivizePickerPosition.bind(this);
+
+    this.setDayPickerContainerRef = this.setDayPickerContainerRef.bind(this);
+  }
+
+  /* istanbul ignore next */
+  componentDidMount() {
+    this.removeEventListener = addEventListener(
+      window,
+      'resize',
+      this.responsivizePickerPosition,
+      { passive: true },
+    );
+    this.responsivizePickerPosition();
+
+    const { focused } = this.props;
+
+    if (focused) {
+      this.setState({
+        isInputFocused: true,
+      });
+    }
+
+    this.isTouchDevice = isTouchDevice();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { focused } = this.props;
+    if (!prevProps.focused && focused) {
+      this.responsivizePickerPosition();
+    }
+  }
+
+  /* istanbul ignore next */
+  componentWillUnmount() {
+    if (this.removeEventListener) this.removeEventListener();
+  }
+
+  onChange(dateString) {
+    const {
+      isOutsideRange,
+      keepOpenOnDateSelect,
+      onDateChange,
+      onFocusChange,
+      onClose,
+    } = this.props;
+    const newDate = toMomentObject(dateString, this.getDisplayFormat());
+
+    const isValid = newDate && !isOutsideRange(newDate);
+    if (isValid) {
+      onDateChange(newDate);
+      if (!keepOpenOnDateSelect) {
+        onFocusChange({ focused: false });
+        onClose({ date: newDate });
+      }
+    } else {
+      onDateChange(null);
+    }
+  }
+
+  onFocus() {
+    const {
+      disabled,
+      onFocusChange,
+      withPortal,
+      withFullScreenPortal,
+      keepFocusOnInput,
+    } = this.props;
+
+    const withAnyPortal = withPortal || withFullScreenPortal;
+    const moveFocusToDayPicker = withAnyPortal || (this.isTouchDevice && !keepFocusOnInput);
+
+    if (moveFocusToDayPicker) {
+      this.onDayPickerFocus();
+    } else {
+      this.onDayPickerBlur();
+    }
+
+    if (!disabled) {
+      onFocusChange({ focused: true });
+    }
+  }
+
+  onClearFocus() {
+    const {
+      date,
+      focused,
+      onFocusChange,
+      onClose,
+    } = this.props;
+    if (!focused) return;
+
+    this.setState({
+      isInputFocused: false,
+      isDayPickerFocused: false,
+    });
+
+    onFocusChange({ focused: false });
+    onClose({ date });
+  }
+
+  onDayPickerFocus() {
+    this.setState({
+      isInputFocused: false,
+      isDayPickerFocused: true,
+      showKeyboardShortcuts: false,
+    });
+  }
+
+  onDayPickerBlur() {
+    this.setState({
+      isInputFocused: true,
+      isDayPickerFocused: false,
+      showKeyboardShortcuts: false,
+    });
+  }
+
+  getDateString(date) {
+    const displayFormat = this.getDisplayFormat();
+    if (date && displayFormat) {
+      return date && date.format(displayFormat);
+    }
+    return toLocalizedDateString(date);
+  }
+
+  getDisplayFormat() {
+    const { displayFormat } = this.props;
+    return typeof displayFormat === 'string' ? displayFormat : displayFormat();
+  }
+
+  setDayPickerContainerRef(ref) {
+    this.dayPickerContainer = ref;
+  }
+
+  clearDate() {
+    const { onDateChange, reopenPickerOnClearDate, onFocusChange } = this.props;
+    onDateChange(null);
+    if (reopenPickerOnClearDate) {
+      onFocusChange({ focused: true });
+    }
+  }
+
+  /* istanbul ignore next */
+  responsivizePickerPosition() {
+    // It's possible the portal props have been changed in response to window resizes
+    // So let's ensure we reset this back to the base state each time
+    this.setState({ dayPickerContainerStyles: {} });
+
+    const {
+      anchorDirection,
+      horizontalMargin,
+      withPortal,
+      withFullScreenPortal,
+      focused,
+    } = this.props;
+    const { dayPickerContainerStyles } = this.state;
+
+    if (!focused) {
+      return;
+    }
+
+    const isAnchoredLeft = anchorDirection === ANCHOR_LEFT;
+
+    if (!withPortal && !withFullScreenPortal) {
+      const containerRect = this.dayPickerContainer.getBoundingClientRect();
+      const currentOffset = dayPickerContainerStyles[anchorDirection] || 0;
+      const containerEdge = isAnchoredLeft
+        ? containerRect[ANCHOR_RIGHT]
+        : containerRect[ANCHOR_LEFT];
+
+      this.setState({
+        dayPickerContainerStyles: getResponsiveContainerStyles(
+          anchorDirection,
+          currentOffset,
+          containerEdge,
+          horizontalMargin,
+        ),
+      });
+    }
+  }
+
+  showKeyboardShortcutsPanel() {
+    this.setState({
+      isInputFocused: false,
+      isDayPickerFocused: true,
+      showKeyboardShortcuts: true,
+    });
+  }
+
+  maybeRenderDayPickerWithPortal() {
+    const { focused, withPortal, withFullScreenPortal } = this.props;
+
+    if (!focused) {
+      return null;
+    }
+
+    if (withPortal || withFullScreenPortal) {
+      return (
+        <Portal>
+          {this.renderDayPicker()}
+        </Portal>
+      );
+    }
+
+    return this.renderDayPicker();
+  }
+
+  renderDayPicker() {
+    const {
+      anchorDirection,
+      openDirection,
+      onDateChange,
+      startDate,
+      endDate,
+      onFocusChange,
+      focused,
+      enableOutsideDays,
+      numberOfMonths,
+      orientation,
+      monthFormat,
+      navPrev,
+      navNext,
+      onPrevMonthClick,
+      onNextMonthClick,
+      onClose,
+      withPortal,
+      withFullScreenPortal,
+      keepOpenOnDateSelect,
+      initialVisibleMonth,
+      renderMonthText,
+      renderCalendarDay,
+      renderDayContents,
+      renderCalendarInfo,
+      calendarInfoPosition,
+      hideKeyboardShortcutsPanel,
+      firstDayOfWeek,
+      customCloseIcon,
+      phrases,
+      dayAriaLabelFormat,
+      daySize,
+      isRTL,
+      isOutsideRange,
+      isDayBlocked,
+      isDayHighlighted,
+      weekDayFormat,
+      styles,
+      verticalHeight,
+      transitionDuration,
+      verticalSpacing,
+      small,
+      theme: { reactDates },
+    } = this.props;
+    const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
+
+    const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onClearFocus : undefined;
+    const closeIcon = customCloseIcon || (<CloseButton />);
+
+    const inputHeight = getInputHeight(reactDates, small);
+
+    const withAnyPortal = withPortal || withFullScreenPortal;
+
+    return (
+      <div // eslint-disable-line jsx-a11y/no-static-element-interactions
+        ref={this.setDayPickerContainerRef}
+        {...css(
+          styles.SingleDateRangeEndPicker_picker,
+          anchorDirection === ANCHOR_LEFT
+            && styles.SingleDateRangeEndPicker_picker__directionLeft,
+          anchorDirection === ANCHOR_RIGHT
+            && styles.SingleDateRangeEndPicker_picker__directionRight,
+          openDirection === OPEN_DOWN
+            && styles.SingleDateRangeEndPicker_picker__openDown,
+          openDirection === OPEN_UP
+            && styles.SingleDateRangeEndPicker_picker__openUp,
+          !withAnyPortal && openDirection === OPEN_DOWN
+            && {
+              top: inputHeight + verticalSpacing,
+            },
+          !withAnyPortal && openDirection === OPEN_UP
+            && {
+              bottom: inputHeight + verticalSpacing,
+            },
+          orientation === HORIZONTAL_ORIENTATION
+            && styles.SingleDateRangeEndPicker_picker__horizontal,
+          orientation === VERTICAL_ORIENTATION
+            && styles.SingleDateRangeEndPicker_picker__vertical,
+          withAnyPortal && styles.SingleDateRangeEndPicker_picker__portal,
+          withFullScreenPortal
+            && styles.SingleDateRangeEndPicker_picker__fullScreenPortal,
+          isRTL && styles.SingleDateRangeEndPicker_picker__rtl,
+          dayPickerContainerStyles,
+        )}
+        onClick={onOutsideClick}
+      >
+        <DayPickerRangeController
+          startDate={startDate}
+          endDate={endDate}
+          onDatesChange={dates => onDateChange(dates.endDate)}
+          onFocusChange={focusedInput => onFocusChange({ focused: !!focusedInput })}
+          orientation={orientation}
+          enableOutsideDays={enableOutsideDays}
+          numberOfMonths={numberOfMonths}
+          monthFormat={monthFormat}
+          withPortal={withAnyPortal}
+          focusedInput={focused ? END_DATE : null}
+          keepOpenOnDateSelect={keepOpenOnDateSelect}
+          hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
+          initialVisibleMonth={initialVisibleMonth}
+          navPrev={navPrev}
+          navNext={navNext}
+          onPrevMonthClick={onPrevMonthClick}
+          onNextMonthClick={onNextMonthClick}
+          onClose={onClose}
+          renderMonthText={renderMonthText}
+          renderCalendarDay={renderCalendarDay}
+          renderDayContents={renderDayContents}
+          renderCalendarInfo={renderCalendarInfo}
+          calendarInfoPosition={calendarInfoPosition}
+          isFocused={isDayPickerFocused}
+          showKeyboardShortcuts={showKeyboardShortcuts}
+          onBlur={this.onDayPickerBlur}
+          phrases={phrases}
+          dayAriaLabelFormat={dayAriaLabelFormat}
+          daySize={daySize}
+          isRTL={isRTL}
+          isOutsideRange={isOutsideRange}
+          isDayBlocked={isDayBlocked}
+          isDayHighlighted={isDayHighlighted}
+          firstDayOfWeek={firstDayOfWeek}
+          weekDayFormat={weekDayFormat}
+          verticalHeight={verticalHeight}
+          transitionDuration={transitionDuration}
+        />
+
+        {withFullScreenPortal && (
+          <button
+            {...css(styles.SingleDateRangeEndPicker_closeButton)}
+            aria-label={phrases.closeDatePicker}
+            type="button"
+            onClick={this.onClearFocus}
+          >
+            <div {...css(styles.SingleDateRangeEndPicker_closeButton_svg)}>
+              {closeIcon}
+            </div>
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const {
+      id,
+      placeholder,
+      disabled,
+      focused,
+      required,
+      readOnly,
+      openDirection,
+      showClearDate,
+      showDefaultInputIcon,
+      inputIconPosition,
+      customCloseIcon,
+      customInputIcon,
+      endDate,
+      phrases,
+      withPortal,
+      withFullScreenPortal,
+      screenReaderInputMessage,
+      isRTL,
+      noBorder,
+      block,
+      small,
+      regular,
+      verticalSpacing,
+      styles,
+    } = this.props;
+
+    const { isInputFocused } = this.state;
+
+    const displayValue = this.getDateString(endDate);
+
+    const onOutsideClick = (!withPortal && !withFullScreenPortal) ? this.onClearFocus : undefined;
+
+    const hideFang = verticalSpacing < FANG_HEIGHT_PX;
+
+    return (
+      <div
+        {...css(
+          styles.SingleDateRangeEndPicker,
+          block && styles.SingleDateRangeEndPicker__block,
+        )}
+      >
+        <OutsideClickHandler onOutsideClick={onOutsideClick}>
+          <SingleDatePickerInput
+            id={id}
+            placeholder={placeholder}
+            focused={focused}
+            isFocused={isInputFocused}
+            disabled={disabled}
+            required={required}
+            readOnly={readOnly}
+            openDirection={openDirection}
+            showCaret={!withPortal && !withFullScreenPortal && !hideFang}
+            onClearDate={this.clearDate}
+            showClearDate={showClearDate}
+            showDefaultInputIcon={showDefaultInputIcon}
+            inputIconPosition={inputIconPosition}
+            customCloseIcon={customCloseIcon}
+            customInputIcon={customInputIcon}
+            displayValue={displayValue}
+            onChange={this.onChange}
+            onFocus={this.onFocus}
+            onKeyDownShiftTab={this.onClearFocus}
+            onKeyDownTab={this.onClearFocus}
+            onKeyDownArrowDown={this.onDayPickerFocus}
+            onKeyDownQuestionMark={this.showKeyboardShortcutsPanel}
+            screenReaderMessage={screenReaderInputMessage}
+            phrases={phrases}
+            isRTL={isRTL}
+            noBorder={noBorder}
+            block={block}
+            small={small}
+            regular={regular}
+            verticalSpacing={verticalSpacing}
+          />
+
+          {this.maybeRenderDayPickerWithPortal()}
+        </OutsideClickHandler>
+      </div>
+    );
+  }
+}
+
+SingleDateRangeEndPicker.propTypes = propTypes;
+SingleDateRangeEndPicker.defaultProps = defaultProps;
+
+export { SingleDateRangeEndPicker as PureSingleDateRangeEndPicker };
+export default withStyles(({ reactDates: { color, zIndex } }) => ({
+  SingleDateRangeEndPicker: {
+    position: 'relative',
+    display: 'inline-block',
+  },
+
+  SingleDateRangeEndPicker__block: {
+    display: 'block',
+  },
+
+  SingleDateRangeEndPicker_picker: {
+    zIndex: zIndex + 1,
+    backgroundColor: color.background,
+    position: 'absolute',
+  },
+
+  SingleDateRangeEndPicker_picker__rtl: {
+    direction: 'rtl',
+  },
+
+  SingleDateRangeEndPicker_picker__directionLeft: {
+    left: 0,
+  },
+
+  SingleDateRangeEndPicker_picker__directionRight: {
+    right: 0,
+  },
+
+  SingleDateRangeEndPicker_picker__portal: {
+    backgroundColor: 'rgba(0, 0, 0, 0.3)',
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    height: '100%',
+    width: '100%',
+  },
+
+  SingleDateRangeEndPicker_picker__fullScreenPortal: {
+    backgroundColor: color.background,
+  },
+
+  SingleDateRangeEndPicker_closeButton: {
+    background: 'none',
+    border: 0,
+    color: 'inherit',
+    font: 'inherit',
+    lineHeight: 'normal',
+    overflow: 'visible',
+    cursor: 'pointer',
+
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    padding: 15,
+    zIndex: zIndex + 2,
+
+    ':hover': {
+      color: `darken(${color.core.grayLighter}, 10%)`,
+      textDecoration: 'none',
+    },
+
+    ':focus': {
+      color: `darken(${color.core.grayLighter}, 10%)`,
+      textDecoration: 'none',
+    },
+  },
+
+  SingleDateRangeEndPicker_closeButton_svg: {
+    height: 15,
+    width: 15,
+    fill: color.core.grayLighter,
+  },
+}))(SingleDateRangeEndPicker);

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ export { default as DayPickerSingleDateController } from './components/DayPicker
 export { default as SingleDatePicker } from './components/SingleDatePicker';
 export { default as SingleDatePickerInput } from './components/SingleDatePickerInput';
 export { default as SingleDatePickerShape } from './shapes/SingleDatePickerShape';
+export { default as SingleDateRangeEndPicker } from './components/SingleDateRangeEndPicker';
+export { default as SingleDateRangeEndPickerShape } from './shapes/SingleDateRangeEndPickerShape';
 export { default as isInclusivelyAfterDay } from './utils/isInclusivelyAfterDay';
 export { default as isInclusivelyBeforeDay } from './utils/isInclusivelyBeforeDay';
 export { default as isNextDay } from './utils/isNextDay';

--- a/src/shapes/SingleDateRangeEndPickerShape.js
+++ b/src/shapes/SingleDateRangeEndPickerShape.js
@@ -1,0 +1,11 @@
+import momentPropTypes from 'react-moment-proptypes';
+import omit from 'lodash/omit';
+
+import SingleDatePickerShape from './SingleDatePickerShape';
+
+export default {
+  ...omit(SingleDatePickerShape, ['date']),
+
+  startDate: momentPropTypes.momentObj,
+  endDate: momentPropTypes.momentObj,
+};

--- a/stories/SingleDateRangeEndPicker.js
+++ b/stories/SingleDateRangeEndPicker.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import moment from 'moment';
+import momentJalaali from 'moment-jalaali';
+import { storiesOf } from '@storybook/react';
+import {
+  VERTICAL_ORIENTATION,
+} from '../src/constants';
+
+import SingleDateRangeEndPickerWrapper from '../examples/SingleDateRangeEndPickerWrapper';
+
+const TestInput = props => (
+  <div style={{ marginTop: 16 }} >
+    <input
+      {...props}
+      type="text"
+      style={{
+        height: 48,
+        width: 284,
+        fontSize: 18,
+        fontWeight: 200,
+        padding: '12px 16px',
+      }}
+    />
+  </div>
+);
+
+storiesOf('SingleDateRangeEndPicker (SDREP)', module)
+  .addWithInfo('default', () => (
+    <SingleDateRangeEndPickerWrapper />
+  ))
+  .addWithInfo('starts in two weeks', () => (
+    <SingleDateRangeEndPickerWrapper
+      initialStartDate={moment().add(2, 'weeks')}
+    />
+  ))
+  .addWithInfo('as part of a form', () => (
+    <div>
+      <SingleDateRangeEndPickerWrapper />
+      <TestInput placeholder="Input 1" />
+      <TestInput placeholder="Input 2" />
+      <TestInput placeholder="Input 3" />
+    </div>
+  ))
+  .addWithInfo('non-english locale (Chinese)', () => {
+    moment.locale('zh-cn');
+    return (
+      <SingleDateRangeEndPickerWrapper
+        placeholder="入住日期"
+        monthFormat="YYYY[年]MMMM"
+        phrases={{
+          closeDatePicker: '关闭',
+          clearDate: '清除日期',
+        }}
+      />
+    );
+  })
+  .addWithInfo('non-english locale (Persian)', () => {
+    moment.locale('fa');
+    return (
+      <SingleDateRangeEndPickerWrapper
+        placeholder="تقویم فارسی"
+        renderMonthText={month => momentJalaali(month).format('jMMMM jYYYY')}
+        renderDayContents={day => momentJalaali(day).format('jD')}
+      />
+    );
+  })
+  .addWithInfo('vertical with custom height', () => (
+    <SingleDateRangeEndPickerWrapper
+      orientation={VERTICAL_ORIENTATION}
+      verticalHeight={568}
+    />
+  ));


### PR DESCRIPTION
<img width="640" alt="screen shot of renderMonth" src="https://user-images.githubusercontent.com/132355/42727838-df1f4204-87ad-11e8-868a-983c0e441f40.png">

`DateRangePicker` is the perfect component to use when you want the user to select a pair of start/end dates at the same time. `SingleDatePicker` is the perfect component to use when you want the user to select just one date, without any other context. However, neither of these components are a perfect fit when you want the user to select a pair of start/end dates, but want the user to select them at _two different places_ in your form. You can use two different `SingleDatePicker` components, but the end date picker will not display the previously-selected start date, and cannot enforce validity checks (end date must be after start date, for example).

To address this, I built the `SingleDateRangeEndPicker`, which is a hybrid between `DateRangePicker` and `SingleDatePicker`. It has behavior similar to the SDP, in that the user selects only a single date, rather than a pair of dates. However, it also accepts a fixed `startDate` prop, so that when the user is selecting this end date, the user will see the date range between start and end, similar to the DRP.

I'm sure that this code can be refactored to reduce code duplication -- I basically copied the `SingleDatePicker.jsx` file and made the necessary changes to make it use `DayPickerRangeController` instead of `DayPickerSingleDateController`. I wanted to submit this pull request early, so that I could get feedback from others about whether this is a good idea, and how to get it merged into the project.