### PR TITLE
Add date offset functionality to DateRangePicker

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -51,6 +51,8 @@ const defaultProps = {
   // input related props
   startDatePlaceholderText: 'Start Date',
   endDatePlaceholderText: 'End Date',
+  startDateOffset: undefined,
+  endDateOffset: undefined,
   disabled: false,
   required: false,
   readOnly: false,
@@ -402,7 +404,9 @@ class DateRangePicker extends React.PureComponent {
       enableOutsideDays,
       focusedInput,
       startDate,
+      startDateOffset,
       endDate,
+      endDateOffset,
       minimumNights,
       keepOpenOnDateSelect,
       renderCalendarDay,
@@ -479,7 +483,9 @@ class DateRangePicker extends React.PureComponent {
           onClose={onClose}
           focusedInput={focusedInput}
           startDate={startDate}
+          startDateOffset={startDateOffset}
           endDate={endDate}
+          endDateOffset={endDateOffset}
           monthFormat={monthFormat}
           renderMonthText={renderMonthText}
           withPortal={withAnyPortal}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -491,6 +491,10 @@ export default class DayPickerRangeController extends React.PureComponent {
       startDate = getSelectedDateOffset(startDateOffset, day);
       endDate = getSelectedDateOffset(endDateOffset, day);
 
+      if (this.isBlocked(startDate) || this.isBlocked(endDate)) {
+        return;
+      }
+
       if (!keepOpenOnDateSelect) {
         onFocusChange(null);
         onClose({ startDate, endDate });

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -28,6 +28,8 @@ export default {
   // input related props
   startDateId: PropTypes.string.isRequired,
   startDatePlaceholderText: PropTypes.string,
+  startDateOffset: PropTypes.func,
+  endDateOffset: PropTypes.func,
   endDateId: PropTypes.string.isRequired,
   endDatePlaceholderText: PropTypes.string,
   disabled: DisabledShape,

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -59,6 +59,12 @@ storiesOf('DRP - Calendar Props', module)
   .add('3 months', withInfo()(() => (
     <DateRangePickerWrapper numberOfMonths={3} autoFocus />
   )))
+  .add('with 7 days range selection', withInfo()(() => (
+    <DateRangePickerWrapper
+      startDateOffset={day => day.subtract(3, 'days')}
+      endDateOffset={day => day.add(3, 'days')}
+    />
+  )))
   .add('with custom day size', withInfo()(() => (
     <DateRangePickerWrapper daySize={50} autoFocus />
   )))

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -699,4 +699,46 @@ describe('DateRangePicker', () => {
       });
     });
   });
+
+  describe('dateOffsets', () => {
+    describe('startDateOffset is passed in', () => {
+      it('Should pass startDateOffset to DayPickerRangeController', () => {
+        const startDate = moment('2018-10-17');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            startDateOffset={date => date.subtract(5, 'days')}
+            onDatesChange={onDatesChangeStub}
+            focusedInput={START_DATE}
+          />
+        )).dive();
+
+        const dayPicker = wrapper.find(DayPickerRangeController);
+        const dayPickerStartDateOffset = dayPicker.props().startDateOffset(startDate);
+
+        expect(dayPickerStartDateOffset.format()).to.equal(startDate.format());
+      });
+    });
+
+    describe('endDateOffset is passed in', () => {
+      it('Should pass endDateOffset to DayPickerRangeController', () => {
+        const endDate = moment('2018-10-17', 'YYYY-MM-DD');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            endDateOffset={date => date.subtract(5, 'days')}
+            onDatesChange={onDatesChangeStub}
+            focusedInput={START_DATE}
+          />
+        )).dive();
+
+        const dayPicker = wrapper.find(DayPickerRangeController);
+        const dayPickerEndDateOffset = dayPicker.props().endDateOffset(endDate);
+
+        expect(dayPickerEndDateOffset.format()).to.equal(endDate.format());
+      });
+    });
+  });
 });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1563,6 +1563,35 @@ describe('DayPickerRangeController', () => {
         expect(args.endDate.format()).to.equal(clickDate.clone().add(4, 'days').format());
       });
 
+      it('does not call props.onDatesChange with startDate === startDateOffset(date) and endDate === endDateOffset(date)', () => {
+        const clickDate = moment(today).clone().add(2, 'days');
+        const onDatesChangeStub = sinon.spy();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            startDateOffset={day => day.subtract(2, 'days')}
+            endDateOffset={day => day.add(4, 'days')}
+            isOutsideRange={day => day.isAfter(moment(today))}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub).to.have.property('callCount', 0);
+      });
+
+      it('does not call props.onDatesChange when dateOffset isOutsideRange', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            endDateOffset={day => day.add(5, 'days')}
+            isOutsideRange={day => day.isAfter(moment(today).clone().add(1, 'days'))}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub).to.have.property('callCount', 0);
+      });
+
       it('calls props.onDatesChange with startDate === startDateOffset(date) and endDate === selectedDate when endDateOffset not provided', () => {
         const clickDate = moment(today).clone().add(2, 'days');
         const onDatesChangeStub = sinon.stub();


### PR DESCRIPTION
As requested in https://github.com/airbnb/react-dates/issues/1062, this PR passes date offset functionality up to the DateRangePicker.

Tests for date offsets are already included within the DayPickerRangeController spec. 
If tests are required for the additional functionality this adds to the DateRangePicker please point me to the spec and I'll add them, an appropriate file to add these wasn't clear to me. 😅 

I'm happy to discuss the inclusion of this PR.