### PR TITLE
Allow different date input formats

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -112,6 +112,7 @@ const defaultProps = {
 
   // internationalization
   displayFormat: () => moment.localeData().longDateFormat('L'),
+  inputFormats: [moment.localeData().longDateFormat('L')],
   monthFormat: 'MMMM YYYY',
   weekDayFormat: 'dd',
   phrases: DateRangePickerPhrases,

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -59,6 +59,7 @@ const propTypes = forbidExtraProps({
   minimumNights: nonNegativeInteger,
   isOutsideRange: PropTypes.func,
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  inputFormats: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
 
   onFocusChange: PropTypes.func,
   onClose: PropTypes.func,
@@ -111,6 +112,7 @@ const defaultProps = {
   minimumNights: 1,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   displayFormat: () => moment.localeData().longDateFormat('L'),
+  inputFormats: () => [moment.localeData().longDateFormat('L')],
 
   onFocusChange() {},
   onClose() {},
@@ -164,7 +166,7 @@ export default class DateRangePickerInputController extends React.Component {
       onDatesChange,
     } = this.props;
 
-    const endDate = toMomentObject(endDateString, this.getDisplayFormat());
+    const endDate = toMomentObject(endDateString, this.getInputFormats());
 
     const isEndDateValid = endDate
       && !isOutsideRange(endDate)
@@ -208,7 +210,7 @@ export default class DateRangePickerInputController extends React.Component {
       disabled,
     } = this.props;
 
-    const startDate = toMomentObject(startDateString, this.getDisplayFormat());
+    const startDate = toMomentObject(startDateString, this.getInputFormats());
     const isEndDateBeforeStartDate = startDate
       && isBeforeDay(endDate, startDate.clone().add(minimumNights, 'days'));
     const isStartDateValid = startDate
@@ -240,6 +242,11 @@ export default class DateRangePickerInputController extends React.Component {
   getDisplayFormat() {
     const { displayFormat } = this.props;
     return typeof displayFormat === 'string' ? displayFormat : displayFormat();
+  }
+
+  getInputFormats() {
+    const { inputFormats } = this.props;
+    return Array.isArray(inputFormats) ? inputFormats : inputFormats();
   }
 
   getDateString(date) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -110,6 +110,7 @@ const defaultProps = {
 
   // internationalization props
   displayFormat: () => moment.localeData().longDateFormat('L'),
+  inputFormats: [moment.localeData().longDateFormat('L')],
   monthFormat: 'MMMM YYYY',
   weekDayFormat: 'dd',
   phrases: SingleDatePickerPhrases,
@@ -191,7 +192,7 @@ class SingleDatePicker extends React.Component {
       onFocusChange,
       onClose,
     } = this.props;
-    const newDate = toMomentObject(dateString, this.getDisplayFormat());
+    const newDate = toMomentObject(dateString, this.getInputFormats());
 
     const isValid = newDate && !isOutsideRange(newDate);
     if (isValid) {
@@ -278,6 +279,11 @@ class SingleDatePicker extends React.Component {
   getDisplayFormat() {
     const { displayFormat } = this.props;
     return typeof displayFormat === 'string' ? displayFormat : displayFormat();
+  }
+
+  getInputFormats() {
+    const { inputFormats } = this.props;
+    return Array.isArray(inputFormats) ? inputFormats : inputFormats();
   }
 
   setDayPickerContainerRef(ref) {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -88,6 +88,7 @@ export default {
 
   // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  inputFormats: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   monthFormat: PropTypes.string,
   weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(DateRangePickerPhrases)),

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -82,6 +82,7 @@ export default {
 
   // internationalization props
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  inputFormats: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.string), PropTypes.func]),
   monthFormat: PropTypes.string,
   weekDayFormat: PropTypes.string,
   phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerPhrases)),

--- a/src/utils/toISODateString.js
+++ b/src/utils/toISODateString.js
@@ -5,7 +5,9 @@ import toMomentObject from './toMomentObject';
 import { ISO_FORMAT } from '../constants';
 
 export default function toISODateString(date, currentFormat) {
-  const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
+  const dateObj = moment.isMoment(date)
+    ? date
+    : toMomentObject(date, currentFormat ? [currentFormat] : undefined);
   if (!dateObj) return null;
 
   return dateObj.format(ISO_FORMAT);

--- a/src/utils/toISOMonthString.js
+++ b/src/utils/toISOMonthString.js
@@ -5,7 +5,9 @@ import toMomentObject from './toMomentObject';
 import { ISO_MONTH_FORMAT } from '../constants';
 
 export default function toISOMonthString(date, currentFormat) {
-  const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
+  const dateObj = moment.isMoment(date)
+    ? date
+    : toMomentObject(date, currentFormat ? [currentFormat] : undefined);
   if (!dateObj) return null;
 
   return dateObj.format(ISO_MONTH_FORMAT);

--- a/src/utils/toLocalizedDateString.js
+++ b/src/utils/toLocalizedDateString.js
@@ -5,7 +5,9 @@ import toMomentObject from './toMomentObject';
 import { DISPLAY_FORMAT } from '../constants';
 
 export default function toLocalizedDateString(date, currentFormat) {
-  const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
+  const dateObj = moment.isMoment(date)
+    ? date
+    : toMomentObject(date, currentFormat ? [currentFormat] : undefined);
   if (!dateObj) return null;
 
   return dateObj.format(DISPLAY_FORMAT);

--- a/src/utils/toMomentObject.js
+++ b/src/utils/toMomentObject.js
@@ -2,9 +2,9 @@ import moment from 'moment';
 
 import { DISPLAY_FORMAT, ISO_FORMAT } from '../constants';
 
-export default function toMomentObject(dateString, customFormat) {
-  const dateFormats = customFormat
-    ? [customFormat, DISPLAY_FORMAT, ISO_FORMAT]
+export default function toMomentObject(dateString, customFormats) {
+  const dateFormats = customFormats
+    ? [...customFormats, DISPLAY_FORMAT, ISO_FORMAT]
     : [DISPLAY_FORMAT, ISO_FORMAT];
 
   const date = moment(dateString, dateFormats, true);

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -295,14 +295,14 @@ describe('DateRangePickerInputController', () => {
       });
     });
 
-    describe('matches custom display format', () => {
+    describe('matches custom input format', () => {
       const customFormat = 'YY|MM[foobar]DD';
       const customFormatDateString = moment(today).add(5, 'days').format(customFormat);
       it('calls props.onDatesChange with correct arguments', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDatesChange={onDatesChangeStub}
           />
         ));
@@ -319,7 +319,7 @@ describe('DateRangePickerInputController', () => {
           const onFocusChangeStub = sinon.stub();
           const wrapper = shallow((
             <DateRangePickerInputController
-              displayFormat={customFormat}
+              inputFormats={[customFormat]}
               onFocusChange={onFocusChangeStub}
             />
           ));
@@ -331,7 +331,7 @@ describe('DateRangePickerInputController', () => {
           const onFocusChangeStub = sinon.stub();
           const wrapper = shallow((
             <DateRangePickerInputController
-              displayFormat={customFormat}
+              inputFormats={[customFormat]}
               onFocusChange={onFocusChangeStub}
             />
           ));
@@ -626,14 +626,14 @@ describe('DateRangePickerInputController', () => {
       });
     });
 
-    describe('matches custom display format', () => {
+    describe('matches custom input format', () => {
       const customFormat = 'YY|MM[foobar]DD';
       const customFormatDateString = moment(today).add(5, 'days').format(customFormat);
       it('calls props.onDatesChange with correct arguments', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDatesChange={onDatesChangeStub}
           />
         ));
@@ -650,7 +650,7 @@ describe('DateRangePickerInputController', () => {
           const onFocusChangeStub = sinon.stub();
           const wrapper = shallow((
             <DateRangePickerInputController
-              displayFormat={customFormat}
+              inputFormats={[customFormat]}
               onFocusChange={onFocusChangeStub}
             />
           ));
@@ -662,7 +662,7 @@ describe('DateRangePickerInputController', () => {
           const onFocusChangeStub = sinon.stub();
           const wrapper = shallow((
             <DateRangePickerInputController
-              displayFormat={customFormat}
+              inputFormats={[customFormat]}
               onFocusChange={onFocusChangeStub}
             />
           ));

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -293,7 +293,7 @@ describe('SingleDatePicker', () => {
       });
     });
 
-    describe('matches custom display format', () => {
+    describe('matches custom input format', () => {
       const customFormat = 'YY|MM[foobar]DD';
       const customFormatDateString = moment().add(5, 'days').format(customFormat);
       it('calls props.onDateChange once', () => {
@@ -301,7 +301,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow((
           <SingleDatePicker
             id="date"
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDateChange={onDateChangeStub}
             onFocusChange={() => {}}
           />
@@ -315,7 +315,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow((
           <SingleDatePicker
             id="date"
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDateChange={onDateChangeStub}
             onFocusChange={() => {}}
           />
@@ -330,7 +330,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow((
           <SingleDatePicker
             id="date"
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDateChange={() => {}}
             onFocusChange={onFocusChangeStub}
           />
@@ -344,7 +344,7 @@ describe('SingleDatePicker', () => {
         const wrapper = shallow((
           <SingleDatePicker
             id="date"
-            displayFormat={customFormat}
+            inputFormats={[customFormat]}
             onDateChange={() => {}}
             onFocusChange={onFocusChangeStub}
           />

--- a/test/utils/toMomentObject_spec.js
+++ b/test/utils/toMomentObject_spec.js
@@ -26,7 +26,16 @@ describe('toMomentObject', () => {
   });
 
   it('parses custom format', () => {
-    const date = toMomentObject('1991---13/07', 'YYYY---DD/MM');
+    const date = toMomentObject('1991---13/07', ['YYYY---DD/MM']);
+
+    expect(date).not.to.equal(null);
+    expect(date.month()).to.equal(6); // moment months are zero-indexed
+    expect(date.date()).to.equal(13);
+    expect(date.year()).to.equal(1991);
+  });
+
+  it('parses custom format matching second input', () => {
+    const date = toMomentObject('1991---13/07', ['YYYY[test]DD/MM', 'YYYY---DD/MM']);
 
     expect(date).not.to.equal(null);
     expect(date.month()).to.equal(6); // moment months are zero-indexed


### PR DESCRIPTION
Allows specifying multiple acceptable input formats so users can manually add dates. For example, both dates in the DD.MM.YYYY, D.M.YYYY and D.M.YY format could be accepted.  Provides a simple implementation for the feature requested in #345 