### PR TITLE
Remove inputRef.blur() call that was causing a focus trap in Safari/IE

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -110,8 +110,6 @@ class DateInput extends React.Component {
 
     if (focused && isFocused) {
       this.inputRef.focus();
-    } else {
-      this.inputRef.blur();
     }
   }
 

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -229,12 +229,10 @@ describe('DateInput', () => {
 
     describe('focus/isFocused', () => {
       const el = {
-        blur() {},
         focus() {},
       };
 
       beforeEach(() => {
-        sinon.spy(el, 'blur');
         sinon.spy(el, 'focus');
       });
 
@@ -252,22 +250,7 @@ describe('DateInput', () => {
 
         wrapper.setProps({ focused: true, isFocused: true });
 
-        expect(el.blur).to.have.property('callCount', 0);
         expect(el.focus).to.have.property('callCount', 1);
-      });
-
-      it('blurs when becoming unfocused', () => {
-        const wrapper = shallow(
-          <DateInput id="date" focused isFocused />,
-          { disableLifecycleMethods: false },
-        ).dive();
-
-        wrapper.instance().inputRef = el;
-
-        wrapper.setProps({ focused: false, isFocused: false });
-
-        expect(el.blur).to.have.property('callCount', 1);
-        expect(el.focus).to.have.property('callCount', 0);
       });
     });
 


### PR DESCRIPTION
Fix for https://github.com/airbnb/react-dates/issues/937

This code was originally added in https://github.com/airbnb/react-dates/pull/212, but weirdly I cannot reproduce the underlying issue. There have been a lot of changes to the internal structure of react-dates... but it is still surprising. :/ 

to: @backwardok @ljharb @wonnage