### PR TITLE
Allow consolidated-events ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "airbnb-prop-types": "^2.10.0",
-    "consolidated-events": "^1.1.1",
+    "consolidated-events": "^1.1.1 || ^2.0.0",
     "is-touch-device": "^1.0.1",
     "lodash": "^4.1.1",
     "object.assign": "^4.1.0",


### PR DESCRIPTION
- Now built with rollup
  ([#8](https://github.com/lencioni/consolidated-events/pull/8))
- Deprecated `removeEventListener` export removed
  ([#13](https://github.com/lencioni/consolidated-events/pull/13))
- Passive event listener test is now removed after being added
  ([#11](https://github.com/lencioni/consolidated-events/pull/11))
- Reduced bundle size impact by replacing a class with a function
  ([#12](https://github.com/lencioni/consolidated-events/pull/12))