### PR TITLE
Tweak default border color

### DIFF
--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -6,7 +6,7 @@ const core = {
   grayLightest: '#f2f2f2',
 
   borderMedium: '#c4c4c4',
-  border: '#dbdbdb',
+  border: '#ebebeb',
   borderLight: '#e4e7e7',
   borderLighter: '#eceeee',
   borderBright: '#f4f5f5',
@@ -57,7 +57,7 @@ export default {
       background: core.white,
       backgroundDark: '#f2f2f2',
       backgroundFocused: core.white,
-      border: 'rgb(219, 219, 219)',
+      border: core.border,
       text: core.gray,
       textDisabled: core.border,
       textFocused: '#007a87',


### PR DESCRIPTION
## Summary
This is a subtle tweak to border color to better align the `react-dates` input style with Airbnb's brand.

@majapw

## Screenshots

| Before | After | Changes highlighted in red |
| --- | --- | --- |
| ![drp-new](https://user-images.githubusercontent.com/2136754/44131400-a6c6e354-a007-11e8-9e44-241b23459413.png) | ![drp-old](https://user-images.githubusercontent.com/2136754/44131401-a6dea6d8-a007-11e8-8dd0-7df83a45f9ce.png) | ![drp-red](https://user-images.githubusercontent.com/2136754/44131402-a6f690e0-a007-11e8-96f7-7e8922ac2159.png) |
| ![hover-new](https://user-images.githubusercontent.com/2136754/44131403-a7155214-a007-11e8-9d17-2284c52e674d.png) | ![hover-old](https://user-images.githubusercontent.com/2136754/44131404-a73145dc-a007-11e8-94fd-868fa41baf60.png) | ![hover-red](https://user-images.githubusercontent.com/2136754/44131405-a74c1704-a007-11e8-8753-43d819ef06a3.png) |
| ![scroll-new](https://user-images.githubusercontent.com/2136754/44131406-a7707edc-a007-11e8-8322-cf6ccd2d074a.png) | ![scroll-old](https://user-images.githubusercontent.com/2136754/44131408-a79fea1e-a007-11e8-8988-ec9a2e815f15.png) | ![scroll-red](https://user-images.githubusercontent.com/2136754/44131409-a7b7b0a4-a007-11e8-9f3f-a3f98113699e.png) |
