### PR TITLE
make nav buttons optional

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -130,7 +130,7 @@ class DayPickerRangeControllerWrapper extends React.Component {
     const endDateString = endDate && endDate.format('YYYY-MM-DD');
 
     return (
-      <div>
+      <div style={{ height: '100%' }}>
         {showInputs &&
           <div style={{ marginBottom: 16 }}>
             <input type="text" name="start date" value={startDateString} readOnly />

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -71,6 +71,7 @@ const propTypes = forbidExtraProps({
   // navigation props
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  noNavButtons: PropTypes.bool,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onMultiplyScrollableMonths: PropTypes.func, // VERTICAL_SCROLLABLE daypickers only
@@ -122,6 +123,7 @@ export const defaultProps = {
   // navigation props
   navPrev: null,
   navNext: null,
+  noNavButtons: false,
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onMultiplyScrollableMonths() {},
@@ -639,10 +641,15 @@ class DayPicker extends React.Component {
     const {
       navPrev,
       navNext,
+      noNavButtons,
       orientation,
       phrases,
       isRTL,
     } = this.props;
+
+    if (noNavButtons) {
+      return null;
+    }
 
     let onNextMonthClick;
     if (orientation === VERTICAL_SCROLLABLE) {

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -72,6 +72,7 @@ const propTypes = forbidExtraProps({
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  noNavButtons: PropTypes.bool,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
@@ -128,6 +129,7 @@ const defaultProps = {
 
   navPrev: null,
   navNext: null,
+  noNavButtons: false,
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -990,6 +992,7 @@ export default class DayPickerRangeController extends React.Component {
       renderMonth,
       navPrev,
       navNext,
+      noNavButtons,
       onOutsideClick,
       withPortal,
       enableOutsideDays,
@@ -1037,6 +1040,7 @@ export default class DayPickerRangeController extends React.Component {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
+        noNavButtons={noNavButtons}
         renderCalendarDay={renderCalendarDay}
         renderDayContents={renderDayContents}
         renderCalendarInfo={renderCalendarInfo}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -7,7 +7,7 @@ import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
-import { VERTICAL_ORIENTATION } from '../src/constants';
+import { VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE } from '../src/constants';
 
 import DayPickerRangeControllerWrapper from '../examples/DayPickerRangeControllerWrapper';
 
@@ -164,6 +164,18 @@ storiesOf('DayPickerRangeController', module)
       orientation={VERTICAL_ORIENTATION}
     />
   ))
+  .addWithInfo('vertical scrollable', () => (
+    <div style={{ height: 300 }}>
+      <DayPickerRangeControllerWrapper
+        onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+        onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+        onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+        orientation={VERTICAL_SCROLLABLE}
+        numberOfMonths={6}
+        verticalHeight={800}
+      />
+    </div>
+  ))
   .addWithInfo('with custom month navigation', () => (
     <DayPickerRangeControllerWrapper
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
@@ -285,5 +297,11 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       verticalBorderSpacing={16}
+    />
+  ))
+  .addWithInfo('with no nav buttons', () => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      noNavButtons
     />
   ));

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -7,6 +7,7 @@ import { shallow } from 'enzyme';
 import DayPickerRangeController from '../../src/components/DayPickerRangeController';
 
 import DayPicker from '../../src/components/DayPicker';
+import DayPickerNavigation from '../../src/components/DayPickerNavigation';
 
 import toISODateString from '../../src/utils/toISODateString';
 import toISOMonthString from '../../src/utils/toISOMonthString';
@@ -3213,6 +3214,18 @@ describe('DayPickerRangeController', () => {
       it('returns false if not last of week', () => {
         const wrapper = shallow(<DayPickerRangeController />);
         expect(wrapper.instance().isLastDayOfWeek(moment().startOf('week').add(1, 'day'))).to.equal(false);
+      });
+    });
+
+    describe('noNavButtons prop', () => {
+      it('renders navigation button', () => {
+        const wrapper = shallow(<DayPickerRangeController />).dive().dive();
+        expect(wrapper.find(DayPickerNavigation)).to.have.lengthOf(1);
+      });
+
+      it('does not render navigation button when noNavButtons prop applied', () => {
+        const wrapper = shallow(<DayPickerRangeController noNavButtons />).dive().dive();
+        expect(wrapper.find(DayPickerNavigation)).to.have.lengthOf(0);
       });
     });
   });


### PR DESCRIPTION
## Summary
Beyond would like to be able to render our own nav buttons completely (rather than just be able to render inside of the existing nav button boxes). I believe that we can do this completely outside of the component by just adding a button that changes the number of months passed to `DayPickerRangeController`. However, to do this, we do _not_ want to render the existing `react-dates` nav buttons. This adds a boolean prop that makes the nav buttons optional.

This should also be helpful if people want to display only a couple of months and not allow users to move infinitely into the future (or any other custom navigation features).

## Reviewers
@majapw 
cc: @ljharb 

### Storybook example of `vertical_scrollable` orientation (didn't exist before)
![screen shot 2018-05-07 at 2 08 40 pm](https://user-images.githubusercontent.com/12832034/39727153-6dace734-5206-11e8-903d-e9cbd97c6add.png)
### Storybook example of new `noNavButtons` prop
![screen shot 2018-05-07 at 2 53 12 pm](https://user-images.githubusercontent.com/12832034/39727155-6ddc1cde-5206-11e8-87b5-9e89b105dce6.png)
