### PR TITLE
Force input border radius to be 0

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -316,6 +316,7 @@ export default withStyles(({
     borderRight: border.input.borderRight,
     borderBottom: border.input.borderBottom,
     borderLeft: border.input.borderLeft,
+    borderRadius: border.input.borderRadius,
   },
 
   DateInput_input__small: {

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -40,6 +40,7 @@ export default {
         borderLeftFocused: 0,
         borderBottomFocused: `2px solid ${core.primary_dark}`,
         borderRightFocused: 0,
+        borderRadius: 0,
       },
     },
 


### PR DESCRIPTION
Some CSS libraries pretty commonly set a border radius on all `input` components which looks super weird with the default stylings for `react-dates`.

If users are setting a custom border radius themselves via css overrides, this shouldn't affect them. 

to: @ljharb @garrettberg