### PR TITLE
[test] only run build on most recent node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
   - 'if [ -n "${KARMA-}" ]; then sleep 3; fi'
 script:
   - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
+  - 'if [ -n "${BUILD-}" ]; then npm run lint ; fi'
   - 'if [ "${TEST-}" = true ]; then npm run tests-only ; fi'
   - 'if [ -n "${KARMA-}" ]; then npm run tests-karma ; fi'
   - 'if [ -n "${COVERAGE-}" ] && [ "${TRAVIS_BRANCH-}" = "master" ]; then npm run cover; cat ./coverage/lcov.info | ./node_modules/.bin/coveralls ; fi'
@@ -29,11 +30,13 @@ matrix:
   fast_finish: true
   include:
     - node_js: "lts/*"
+      env: LINT=true TEST=false
+    - node_js: "lts/*"
+      env: BUILD=true TEST=false
+    - node_js: "lts/*"
       env: COVERAGE=true TEST=false
     - node_js: "lts/*"
       env: KARMA=true TEST=false
-    - node_js: "lts/*"
-      env: LINT=true TEST=false
   allow_failures:
     - node_js: "9"
     - node_js: "7"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tests-only": "npm run mocha --silent test",
     "pretests-karma": "npm run react",
     "tests-karma": "karma start",
-    "test": "npm run tests-only",
+    "test": "npm run build && npm run tests-only",
     "storybook": "start-storybook -p 6006",
     "storybook:css": "npm run build:css && start-storybook -p 6006 -c .storybook-css",
     "tag": "git tag v$npm_package_version",


### PR DESCRIPTION
Build script fails if run on Node4. The build really only needs to be run once, and on newest version of node, so we make that change here. 