### PR TITLE
Change month height calculation to be based on number of weeks instead of DOM calculations

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -44,7 +44,7 @@ const propTypes = forbidExtraProps({
   renderCalendarDay: PropTypes.func,
   renderDayContents: PropTypes.func,
   firstDayOfWeek: DayOfWeekShape,
-  setMonthHeight: PropTypes.func,
+  setMonthTitleHeight: PropTypes.func,
   verticalBorderSpacing: nonNegativeInteger,
 
   focusedDate: momentPropTypes.momentObj, // indicates focusable day
@@ -70,7 +70,7 @@ const defaultProps = {
   renderCalendarDay: props => (<CalendarDay {...props} />),
   renderDayContents: null,
   firstDayOfWeek: null,
-  setMonthHeight() {},
+  setMonthTitleHeight: null,
 
   focusedDate: null,
   isFocused: false,
@@ -95,12 +95,11 @@ class CalendarMonth extends React.Component {
     };
 
     this.setCaptionRef = this.setCaptionRef.bind(this);
-    this.setGridRef = this.setGridRef.bind(this);
-    this.setMonthHeight = this.setMonthHeight.bind(this);
+    this.setMonthTitleHeight = this.setMonthTitleHeight.bind(this);
   }
 
   componentDidMount() {
-    this.setMonthHeightTimeout = setTimeout(this.setMonthHeight, 0);
+    this.setMonthTitleHeightTimeout = setTimeout(this.setMonthTitleHeight, 0);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -123,25 +122,21 @@ class CalendarMonth extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.setMonthHeightTimeout) {
-      clearTimeout(this.setMonthHeightTimeout);
+    if (this.setMonthTitleHeightTimeout) {
+      clearTimeout(this.setMonthTitleHeightTimeout);
     }
   }
 
-  setMonthHeight() {
-    const { setMonthHeight } = this.props;
-    const captionHeight = calculateDimension(this.captionRef, 'height', true, true);
-    const gridHeight = calculateDimension(this.gridRef, 'height');
-
-    setMonthHeight(captionHeight + gridHeight + 1);
+  setMonthTitleHeight() {
+    const { setMonthTitleHeight } = this.props;
+    if (setMonthTitleHeight) {
+      const captionHeight = calculateDimension(this.captionRef, 'height', true, true);
+      setMonthTitleHeight(captionHeight);
+    }
   }
 
   setCaptionRef(ref) {
     this.captionRef = ref;
-  }
-
-  setGridRef(ref) {
-    this.gridRef = ref;
   }
 
   render() {
@@ -199,7 +194,7 @@ class CalendarMonth extends React.Component {
           )}
           role="presentation"
         >
-          <tbody ref={this.setGridRef}>
+          <tbody>
             {weeks.map((week, i) => (
               <CalendarWeek key={i}>
                 {week.map((day, dayOfWeek) => renderCalendarDay({

--- a/src/utils/getNumberOfCalendarMonthWeeks.js
+++ b/src/utils/getNumberOfCalendarMonthWeeks.js
@@ -1,0 +1,15 @@
+import moment from 'moment';
+
+function getBlankDaysBeforeFirstDay(firstDayOfMonth, firstDayOfWeek) {
+  const weekDayDiff = firstDayOfMonth.day() - firstDayOfWeek;
+  return (weekDayDiff + 7) % 7;
+}
+
+export default function getNumberOfCalendarMonthWeeks(
+  month,
+  firstDayOfWeek = moment.localeData().firstDayOfWeek(),
+) {
+  const firstDayOfMonth = month.clone().startOf('month');
+  const numBlankDays = getBlankDaysBeforeFirstDay(firstDayOfMonth, firstDayOfWeek);
+  return Math.ceil((numBlankDays + month.daysInMonth()) / 7);
+}

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -16,9 +16,9 @@ describe('CalendarMonthGrid', () => {
   });
 
   it('has style equal to getTransformStyles(foo)', () => {
-    const transformValue = 'foo';
-    const transformStyles = getTransformStyles(transformValue);
-    const wrapper = shallow(<CalendarMonthGrid transformValue={transformValue} />).dive();
+    const translationValue = 'foo';
+    const transformStyles = getTransformStyles(`translateX(${translationValue}px)`);
+    const wrapper = shallow(<CalendarMonthGrid translationValue={translationValue} />).dive();
     Object.keys(transformStyles).forEach((key) => {
       expect(wrapper.prop('style')[key]).to.equal(transformStyles[key]);
     });

--- a/test/utils/getNumberOfCalendarMonthWeeks_spec.js
+++ b/test/utils/getNumberOfCalendarMonthWeeks_spec.js
@@ -1,0 +1,26 @@
+import moment from 'moment';
+import { expect } from 'chai';
+
+import getNumberOfCalendarMonthWeeks from '../../src/utils/getNumberOfCalendarMonthWeeks';
+
+describe('getNumberOfCalendarMonthWeeks', () => {
+  it('returns 4 weeks for a 4-week month', () => {
+    const february2018 = moment('2018-02-01', 'YYYY-MM-DD');
+    expect(getNumberOfCalendarMonthWeeks(february2018, 4)).to.equal(4);
+  });
+
+  it('returns 5 weeks for a 5-week month', () => {
+    const july2018 = moment('2018-07-01', 'YYYY-MM-DD');
+    expect(getNumberOfCalendarMonthWeeks(july2018, 0)).to.equal(5);
+  });
+
+  it('returns 6 weeks for a 6-week month', () => {
+    const september2018 = moment('2018-09-01', 'YYYY-MM-DD');
+    expect(getNumberOfCalendarMonthWeeks(september2018, 0)).to.equal(6);
+  });
+
+  it('changing the first day of week changes the number of weeks', () => {
+    const september2018 = moment('2018-09-01', 'YYYY-MM-DD');
+    expect(getNumberOfCalendarMonthWeeks(september2018, 6)).to.equal(5);
+  });
+});


### PR DESCRIPTION
Hello friends! 

This is a precursor to getting https://github.com/airbnb/react-dates/pull/1106 merged in. I separated it out into its own change because it was fairly involved and I didn't want to pollute the code-change in #1106 with something not *entirely* related.

Basically, when playing around with the month/year selection I found an issue where if you jumped to a month of a different height (5 week month => 6 week month), the height wouldn't automatically adjust as expected. When I started trying to fix the issue, it became apparent that it wasn't possible to do without jank using the existing paradigms.

*Before:*
1. On render, each `CalendarMonth` component (including the two invisible ones for animation) would measure its own height in the DOM.
2. Each `CalendarMonth` would then call a callback prop, `setMonthHeight`, with this measured value.
3. The `CalendarMonthGrid` would add these values to an ordered array of `CalendarMonth` heights which it would then pass back up to the `DayPicker` via the `setCalendarMonthHeights` prop
4. Once the `DayPicker` would have all of the heights, it would calculate the expected height based on the max of the visible months and grow the calendar appropriately.
5. On month transitions, it would use this array of heights to grow or shrink the calendar appropriately while transitioning.

The important thing to note is that the only way it could change the height *while* transitioning was to use the self-calculations made by the invisible months that were already rendered to the DOM. When we want to transition to an arbitrary month or year, there's guaranteed to be jank in this system because we have to render the month before we know its height. The end result is that if you transition from July 2018 to July 2017, the 6-week month will be cut off before it grows. The other option is to hide the calendar in this interim, but that flash is also very apparent.

SO, this change is designed to amend that.

*Now:*
1. On the first render (and any time `renderMonth` changes), the `CalendarMonth` measures itself, subtracts out the height of the `CalendarDay` table (which is deterministic based on number of weeks and the `daySize` prop), and call the `setMonthTitleHeight` prop with the value. 
2. The `DayPicker` receives this value and saves it in `this.monthTitleHeight`
3. The `DayPicker` also maintains an array of the number of weeks in each visible month.
4. On every month transition, the `DayPicker` uses the number of weeks in the month coming into view along with the `daySize` prop and the saved `monthTitleHeight` to calculate the expected height of the incoming month and adjusts the height appropriately.

I've tested this in both the vertical and the horizontal pickers and it seems pretty effective! Because we can pretty readily calculate the number of weeks in any incoming month, this should open the door to slick month transitions to any month. We also, tbh, could probably remove the invisible months from render until it's time to slide them in. That can wait for another time though.

Note, this does assume a pretty constant month title height, but tbh I think that was an implicit assumption before. 

Would love some eyes! @ljharb @gabergg @GoGoCarl

These props that I'm changing are all what I would consider internal props (it would be weird if an outside consumer was relying on them for anything)... but are technically part of the API, so this change could be considered breaking. Idk. 

TODO: 
-[X] Write tests for `getNumberOfCalendarMonthWeeks`
-[X] reset month height when renderMonth changes