### PR TITLE
Address missing daypicker width when calendarMonthPadding theme variable is undefined

### DIFF
--- a/src/utils/getCalendarMonthWidth.js
+++ b/src/utils/getCalendarMonthWidth.js
@@ -1,3 +1,3 @@
-export default function getCalendarMonthWidth(daySize, calendarMonthPadding) {
+export default function getCalendarMonthWidth(daySize, calendarMonthPadding = 0) {
   return (7 * daySize) + (2 * calendarMonthPadding) + 1;
 }

--- a/test/utils/getCalendarMonthWidth_spec.js
+++ b/test/utils/getCalendarMonthWidth_spec.js
@@ -6,4 +6,12 @@ describe('#getCalendarMonthWidth', () => {
   it('correctly calculates width for default day size of 39', () => {
     expect(getCalendarMonthWidth(39, 13)).to.equal(300);
   });
+
+  it('returns a number when padding is undefined', () => {
+    expect(Number.isNaN(getCalendarMonthWidth(39, undefined))).to.equal(false);
+  });
+
+  it('returns a number when padding is null', () => {
+    expect(Number.isNaN(getCalendarMonthWidth(39, null))).to.equal(false);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/airbnb/react-dates/issues/1352

We added a new theme variable (`horizontalMonthPadding`) in v17.2.0. Unfortunately, when it was undefined, the effect was a trashfire (the daypicker width would be set to `NaN`). This PR addresses that edgecase and offers a fix!

to: @ljharb @noratarano @codylawson