### PR TITLE
Change month nav buttons to be divs with role="button"

### DIFF
--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -115,7 +115,9 @@ function DayPickerNavigation({
       )}
     >
       {!isVerticalScrollable && (
-        <button
+        <div
+          role="button"
+          tabIndex="0"
           {...css(
             styles.DayPickerNavigation_button,
             isDefaultNavPrev && styles.DayPickerNavigation_button__default,
@@ -135,18 +137,23 @@ function DayPickerNavigation({
               ],
             ]),
           )}
-          type="button"
           aria-label={phrases.jumpToPrevMonth}
           onClick={onPrevMonthClick}
+          onKeyUp={(e) => {
+            const { key } = e;
+            if (key === 'Enter' || key === ' ') onPrevMonthClick(e);
+          }}
           onMouseUp={(e) => {
             e.currentTarget.blur();
           }}
         >
           {navPrevIcon}
-        </button>
+        </div>
       )}
 
-      <button
+      <div
+        role="button"
+        tabIndex="0"
         {...css(
           styles.DayPickerNavigation_button,
           isDefaultNavNext && styles.DayPickerNavigation_button__default,
@@ -169,15 +176,18 @@ function DayPickerNavigation({
             ],
           ]),
         )}
-        type="button"
         aria-label={phrases.jumpToNextMonth}
         onClick={onNextMonthClick}
+        onKeyUp={(e) => {
+          const { key } = e;
+          if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+        }}
         onMouseUp={(e) => {
           e.currentTarget.blur();
         }}
       >
         {navNextIcon}
-      </button>
+      </div>
     </div>
   );
 }
@@ -283,11 +293,13 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     height: 19,
     width: 19,
     fill: color.core.grayLight,
+    display: 'block',
   },
 
   DayPickerNavigation_svg__vertical: {
     height: 42,
     width: 42,
     fill: color.text,
+    display: 'block',
   },
 }))(DayPickerNavigation);

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -8,14 +8,14 @@ import { VERTICAL_SCROLLABLE } from '../../src/constants';
 
 describe('DayPickerNavigation', () => {
   describe('#render', () => {
-    it('renders two buttons', () => {
+    it('renders two role="button" divs', () => {
       const wrapper = shallow(<DayPickerNavigation />).dive();
-      expect(wrapper.find('button')).to.have.lengthOf(2);
+      expect(wrapper.find('[role="button"]')).to.have.lengthOf(2);
     });
 
     it('renders one button when vertically scrollable', () => {
       const wrapper = shallow(<DayPickerNavigation orientation={VERTICAL_SCROLLABLE} />).dive();
-      expect(wrapper.find('button')).to.have.lengthOf(1);
+      expect(wrapper.find('[role="button"]')).to.have.lengthOf(1);
     });
   });
 
@@ -24,7 +24,7 @@ describe('DayPickerNavigation', () => {
       const onPrevMonthStub = sinon.stub();
       const prevMonthButton = shallow(<DayPickerNavigation
         onPrevMonthClick={onPrevMonthStub}
-      />).dive().find('button').at(0);
+      />).dive().find('[role="button"]').at(0);
       prevMonthButton.simulate('click');
       expect(onPrevMonthStub).to.have.property('callCount', 1);
     });
@@ -33,7 +33,7 @@ describe('DayPickerNavigation', () => {
       const onNextMonthStub = sinon.stub();
       const nextMonthButton = shallow(<DayPickerNavigation
         onNextMonthClick={onNextMonthStub}
-      />).dive().find('button').at(1);
+      />).dive().find('[role="button"]').at(1);
       nextMonthButton.simulate('click');
       expect(onNextMonthStub).to.have.property('callCount', 1);
     });


### PR DESCRIPTION
Custom month nav buttons are not currently clickable in Firefox. Changing them to divs addresses the problem. This is due to the difference in treatment of button elements by Firefox (absolutely positioned children of <button> elements that are rendered outside of the <button> visually are not interactive).

Separately, this work highlighted the fact that custom month navigation does not currently have a focus ring. That is something not addressed by this commit but which will be investigated in the near future. I have opened an issue here: https://github.com/airbnb/react-dates/issues/1304.

Fixes https://github.com/airbnb/react-dates/issues/1303

to: @ha1ogen @noratarano @ljharb @backwardok @garrettberg