### PR TITLE
Fixes DateInput_Fang gap for DateInput with noBorder

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -36,6 +36,7 @@ const propTypes = forbidExtraProps({
   verticalSpacing: nonNegativeInteger,
   small: PropTypes.bool,
   block: PropTypes.bool,
+  noBorder: PropTypes.bool,
   regular: PropTypes.bool,
 
   onChange: PropTypes.func,
@@ -64,6 +65,7 @@ const defaultProps = {
   small: false,
   block: false,
   regular: false,
+  noBorder: false,
 
   onChange() {},
   onFocus() {},
@@ -185,6 +187,7 @@ class DateInput extends React.Component {
       regular,
       block,
       styles,
+      noBorder,
       theme: { reactDates },
     } = this.props;
 
@@ -240,10 +243,10 @@ class DateInput extends React.Component {
             {...css(
               styles.DateInput_fang,
               openDirection === OPEN_DOWN && {
-                top: inputHeight + verticalSpacing - FANG_HEIGHT_PX - 1,
+                top: inputHeight + verticalSpacing - FANG_HEIGHT_PX - 1 + (noBorder ? 1 : 0),
               },
               openDirection === OPEN_UP && {
-                bottom: inputHeight + verticalSpacing - FANG_HEIGHT_PX - 1,
+                bottom: inputHeight + verticalSpacing - FANG_HEIGHT_PX - 1 + (noBorder ? 1 : 0),
               },
             )}
           >

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -237,6 +237,7 @@ function DateRangePickerInput({
         verticalSpacing={verticalSpacing}
         small={small}
         regular={regular}
+        noBorder={noBorder}
       />
 
       <div
@@ -267,6 +268,7 @@ function DateRangePickerInput({
         verticalSpacing={verticalSpacing}
         small={small}
         regular={regular}
+        noBorder={noBorder}
       />
 
       {showClearDates && (


### PR DESCRIPTION
Hi,

there is a 1px gap between "DateInput_Fang" and "DateRangePicker_picker", if property noBorder is set. This pr passes noBorder down to DateInput to handle this gap.