### PR TITLE
Fix minimum nights availability issue

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -370,29 +370,16 @@ export default class DayPickerRangeController extends React.Component {
       }
     }
 
-    if (minimumNights > 0 && startDate && focusedInput === END_DATE) {
-      modifiers = this.addModifierToRange(
-        modifiers,
-        startDate,
-        startDate.clone().add(minimumNights, 'days'),
-        'blocked-minimum-nights',
-      );
-    }
-
     if (didFocusChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = moment(day);
-
-          if (this.isBlocked(momentObj)) {
-            modifiers = this.addModifier(modifiers, momentObj, 'blocked');
-          } else {
-            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
-          }
+          let isBlocked = false;
 
           if (didFocusChange || recomputeOutsideRange) {
             if (isOutsideRange(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-out-of-range');
+              isBlocked = true;
             } else {
               modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-out-of-range');
             }
@@ -401,9 +388,16 @@ export default class DayPickerRangeController extends React.Component {
           if (didFocusChange || recomputeDayBlocked) {
             if (isDayBlocked(momentObj)) {
               modifiers = this.addModifier(modifiers, momentObj, 'blocked-calendar');
+              isBlocked = true;
             } else {
               modifiers = this.deleteModifier(modifiers, momentObj, 'blocked-calendar');
             }
+          }
+
+          if (isBlocked) {
+            modifiers = this.addModifier(modifiers, momentObj, 'blocked');
+          } else {
+            modifiers = this.deleteModifier(modifiers, momentObj, 'blocked');
           }
 
           if (didFocusChange || recomputeDayHighlighted) {
@@ -415,6 +409,22 @@ export default class DayPickerRangeController extends React.Component {
           }
         });
       });
+    }
+
+    if (minimumNights > 0 && startDate && focusedInput === END_DATE) {
+      modifiers = this.addModifierToRange(
+        modifiers,
+        startDate,
+        startDate.clone().add(minimumNights, 'days'),
+        'blocked-minimum-nights',
+      );
+
+      modifiers = this.addModifierToRange(
+        modifiers,
+        startDate,
+        startDate.clone().add(minimumNights, 'days'),
+        'blocked',
+      );
     }
 
     const today = moment();


### PR DESCRIPTION
Some strange behavior that we noticed on airbnb.com is that after the first render (e.g. when you change focus or change the selected date) on a calendar with minimum nights enabled, while the actual interactivity of the minimum nights days still updates correctly, the aria-label would be the opposite of what was expected. This meant that when the days were grayed out due to not satisfying the minimum nights requirement, the aria label would read them as available and when they were clickable, like when the start date was focused, the aria label would read them as unavailable. 

Digging into this issue, it appeared to be related to how the `'blocked'` modifier was being updated when the state changed. Looking at `componentWillReceiveProps` in the `DayPickerRangeController`, where most of the logic for modifiers lives. 

Specifically, the inconsistency happened when focus changed and would remain thereafter. I think that the minimum nights logic would sometimes remove a 'blocked' modifier or forget to add a 'blocked' modifier unintentionally, which would flip the aria label from available to unavailable.

This change in ordering seems to address the issue.

@ljharb @backwardok @sdjidjev @airbnb/webinfra PTAL