### PR TITLE
Only blur the activeElement after the month transition if available.

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -727,6 +727,7 @@ class DayPicker extends BaseClass {
           activeElement
           && activeElement !== document.body
           && this.container.contains(activeElement)
+          && activeElement.blur
         ) {
           activeElement.blur();
         }


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-dates/issues/1097

In IE11 and some other browsers, SVGs cannot be blurred. Notably, when you press the month nav, the SVG is sometimes focused. This causes a JS error in those browsers.

to: @ljharb @noratarano 