### PR TITLE
Set DayPickerNavigation__horizontal height to 0

### DIFF
--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -191,7 +191,10 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     zIndex: zIndex + 2,
   },
 
-  DayPickerNavigation__horizontal: {},
+  DayPickerNavigation__horizontal: {
+    height: 0,
+  },
+
   DayPickerNavigation__vertical: {},
   DayPickerNavigation__verticalScrollable: {},
 


### PR DESCRIPTION
I ran into a specific edge-case where it turns out that the navigation buttons have an implicit expectation that this value is set to 0. Thus, in an application where there is a top-level line height is set, the navigation and week headers would get shoved down especially when using custom navigation. This change addresses that issue while not affecting existing datepickers. 

<img width="341" alt="screen shot 2018-07-17 at 4 06 39 pm" src="https://user-images.githubusercontent.com/1383861/42850560-0fc8e44c-89dd-11e8-8736-a392a1c80a61.png">

to: @ljharb 