### PR TITLE
Giving internal state 'dateString' first priority for input value.

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -187,7 +187,7 @@ class DateInput extends React.Component {
       theme: { reactDates },
     } = this.props;
 
-    const value = displayValue || dateString || '';
+    const value = dateString || displayValue || '';
     const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     const withFang = showCaret && focused;

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -31,6 +31,16 @@ describe('DateInput', () => {
         expect(wrapper.find('input').props().value).to.equal(DATE_STRING);
       });
 
+      it('props.displayValue overrides dateString when not null', () => {
+        const DATE_STRING = 'foobar';
+        const DISPLAY_VALUE = 'display-value';
+        const wrapper = shallow(<DateInput id="date" />).dive();
+        wrapper.setState({ dateString: DATE_STRING });
+        expect(wrapper.find('input').props().value).to.equal(DATE_STRING);
+        wrapper.setProps({ displayValue: DISPLAY_VALUE });
+        expect(wrapper.find('input').props().value).to.equal(DISPLAY_VALUE);
+      });
+
       describe('props.readOnly is truthy', () => {
         it('sets readOnly', () => {
           const wrapper = shallow(<DateInput id="date" readOnly />).dive();


### PR DESCRIPTION
Resolve #1013 

It's an issue with [react](https://github.com/facebook/react/issues/955) when replacing the entire string value vs internal managed state.

This change will use dateString when the user is typing within the input field and switch over to displayValue when a date is selected via the calendar.