### PR TITLE
Pass through modifiers propType

### DIFF
--- a/scripts/buildCSS.js
+++ b/scripts/buildCSS.js
@@ -8,6 +8,9 @@ const compileCSS = require('react-with-styles-interface-css-compiler');
 const registerMaxSpecificity = require('react-with-styles-interface-css/dist/utils/registerMaxSpecificity').default;
 const registerCSSInterfaceWithDefaultTheme = require('../src/utils/registerCSSInterfaceWithDefaultTheme').default;
 
+console.error = msg => { throw new SyntaxError(msg); };
+console.warn = msg => { throw new SyntaxError(msg); };
+
 const args = process.argv.slice(2);
 const optimizeForProduction = args.includes('-o') || args.includes('--optimize');
 

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
+import ModifiersShape from '../shapes/ModifiersShape';
 
 import { DAY_SIZE } from '../constants';
 
@@ -17,7 +18,7 @@ const propTypes = forbidExtraProps({
   day: momentPropTypes.momentObj,
   daySize: nonNegativeInteger,
   isOutsideDay: PropTypes.bool,
-  modifiers: PropTypes.instanceOf(Set),
+  modifiers: ModifiersShape,
   isFocused: PropTypes.bool,
   tabIndex: PropTypes.oneOf([0, -1]),
   onDayClick: PropTypes.func,

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -19,6 +19,7 @@ import getCalendarMonthWeeks from '../utils/getCalendarMonthWeeks';
 import isSameDay from '../utils/isSameDay';
 import toISODateString from '../utils/toISODateString';
 
+import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 
@@ -34,7 +35,7 @@ const propTypes = forbidExtraProps({
   month: momentPropTypes.momentObj,
   isVisible: PropTypes.bool,
   enableOutsideDays: PropTypes.bool,
-  modifiers: PropTypes.object,
+  modifiers: PropTypes.objectOf(ModifiersShape),
   orientation: ScrollableOrientationShape,
   daySize: nonNegativeInteger,
   onDayClick: PropTypes.func,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -19,6 +19,7 @@ import toISOMonthString from '../utils/toISOMonthString';
 import isPrevMonth from '../utils/isPrevMonth';
 import isNextMonth from '../utils/isNextMonth';
 
+import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 
@@ -36,7 +37,7 @@ const propTypes = forbidExtraProps({
   initialMonth: momentPropTypes.momentObj,
   isAnimating: PropTypes.bool,
   numberOfMonths: PropTypes.number,
-  modifiers: PropTypes.object,
+  modifiers: PropTypes.objectOf(PropTypes.objectOf(ModifiersShape)),
   orientation: ScrollableOrientationShape,
   onDayClick: PropTypes.func,
   onDayMouseEnter: PropTypes.func,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -26,6 +26,7 @@ import calculateDimension from '../utils/calculateDimension';
 import getActiveElement from '../utils/getActiveElement';
 import isDayVisible from '../utils/isDayVisible';
 
+import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
@@ -86,7 +87,7 @@ const propTypes = forbidExtraProps({
   renderMonthElement: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),
 
   // day props
-  modifiers: PropTypes.object,
+  modifiers: PropTypes.objectOf(PropTypes.objectOf(ModifiersShape)),
   renderCalendarDay: PropTypes.func,
   renderDayContents: PropTypes.func,
   onDayClick: PropTypes.func,

--- a/src/shapes/ModifiersShape.js
+++ b/src/shapes/ModifiersShape.js
@@ -1,3 +1,20 @@
 import PropTypes from 'prop-types';
+import { and } from 'airbnb-prop-types';
 
-export default PropTypes.instanceOf(Set);
+export default and([
+  PropTypes.instanceOf(Set),
+  function modifiers(props, propName, ...rest) {
+    const { [propName]: propValue } = props;
+    let firstError;
+    [...propValue].some((v, i) => {
+      const fakePropName = `${propName}: index ${i}`;
+      firstError = PropTypes.string.isRequired(
+        { [fakePropName]: v },
+        fakePropName,
+        ...rest,
+      );
+      return firstError != null;
+    });
+    return firstError == null ? null : firstError;
+  },
+], 'Modifiers (Set of Strings)');

--- a/src/shapes/ModifiersShape.js
+++ b/src/shapes/ModifiersShape.js
@@ -1,0 +1,3 @@
+import PropTypes from 'prop-types';
+
+export default PropTypes.instanceOf(Set);


### PR DESCRIPTION
This is related to #1198.

An alternative approach (which I'm happy to change to) would put the `modifiers` Set shape in a separate tiny file, and import it where needed.