### PR TITLE
Conditionally use `PureComponent` instead of `Component`

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,6 @@
 import React from 'react';
 if (process.env.NODE_ENV !== 'production') {
-  const {whyDidYouUpdate} = require('why-did-you-update');
+  const { whyDidYouUpdate } = require('why-did-you-update');
   whyDidYouUpdate(React);
 }
 

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,9 @@
 import React from 'react';
+if (process.env.NODE_ENV !== 'production') {
+  const {whyDidYouUpdate} = require('why-did-you-update');
+  whyDidYouUpdate(React);
+}
+
 import moment from 'moment';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Create a CSS file with the contents of `require.resolve('react-dates/lib/css/_da
 
 To see this in action, you can check out https://github.com/majapw/react-dates-demo which adds `react-dates` on top of a simple `create-react-app` setup.
 
+#### Overriding Base Class
+By default `react-dates` will use `PureComponent` conditionally if it is available.  However, it is possible to override this setting and use `Component` and `shouldComponentUpdate` instead. It is also possible to override the logic in `build/util/baseClass` if you know that you are using a React version with `PureComponent`.
+  ```javascript
+    import React from 'react';
+    export default React.PureComponent;
+    export const pureComponentAvailable = true;
+  ```
+
 #### Overriding styles
 Right now, the easiest way to tweak `react-dates` to your heart's content is to create another stylesheet to override the default react-dates styles. For example, you could create a file named `react_dates_overrides.css` with the following contents:
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "sinon": "^6.1.5",
     "sinon-sandbox": "^2.0.0",
     "style-loader": "^0.20.3",
-    "webpack": "^2.6.1"
+    "webpack": "^2.6.1",
+    "why-did-you-update": "^0.1.1"
   },
   "dependencies": {
     "airbnb-prop-types": "^2.10.0",

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -10,6 +9,7 @@ import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
 import ModifiersShape from '../shapes/ModifiersShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import { DAY_SIZE } from '../constants';
 
@@ -48,15 +48,13 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-class CalendarDay extends React.Component {
+const BaseClass = baseClass();
+
+class CalendarDay extends BaseClass {
   constructor(...args) {
     super(...args);
 
     this.setButtonRef = this.setButtonRef.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {
@@ -339,4 +337,4 @@ export default withStyles(({ reactDates: { color, font } }) => ({
   CalendarDay__today: {},
   CalendarDay__firstDayOfWeek: {},
   CalendarDay__lastDayOfWeek: {},
-}))(CalendarDay);
+}), { pureComponent: pureComponentAvailable })(CalendarDay);

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -48,9 +48,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-const BaseClass = baseClass();
-
-class CalendarDay extends BaseClass {
+class CalendarDay extends baseClass() {
   constructor(...args) {
     super(...args);
 
@@ -337,4 +335,4 @@ export default withStyles(({ reactDates: { color, font } }) => ({
   CalendarDay__today: {},
   CalendarDay__firstDayOfWeek: {},
   CalendarDay__lastDayOfWeek: {},
-}), { pureComponent: pureComponentAvailable })(CalendarDay);
+}), { pureComponent: pureComponentAvailable() })(CalendarDay);

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -48,6 +48,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
+/** @extends React.Component */
 class CalendarDay extends baseClass() {
   constructor(...args) {
     super(...args);

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -9,7 +9,7 @@ import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
 import ModifiersShape from '../shapes/ModifiersShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import { DAY_SIZE } from '../constants';
 
@@ -49,7 +49,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class CalendarDay extends baseClass() {
+class CalendarDay extends BaseClass {
   constructor(...args) {
     super(...args);
 
@@ -336,4 +336,4 @@ export default withStyles(({ reactDates: { color, font } }) => ({
   CalendarDay__today: {},
   CalendarDay__firstDayOfWeek: {},
   CalendarDay__lastDayOfWeek: {},
-}), { pureComponent: pureComponentAvailable() })(CalendarDay);
+}), { pureComponent: pureComponentAvailable })(CalendarDay);

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -21,7 +21,7 @@ import toISODateString from '../utils/toISODateString';
 import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -91,7 +91,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class CalendarMonth extends baseClass() {
+class CalendarMonth extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -274,4 +274,4 @@ export default withStyles(({ reactDates: { color, font, spacing } }) => ({
     paddingTop: 12,
     paddingBottom: 7,
   },
-}), { pureComponent: pureComponentAvailable() })(CalendarMonth);
+}), { pureComponent: pureComponentAvailable })(CalendarMonth);

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -90,6 +90,7 @@ const defaultProps = {
   verticalBorderSpacing: undefined,
 };
 
+/** @extends React.Component */
 class CalendarMonth extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -90,9 +90,7 @@ const defaultProps = {
   verticalBorderSpacing: undefined,
 };
 
-const BaseClass = baseClass();
-
-class CalendarMonth extends BaseClass {
+class CalendarMonth extends baseClass() {
   constructor(props) {
     super(props);
 
@@ -275,4 +273,4 @@ export default withStyles(({ reactDates: { color, font, spacing } }) => ({
     paddingTop: 12,
     paddingBottom: 7,
   },
-}), { pureComponent: pureComponentAvailable })(CalendarMonth);
+}), { pureComponent: pureComponentAvailable() })(CalendarMonth);

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -22,6 +21,7 @@ import toISODateString from '../utils/toISODateString';
 import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -90,7 +90,9 @@ const defaultProps = {
   verticalBorderSpacing: undefined,
 };
 
-class CalendarMonth extends React.Component {
+const BaseClass = baseClass();
+
+class CalendarMonth extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -130,10 +132,6 @@ class CalendarMonth extends React.Component {
         ),
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillUnmount() {
@@ -277,4 +275,4 @@ export default withStyles(({ reactDates: { color, font, spacing } }) => ({
     paddingTop: 12,
     paddingBottom: 7,
   },
-}))(CalendarMonth);
+}), { pureComponent: pureComponentAvailable })(CalendarMonth);

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -22,6 +21,7 @@ import isNextMonth from '../utils/isNextMonth';
 import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -114,7 +114,9 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
   return months;
 }
 
-class CalendarMonthGrid extends React.Component {
+const BaseClass = baseClass();
+
+class CalendarMonthGrid extends BaseClass {
   constructor(props) {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
@@ -178,10 +180,6 @@ class CalendarMonthGrid extends React.Component {
     this.setState({
       months: newMonths,
     });
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate() {
@@ -425,4 +423,4 @@ export default withStyles(({
   CalendarMonthGrid_month__hidden: {
     visibility: 'hidden',
   },
-}))(CalendarMonthGrid);
+}), { pureComponent: pureComponentAvailable })(CalendarMonthGrid);

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -21,7 +21,7 @@ import isNextMonth from '../utils/isNextMonth';
 import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -115,7 +115,7 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
 }
 
 /** @extends React.Component */
-class CalendarMonthGrid extends baseClass() {
+class CalendarMonthGrid extends BaseClass {
   constructor(props) {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
@@ -422,4 +422,4 @@ export default withStyles(({
   CalendarMonthGrid_month__hidden: {
     visibility: 'hidden',
   },
-}), { pureComponent: pureComponentAvailable() })(CalendarMonthGrid);
+}), { pureComponent: pureComponentAvailable })(CalendarMonthGrid);

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -114,9 +114,7 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
   return months;
 }
 
-const BaseClass = baseClass();
-
-class CalendarMonthGrid extends BaseClass {
+class CalendarMonthGrid extends baseClass() {
   constructor(props) {
     super(props);
     const withoutTransitionMonths = props.orientation === VERTICAL_SCROLLABLE;
@@ -423,4 +421,4 @@ export default withStyles(({
   CalendarMonthGrid_month__hidden: {
     visibility: 'hidden',
   },
-}), { pureComponent: pureComponentAvailable })(CalendarMonthGrid);
+}), { pureComponent: pureComponentAvailable() })(CalendarMonthGrid);

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -114,6 +114,7 @@ function getMonths(initialMonth, numberOfMonths, withoutTransitionMonths) {
   return months;
 }
 
+/** @extends React.Component */
 class CalendarMonthGrid extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger, or } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
@@ -9,6 +8,7 @@ import moment from 'moment';
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import { DAY_SIZE } from '../constants';
 import DefaultTheme from '../theme/DefaultTheme';
@@ -212,7 +212,9 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-class CustomizableCalendarDay extends React.Component {
+const BaseClass = baseClass();
+
+class CustomizableCalendarDay extends BaseClass {
   constructor(...args) {
     super(...args);
 
@@ -221,10 +223,6 @@ class CustomizableCalendarDay extends React.Component {
     };
 
     this.setButtonRef = this.setButtonRef.bind(this);
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {
@@ -369,4 +367,4 @@ export default withStyles(({ reactDates: { font } }) => ({
   CalendarDay__defaultCursor: {
     cursor: 'default',
   },
-}))(CustomizableCalendarDay);
+}), { pureComponent: pureComponentAvailable })(CustomizableCalendarDay);

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -212,6 +212,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
+/** @extends React.Component */
 class CustomizableCalendarDay extends baseClass() {
   constructor(...args) {
     super(...args);

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -8,7 +8,7 @@ import moment from 'moment';
 import { CalendarDayPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import { DAY_SIZE } from '../constants';
 import DefaultTheme from '../theme/DefaultTheme';
@@ -213,7 +213,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class CustomizableCalendarDay extends baseClass() {
+class CustomizableCalendarDay extends BaseClass {
   constructor(...args) {
     super(...args);
 
@@ -366,4 +366,4 @@ export default withStyles(({ reactDates: { font } }) => ({
   CalendarDay__defaultCursor: {
     cursor: 'default',
   },
-}), { pureComponent: pureComponentAvailable() })(CustomizableCalendarDay);
+}), { pureComponent: pureComponentAvailable })(CustomizableCalendarDay);

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -212,9 +212,7 @@ const defaultProps = {
   phrases: CalendarDayPhrases,
 };
 
-const BaseClass = baseClass();
-
-class CustomizableCalendarDay extends BaseClass {
+class CustomizableCalendarDay extends baseClass() {
   constructor(...args) {
     super(...args);
 
@@ -367,4 +365,4 @@ export default withStyles(({ reactDates: { font } }) => ({
   CalendarDay__defaultCursor: {
     cursor: 'default',
   },
-}), { pureComponent: pureComponentAvailable })(CustomizableCalendarDay);
+}), { pureComponent: pureComponentAvailable() })(CustomizableCalendarDay);

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -7,6 +7,7 @@ import isTouchDevice from 'is-touch-device';
 
 import getInputHeight from '../utils/getInputHeight';
 import openDirectionShape from '../shapes/OpenDirectionShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 import {
   OPEN_DOWN,
   OPEN_UP,
@@ -77,7 +78,9 @@ const defaultProps = {
   isFocused: false,
 };
 
-class DateInput extends React.Component {
+const BaseClass = baseClass();
+
+class DateInput extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -379,4 +382,4 @@ export default withStyles(({
     stroke: color.core.border,
     fill: 'transparent',
   },
-}))(DateInput);
+}), { pureComponent: pureComponentAvailable })(DateInput);

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -78,9 +78,7 @@ const defaultProps = {
   isFocused: false,
 };
 
-const BaseClass = baseClass();
-
-class DateInput extends BaseClass {
+class DateInput extends baseClass() {
   constructor(props) {
     super(props);
 
@@ -382,4 +380,4 @@ export default withStyles(({
     stroke: color.core.border,
     fill: 'transparent',
   },
-}), { pureComponent: pureComponentAvailable })(DateInput);
+}), { pureComponent: pureComponentAvailable() })(DateInput);

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -78,6 +78,7 @@ const defaultProps = {
   isFocused: false,
 };
 
+/** @extends React.Component */
 class DateInput extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -7,7 +7,7 @@ import isTouchDevice from 'is-touch-device';
 
 import getInputHeight from '../utils/getInputHeight';
 import openDirectionShape from '../shapes/OpenDirectionShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 import {
   OPEN_DOWN,
   OPEN_UP,
@@ -79,7 +79,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class DateInput extends baseClass() {
+class DateInput extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -381,4 +381,4 @@ export default withStyles(({
     stroke: color.core.border,
     fill: 'transparent',
   },
-}), { pureComponent: pureComponentAvailable() })(DateInput);
+}), { pureComponent: pureComponentAvailable })(DateInput);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
 import moment from 'moment';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
@@ -16,6 +15,7 @@ import getDetachedContainerStyles from '../utils/getDetachedContainerStyles';
 import getInputHeight from '../utils/getInputHeight';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import disableScroll from '../utils/disableScroll';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import DateRangePickerInputController from './DateRangePickerInputController';
 import DayPickerRangeController from './DayPickerRangeController';
@@ -118,7 +118,9 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-class DateRangePicker extends React.Component {
+const BaseClass = baseClass();
+
+class DateRangePicker extends BaseClass {
   constructor(props) {
     super(props);
     this.state = {
@@ -161,10 +163,6 @@ class DateRangePicker extends React.Component {
     }
 
     this.isTouchDevice = isTouchDevice();
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentDidUpdate(prevProps) {
@@ -674,4 +672,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}))(DateRangePicker);
+}), { pureComponent: pureComponentAvailable })(DateRangePicker);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -118,9 +118,7 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-const BaseClass = baseClass();
-
-class DateRangePicker extends BaseClass {
+class DateRangePicker extends baseClass() {
   constructor(props) {
     super(props);
     this.state = {
@@ -672,4 +670,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}), { pureComponent: pureComponentAvailable })(DateRangePicker);
+}), { pureComponent: pureComponentAvailable() })(DateRangePicker);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -118,6 +118,7 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
+/** @extends React.Component */
 class DateRangePicker extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -15,7 +15,7 @@ import getDetachedContainerStyles from '../utils/getDetachedContainerStyles';
 import getInputHeight from '../utils/getInputHeight';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import disableScroll from '../utils/disableScroll';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import DateRangePickerInputController from './DateRangePickerInputController';
 import DayPickerRangeController from './DayPickerRangeController';
@@ -119,7 +119,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class DateRangePicker extends baseClass() {
+class DateRangePicker extends BaseClass {
   constructor(props) {
     super(props);
     this.state = {
@@ -671,4 +671,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}), { pureComponent: pureComponentAvailable() })(DateRangePicker);
+}), { pureComponent: pureComponentAvailable })(DateRangePicker);

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -397,4 +397,4 @@ export default withStyles(({ reactDates: { border, color, sizing } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}), { pureComponent: pureComponentAvailable() })(DateRangePickerInput);
+}), { pureComponent: pureComponentAvailable })(DateRangePickerInput);

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -10,6 +10,7 @@ import openDirectionShape from '../shapes/OpenDirectionShape';
 import DateInput from './DateInput';
 import IconPositionShape from '../shapes/IconPositionShape';
 import DisabledShape from '../shapes/DisabledShape';
+import { pureComponentAvailable } from '../utils/baseClass';
 
 import RightArrow from './RightArrow';
 import LeftArrow from './LeftArrow';
@@ -396,4 +397,4 @@ export default withStyles(({ reactDates: { border, color, sizing } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}))(DateRangePickerInput);
+}), { pureComponent: pureComponentAvailable })(DateRangePickerInput);

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -397,4 +397,4 @@ export default withStyles(({ reactDates: { border, color, sizing } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}), { pureComponent: pureComponentAvailable })(DateRangePickerInput);
+}), { pureComponent: pureComponentAvailable() })(DateRangePickerInput);

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -133,9 +133,7 @@ const defaultProps = {
   isRTL: false,
 };
 
-const BaseClass = baseClass();
-
-export default class DateRangePickerInputController extends BaseClass {
+export default class DateRangePickerInputController extends baseClass() {
   constructor(props) {
     super(props);
 

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -133,6 +133,7 @@ const defaultProps = {
   isRTL: false,
 };
 
+/** @extends React.Component */
 export default class DateRangePickerInputController extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -20,7 +20,7 @@ import toLocalizedDateString from '../utils/toLocalizedDateString';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isBeforeDay from '../utils/isBeforeDay';
 
-import baseClass from '../utils/baseClass';
+import BaseClass from '../utils/baseClass';
 
 import {
   START_DATE,
@@ -134,7 +134,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-export default class DateRangePickerInputController extends baseClass() {
+export default class DateRangePickerInputController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -20,6 +20,8 @@ import toLocalizedDateString from '../utils/toLocalizedDateString';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import isBeforeDay from '../utils/isBeforeDay';
 
+import baseClass from '../utils/baseClass';
+
 import {
   START_DATE,
   END_DATE,
@@ -131,7 +133,9 @@ const defaultProps = {
   isRTL: false,
 };
 
-export default class DateRangePickerInputController extends React.Component {
+const BaseClass = baseClass();
+
+export default class DateRangePickerInputController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -163,9 +163,7 @@ export const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-const BaseClass = baseClass();
-
-class DayPicker extends BaseClass {
+class DayPicker extends baseClass() {
   constructor(props) {
     super(props);
 
@@ -1239,4 +1237,4 @@ export default withStyles(({
       },
     }),
   },
-}), { pureComponent: pureComponentAvailable })(DayPicker);
+}), { pureComponent: pureComponentAvailable() })(DayPicker);

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -163,6 +163,7 @@ export const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
+/** @extends React.Component */
 class DayPicker extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -29,7 +29,7 @@ import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -164,7 +164,7 @@ export const defaultProps = {
 };
 
 /** @extends React.Component */
-class DayPicker extends baseClass() {
+class DayPicker extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -1238,4 +1238,4 @@ export default withStyles(({
       },
     }),
   },
-}), { pureComponent: pureComponentAvailable() })(DayPicker);
+}), { pureComponent: pureComponentAvailable })(DayPicker);

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import shallowCompare from 'react-addons-shallow-compare';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
@@ -30,6 +29,7 @@ import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -163,7 +163,9 @@ export const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-class DayPicker extends React.Component {
+const BaseClass = baseClass();
+
+class DayPicker extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -297,10 +299,6 @@ class DayPicker extends React.Component {
         monthTitleHeight: null,
       });
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
   }
 
   componentWillUpdate() {
@@ -1241,4 +1239,4 @@ export default withStyles(({
       },
     }),
   },
-}))(DayPicker);
+}), { pureComponent: pureComponentAvailable })(DayPicker);

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -73,9 +73,7 @@ function getKeyboardShortcuts(phrases) {
   ];
 }
 
-const BaseClass = baseClass();
-
-class DayPickerKeyboardShortcuts extends BaseClass {
+class DayPickerKeyboardShortcuts extends baseClass() {
   constructor(...args) {
     super(...args);
 
@@ -397,4 +395,4 @@ export default withStyles(({ reactDates: { color, font, zIndex } }) => ({
       fill: color.core.grayLight,
     },
   },
-}), { pureComponent: pureComponentAvailable })(DayPickerKeyboardShortcuts);
+}), { pureComponent: pureComponentAvailable() })(DayPickerKeyboardShortcuts);

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -73,6 +73,7 @@ function getKeyboardShortcuts(phrases) {
   ];
 }
 
+/** @extends React.Component */
 class DayPickerKeyboardShortcuts extends baseClass() {
   constructor(...args) {
     super(...args);

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -5,7 +5,7 @@ import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import KeyboardShortcutRow from './KeyboardShortcutRow';
 import CloseButton from './CloseButton';
@@ -74,7 +74,7 @@ function getKeyboardShortcuts(phrases) {
 }
 
 /** @extends React.Component */
-class DayPickerKeyboardShortcuts extends baseClass() {
+class DayPickerKeyboardShortcuts extends BaseClass {
   constructor(...args) {
     super(...args);
 
@@ -396,4 +396,4 @@ export default withStyles(({ reactDates: { color, font, zIndex } }) => ({
       fill: color.core.grayLight,
     },
   },
-}), { pureComponent: pureComponentAvailable() })(DayPickerKeyboardShortcuts);
+}), { pureComponent: pureComponentAvailable })(DayPickerKeyboardShortcuts);

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -5,6 +5,7 @@ import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import KeyboardShortcutRow from './KeyboardShortcutRow';
 import CloseButton from './CloseButton';
@@ -72,7 +73,9 @@ function getKeyboardShortcuts(phrases) {
   ];
 }
 
-class DayPickerKeyboardShortcuts extends React.Component {
+const BaseClass = baseClass();
+
+class DayPickerKeyboardShortcuts extends BaseClass {
   constructor(...args) {
     super(...args);
 
@@ -394,4 +397,4 @@ export default withStyles(({ reactDates: { color, font, zIndex } }) => ({
       fill: color.core.grayLight,
     },
   },
-}))(DayPickerKeyboardShortcuts);
+}), { pureComponent: pureComponentAvailable })(DayPickerKeyboardShortcuts);

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -5,6 +5,7 @@ import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerNavigationPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import { pureComponentAvailable } from '../utils/baseClass';
 
 import LeftArrow from './LeftArrow';
 import RightArrow from './RightArrow';
@@ -302,4 +303,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     fill: color.text,
     display: 'block',
   },
-}))(DayPickerNavigation);
+}), { pureComponent: pureComponentAvailable })(DayPickerNavigation);

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -303,4 +303,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     fill: color.text,
     display: 'block',
   },
-}), { pureComponent: pureComponentAvailable() })(DayPickerNavigation);
+}), { pureComponent: pureComponentAvailable })(DayPickerNavigation);

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -303,4 +303,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     fill: color.text,
     display: 'block',
   },
-}), { pureComponent: pureComponentAvailable })(DayPickerNavigation);
+}), { pureComponent: pureComponentAvailable() })(DayPickerNavigation);

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -174,6 +174,7 @@ const getChooseAvailableDatePhrase = (phrases, focusedInput) => {
   return phrases.chooseAvailableDate;
 };
 
+/** @extends React.Component */
 export default class DayPickerRangeController extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -28,7 +28,7 @@ import FocusedInputShape from '../shapes/FocusedInputShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
-import baseClass from '../utils/baseClass';
+import BaseClass from '../utils/baseClass';
 
 import {
   START_DATE,
@@ -175,7 +175,7 @@ const getChooseAvailableDatePhrase = (phrases, focusedInput) => {
 };
 
 /** @extends React.Component */
-export default class DayPickerRangeController extends baseClass() {
+export default class DayPickerRangeController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -28,7 +28,7 @@ import FocusedInputShape from '../shapes/FocusedInputShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import baseClass from '../utils/baseClass';
 
 import {
   START_DATE,
@@ -174,9 +174,7 @@ const getChooseAvailableDatePhrase = (phrases, focusedInput) => {
   return phrases.chooseAvailableDate;
 };
 
-const BaseClass = baseClass();
-
-export default class DayPickerRangeController extends BaseClass {
+export default class DayPickerRangeController extends baseClass() {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -28,6 +28,7 @@ import FocusedInputShape from '../shapes/FocusedInputShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import {
   START_DATE,
@@ -173,7 +174,9 @@ const getChooseAvailableDatePhrase = (phrases, focusedInput) => {
   return phrases.chooseAvailableDate;
 };
 
-export default class DayPickerRangeController extends React.Component {
+const BaseClass = baseClass();
+
+export default class DayPickerRangeController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -143,6 +143,7 @@ const defaultProps = {
   isRTL: false,
 };
 
+/** @extends React.Component */
 export default class DayPickerSingleDateController extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -21,6 +21,7 @@ import toISOMonthString from '../utils/toISOMonthString';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
+import baseClass from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -142,7 +143,9 @@ const defaultProps = {
   isRTL: false,
 };
 
-export default class DayPickerSingleDateController extends React.Component {
+const BaseClass = baseClass();
+
+export default class DayPickerSingleDateController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -143,9 +143,7 @@ const defaultProps = {
   isRTL: false,
 };
 
-const BaseClass = baseClass();
-
-export default class DayPickerSingleDateController extends BaseClass {
+export default class DayPickerSingleDateController extends baseClass() {
   constructor(props) {
     super(props);
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -21,7 +21,7 @@ import toISOMonthString from '../utils/toISOMonthString';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 import CalendarInfoPositionShape from '../shapes/CalendarInfoPositionShape';
-import baseClass from '../utils/baseClass';
+import BaseClass from '../utils/baseClass';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -144,7 +144,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-export default class DayPickerSingleDateController extends baseClass() {
+export default class DayPickerSingleDateController extends BaseClass {
   constructor(props) {
     super(props);
 

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { pureComponentAvailable } from '../utils/baseClass';
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -89,4 +90,4 @@ export default withStyles(({ reactDates: { color } }) => ({
     wordBreak: 'break-word',
     marginLeft: 8,
   },
-}))(KeyboardShortcutRow);
+}), { pureComponent: pureComponentAvailable })(KeyboardShortcutRow);

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -90,4 +90,4 @@ export default withStyles(({ reactDates: { color } }) => ({
     wordBreak: 'break-word',
     marginLeft: 8,
   },
-}), { pureComponent: pureComponentAvailable })(KeyboardShortcutRow);
+}), { pureComponent: pureComponentAvailable() })(KeyboardShortcutRow);

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -90,4 +90,4 @@ export default withStyles(({ reactDates: { color } }) => ({
     wordBreak: 'break-word',
     marginLeft: 8,
   },
-}), { pureComponent: pureComponentAvailable() })(KeyboardShortcutRow);
+}), { pureComponent: pureComponentAvailable })(KeyboardShortcutRow);

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -117,6 +117,7 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
+/** @extends React.Component */
 class SingleDatePicker extends baseClass() {
   constructor(props) {
     super(props);

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -117,9 +117,7 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-const BaseClass = baseClass();
-
-class SingleDatePicker extends BaseClass {
+class SingleDatePicker extends baseClass() {
   constructor(props) {
     super(props);
 
@@ -693,4 +691,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}), { pureComponent: pureComponentAvailable })(SingleDatePicker);
+}), { pureComponent: pureComponentAvailable() })(SingleDatePicker);

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -17,7 +17,7 @@ import getDetachedContainerStyles from '../utils/getDetachedContainerStyles';
 import getInputHeight from '../utils/getInputHeight';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import disableScroll from '../utils/disableScroll';
-import baseClass, { pureComponentAvailable } from '../utils/baseClass';
+import BaseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import SingleDatePickerInput from './SingleDatePickerInput';
 import DayPickerSingleDateController from './DayPickerSingleDateController';
@@ -118,7 +118,7 @@ const defaultProps = {
 };
 
 /** @extends React.Component */
-class SingleDatePicker extends baseClass() {
+class SingleDatePicker extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -692,4 +692,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}), { pureComponent: pureComponentAvailable() })(SingleDatePicker);
+}), { pureComponent: pureComponentAvailable })(SingleDatePicker);

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -17,6 +17,7 @@ import getDetachedContainerStyles from '../utils/getDetachedContainerStyles';
 import getInputHeight from '../utils/getInputHeight';
 import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
 import disableScroll from '../utils/disableScroll';
+import baseClass, { pureComponentAvailable } from '../utils/baseClass';
 
 import SingleDatePickerInput from './SingleDatePickerInput';
 import DayPickerSingleDateController from './DayPickerSingleDateController';
@@ -116,7 +117,9 @@ const defaultProps = {
   dayAriaLabelFormat: undefined,
 };
 
-class SingleDatePicker extends React.Component {
+const BaseClass = baseClass();
+
+class SingleDatePicker extends BaseClass {
   constructor(props) {
     super(props);
 
@@ -690,4 +693,4 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: 15,
     fill: color.core.grayLighter,
   },
-}))(SingleDatePicker);
+}), { pureComponent: pureComponentAvailable })(SingleDatePicker);

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -311,4 +311,4 @@ export default withStyles(({ reactDates: { border, color } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}), { pureComponent: pureComponentAvailable })(SingleDatePickerInput);
+}), { pureComponent: pureComponentAvailable() })(SingleDatePickerInput);

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -14,6 +14,7 @@ import CalendarIcon from './CalendarIcon';
 
 import openDirectionShape from '../shapes/OpenDirectionShape';
 import { ICON_BEFORE_POSITION, ICON_AFTER_POSITION, OPEN_DOWN } from '../constants';
+import { pureComponentAvailable } from '../utils/baseClass';
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -310,4 +311,4 @@ export default withStyles(({ reactDates: { border, color } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}))(SingleDatePickerInput);
+}), { pureComponent: pureComponentAvailable })(SingleDatePickerInput);

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -311,4 +311,4 @@ export default withStyles(({ reactDates: { border, color } }) => ({
     width: 14,
     verticalAlign: 'middle',
   },
-}), { pureComponent: pureComponentAvailable() })(SingleDatePickerInput);
+}), { pureComponent: pureComponentAvailable })(SingleDatePickerInput);

--- a/src/utils/baseClass.js
+++ b/src/utils/baseClass.js
@@ -1,22 +1,11 @@
 import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
-export const pureComponentAvailable = typeof React.PureComponent !== 'undefined';
-
-const baseClass = (pureComponent = pureComponentAvailable) => {
-  if (pureComponent) {
-    if (!React.PureComponent) {
-      throw new ReferenceError('withStyles() pureComponent option requires React 15.3.0 or later');
-    }
-
-    return React.PureComponent;
+class BaseClass extends (React.PureComponent || React.Component) {
+  [React.PureComponent || 'shouldComponentUpdate'](nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
   }
+}
 
-  return class BaseClass extends React.Component {
-    shouldComponentUpdate(nextProps, nextState) {
-      return shallowCompare(this, nextProps, nextState);
-    }
-  };
-};
-
-export default baseClass();
+export const pureComponentAvailable = typeof React.PureComponent !== 'undefined';
+export default BaseClass;

--- a/src/utils/baseClass.js
+++ b/src/utils/baseClass.js
@@ -2,7 +2,7 @@ import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
 class BaseClass extends (React.PureComponent || React.Component) {
-  [React.PureComponent || 'shouldComponentUpdate'](nextProps, nextState) {
+  [!React.PureComponent && 'shouldComponentUpdate'](nextProps, nextState) {
     return shallowCompare(this, nextProps, nextState);
   }
 }

--- a/src/utils/baseClass.js
+++ b/src/utils/baseClass.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
-export const pureComponentAvailable = () => typeof React.PureComponent !== 'undefined';
+export const pureComponentAvailable = typeof React.PureComponent !== 'undefined';
 
-export default function baseClass(pureComponent = pureComponentAvailable()) {
+const baseClass = (pureComponent = pureComponentAvailable) => {
   if (pureComponent) {
     if (!React.PureComponent) {
       throw new ReferenceError('withStyles() pureComponent option requires React 15.3.0 or later');
@@ -17,4 +17,6 @@ export default function baseClass(pureComponent = pureComponentAvailable()) {
       return shallowCompare(this, nextProps, nextState);
     }
   };
-}
+};
+
+export default baseClass();

--- a/src/utils/baseClass.js
+++ b/src/utils/baseClass.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
+
+export const pureComponentAvailable = typeof React.PureComponent !== 'undefined';
+
+export default function baseClass(pureComponent = pureComponentAvailable) {
+  if (pureComponent) {
+    if (!React.PureComponent) {
+      throw new ReferenceError('withStyles() pureComponent option requires React 15.3.0 or later');
+    }
+
+    return React.PureComponent;
+  }
+
+  return class BaseClass extends React.Component {
+    shouldComponentUpdate(nextProps, nextState) {
+      return shallowCompare(this, nextProps, nextState);
+    }
+  };
+}

--- a/src/utils/baseClass.js
+++ b/src/utils/baseClass.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import shallowCompare from 'react-addons-shallow-compare';
 
-export const pureComponentAvailable = typeof React.PureComponent !== 'undefined';
+export const pureComponentAvailable = () => typeof React.PureComponent !== 'undefined';
 
-export default function baseClass(pureComponent = pureComponentAvailable) {
+export default function baseClass(pureComponent = pureComponentAvailable()) {
   if (pureComponent) {
     if (!React.PureComponent) {
       throw new ReferenceError('withStyles() pureComponent option requires React 15.3.0 or later');


### PR DESCRIPTION
Working to resolve #1297.  Conditionally using `React.PureComponent` instead of `React.Component`