### PR TITLE
Changing border-styles to minimize border overlapping

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -185,7 +185,7 @@ export default withStyles(({ reactDates: { color, font } }) => ({
 
     ':hover': {
       background: color.core.borderLight,
-      border: `1px double ${color.core.borderLight}`,
+      border: `1px solid ${color.core.borderLight}`,
       color: 'inherit',
     },
   },
@@ -239,58 +239,62 @@ export default withStyles(({ reactDates: { color, font } }) => ({
 
   CalendarDay__selected_span: {
     background: color.selectedSpan.backgroundColor,
-    border: `1px solid ${color.selectedSpan.borderColor}`,
+    border: `1px double ${color.selectedSpan.borderColor}`,
     color: color.selectedSpan.color,
 
     ':hover': {
       background: color.selectedSpan.backgroundColor_hover,
-      border: `1px solid ${color.selectedSpan.borderColor}`,
+      border: `1px double ${color.selectedSpan.borderColor}`,
       color: color.selectedSpan.color_active,
     },
 
     ':active': {
       background: color.selectedSpan.backgroundColor_active,
-      border: `1px solid ${color.selectedSpan.borderColor}`,
+      border: `1px double ${color.selectedSpan.borderColor}`,
       color: color.selectedSpan.color_active,
     },
   },
 
   CalendarDay__last_in_range: {
-    borderRight: color.core.primary,
+    borderStyle: 'solid',
+
+    ':hover': {
+      borderStyle: 'solid',
+    },
   },
 
   CalendarDay__selected: {
     background: color.selected.backgroundColor,
-    border: `1px solid ${color.selected.borderColor}`,
+    border: `1px double ${color.selected.borderColor}`,
     color: color.selected.color,
 
     ':hover': {
       background: color.selected.backgroundColor_hover,
-      border: `1px solid ${color.selected.borderColor}`,
+      border: `1px double ${color.selected.borderColor}`,
       color: color.selected.color_active,
     },
 
     ':active': {
       background: color.selected.backgroundColor_active,
-      border: `1px solid ${color.selected.borderColor}`,
+      border: `1px double ${color.selected.borderColor}`,
       color: color.selected.color_active,
     },
   },
 
   CalendarDay__hovered_span: {
     background: color.hoveredSpan.backgroundColor,
-    border: `1px solid ${color.hoveredSpan.borderColor}`,
+    border: `1px double ${color.hoveredSpan.borderColor}`,
     color: color.hoveredSpan.color,
 
     ':hover': {
       background: color.hoveredSpan.backgroundColor_hover,
-      border: `1px solid ${color.hoveredSpan.borderColor}`,
+      border: `1px double ${color.hoveredSpan.borderColor}`,
       color: color.hoveredSpan.color_active,
     },
 
     ':active': {
       background: color.hoveredSpan.backgroundColor_active,
-      border: `1px solid ${color.hoveredSpan.borderColor}`,
+      border: `1px double ${color.hoveredSpan.borderColor}`,
       color: color.hoveredSpan.color_active,
     },
   },

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -81,7 +81,7 @@ export const defaultStyles = {
 
   hover: {
     background: color.core.borderLight,
-    border: `1px double ${color.core.borderLight}`,
+    border: `1px solid ${color.core.borderLight}`,
     color: 'inherit',
   },
 };
@@ -139,40 +139,44 @@ export const blockedOutOfRangeStyles = {
 
 export const hoveredSpanStyles = {
   background: color.hoveredSpan.backgroundColor,
-  border: `1px solid ${color.hoveredSpan.borderColor}`,
+  border: `1px double ${color.hoveredSpan.borderColor}`,
   color: color.hoveredSpan.color,
 
   hover: {
     background: color.hoveredSpan.backgroundColor_hover,
-    border: `1px solid ${color.hoveredSpan.borderColor}`,
+    border: `1px double ${color.hoveredSpan.borderColor}`,
     color: color.hoveredSpan.color_active,
   },
 };
 
 export const selectedSpanStyles = {
   background: color.selectedSpan.backgroundColor,
-  border: `1px solid ${color.selectedSpan.borderColor}`,
+  border: `1px double ${color.selectedSpan.borderColor}`,
   color: color.selectedSpan.color,
 
   hover: {
     background: color.selectedSpan.backgroundColor_hover,
-    border: `1px solid ${color.selectedSpan.borderColor}`,
+    border: `1px double ${color.selectedSpan.borderColor}`,
     color: color.selectedSpan.color_active,
   },
 };
 
 export const lastInRangeStyles = {
-  borderRight: color.core.primary,
+  borderStyle: 'solid',
+
+  hover: {
+    borderStyle: 'solid',
+  },
 };
 
 export const selectedStyles = {
   background: color.selected.backgroundColor,
-  border: `1px solid ${color.selected.borderColor}`,
+  border: `1px double ${color.selected.borderColor}`,
   color: color.selected.color,
 
   hover: {
     background: color.selected.backgroundColor_hover,
-    border: `1px solid ${color.selected.borderColor}`,
+    border: `1px double ${color.selected.borderColor}`,
     color: color.selected.color_active,
   },
 };


### PR DESCRIPTION
Fixing some funky issues with the border-style, here's a before/after screenshot explaining the differences

## Before (Live)
- Border of the hovered day overlaps border of the selected range (making the date box look taller)
- Top border of bottom left 3 selected in range does not have the selected color
- Top border of the second day in range is incorrect (making it look a pixel shorter than the first day)
- Last day has a border to the left (making it a pixel thinner than the first day)
![screen shot 2018-08-28 at 19 58 54](https://user-images.githubusercontent.com/16815919/44744571-5c7ddb80-aafd-11e8-9b61-02c8cdac001b.png)

## After
- All days in range have the correct border color
- Hovered day now does not overlap the selection
- Last day now takes full width 
![screen shot 2018-08-28 at 19 59 26](https://user-images.githubusercontent.com/16815919/44744764-c5655380-aafd-11e8-9079-8ade2663c10e.png)


