### PR TITLE
Add SingleDatePickerInputController component

### DIFF
--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -88,8 +88,6 @@ const defaultProps = {
   phrases: SingleDatePickerInputPhrases,
 };
 
-/* eslint react/no-this-in-sfc: 1 */
-
 function SingleDatePickerInput({
   id,
   placeholder,
@@ -196,8 +194,6 @@ function SingleDatePickerInput({
           type="button"
           aria-label={phrases.clearDate}
           disabled={disabled}
-          onMouseEnter={this && this.onClearDateMouseEnter}
-          onMouseLeave={this && this.onClearDateMouseLeave}
           onClick={onClearDate}
         >
           {closeIcon}

--- a/src/components/SingleDatePickerInputController.jsx
+++ b/src/components/SingleDatePickerInputController.jsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import momentPropTypes from 'react-moment-proptypes';
+import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
+import openDirectionShape from '../shapes/OpenDirectionShape';
+
+import { SingleDatePickerInputPhrases } from '../defaultPhrases';
+import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+
+import SingleDatePickerInput from './SingleDatePickerInput';
+
+import IconPositionShape from '../shapes/IconPositionShape';
+import DisabledShape from '../shapes/DisabledShape';
+
+import toMomentObject from '../utils/toMomentObject';
+import toLocalizedDateString from '../utils/toLocalizedDateString';
+
+import isInclusivelyAfterDay from '../utils/isInclusivelyAfterDay';
+
+import BaseClass from '../utils/baseClass';
+
+import {
+  ICON_BEFORE_POSITION,
+  OPEN_DOWN,
+} from '../constants';
+
+const propTypes = forbidExtraProps({
+  date: momentPropTypes.momentObj,
+  onDateChange: PropTypes.func.isRequired,
+
+  focused: PropTypes.bool,
+  onFocusChange: PropTypes.func.isRequired,
+
+  id: PropTypes.string.isRequired,
+  placeholder: PropTypes.string, // also used as label
+  screenReaderMessage: PropTypes.string,
+  showClearDate: PropTypes.bool,
+  showCaret: PropTypes.bool,
+  showDefaultInputIcon: PropTypes.bool,
+  inputIconPosition: IconPositionShape,
+  disabled: DisabledShape,
+  required: PropTypes.bool,
+  readOnly: PropTypes.bool,
+  openDirection: openDirectionShape,
+  noBorder: PropTypes.bool,
+  block: PropTypes.bool,
+  small: PropTypes.bool,
+  regular: PropTypes.bool,
+  verticalSpacing: nonNegativeInteger,
+
+  keepOpenOnDateSelect: PropTypes.bool,
+  reopenPickerOnClearDate: PropTypes.bool,
+  isOutsideRange: PropTypes.func,
+  displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+
+  onClose: PropTypes.func,
+  onKeyDownArrowDown: PropTypes.func,
+  onKeyDownQuestionMark: PropTypes.func,
+
+  customInputIcon: PropTypes.node,
+  customCloseIcon: PropTypes.node,
+
+  // accessibility
+  isFocused: PropTypes.bool,
+
+  // i18n
+  phrases: PropTypes.shape(getPhrasePropTypes(SingleDatePickerInputPhrases)),
+
+  isRTL: PropTypes.bool,
+});
+
+const defaultProps = {
+  date: null,
+  focused: false,
+
+  placeholder: '',
+  screenReaderMessage: 'Date',
+  showClearDate: false,
+  showCaret: false,
+  showDefaultInputIcon: false,
+  inputIconPosition: ICON_BEFORE_POSITION,
+  disabled: false,
+  required: false,
+  readOnly: false,
+  openDirection: OPEN_DOWN,
+  noBorder: false,
+  block: false,
+  small: false,
+  regular: false,
+  verticalSpacing: undefined,
+
+  keepOpenOnDateSelect: false,
+  reopenPickerOnClearDate: false,
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  displayFormat: () => moment.localeData().longDateFormat('L'),
+
+  onClose() {},
+  onKeyDownArrowDown() {},
+  onKeyDownQuestionMark() {},
+
+  customInputIcon: null,
+  customCloseIcon: null,
+
+  // accessibility
+  isFocused: false,
+
+  // i18n
+  phrases: SingleDatePickerInputPhrases,
+
+  isRTL: false,
+};
+
+/** @extends React.Component */
+export default class SingleDatePickerInputController extends BaseClass {
+  constructor(props) {
+    super(props);
+
+    this.onChange = this.onChange.bind(this);
+    this.onFocus = this.onFocus.bind(this);
+    this.onClearFocus = this.onClearFocus.bind(this);
+    this.clearDate = this.clearDate.bind(this);
+  }
+
+  onChange(dateString) {
+    const {
+      isOutsideRange,
+      keepOpenOnDateSelect,
+      onDateChange,
+      onFocusChange,
+      onClose,
+    } = this.props;
+    const newDate = toMomentObject(dateString, this.getDisplayFormat());
+
+    const isValid = newDate && !isOutsideRange(newDate);
+    if (isValid) {
+      onDateChange(newDate);
+      if (!keepOpenOnDateSelect) {
+        onFocusChange({ focused: false });
+        onClose({ date: newDate });
+      }
+    } else {
+      onDateChange(null);
+    }
+  }
+
+
+  onFocus() {
+    const {
+      onFocusChange,
+      disabled,
+    } = this.props;
+
+    if (!disabled) {
+      onFocusChange({ focused: true });
+    }
+  }
+
+  onClearFocus() {
+    const {
+      focused,
+      onFocusChange,
+      onClose,
+      date,
+    } = this.props;
+    if (!focused) return;
+
+    onFocusChange({ focused: false });
+    onClose({ date });
+  }
+
+  getDisplayFormat() {
+    const { displayFormat } = this.props;
+    return typeof displayFormat === 'string' ? displayFormat : displayFormat();
+  }
+
+  getDateString(date) {
+    const displayFormat = this.getDisplayFormat();
+    if (date && displayFormat) {
+      return date && date.format(displayFormat);
+    }
+    return toLocalizedDateString(date);
+  }
+
+  clearDate() {
+    const { onDateChange, reopenPickerOnClearDate, onFocusChange } = this.props;
+    onDateChange(null);
+    if (reopenPickerOnClearDate) {
+      onFocusChange({ focused: true });
+    }
+  }
+
+  render() {
+    const {
+      id,
+      placeholder,
+      disabled,
+      focused,
+      isFocused,
+      required,
+      readOnly,
+      openDirection,
+      showClearDate,
+      showCaret,
+      showDefaultInputIcon,
+      inputIconPosition,
+      customCloseIcon,
+      customInputIcon,
+      date,
+      phrases,
+      onKeyDownArrowDown,
+      onKeyDownQuestionMark,
+      screenReaderMessage,
+      isRTL,
+      noBorder,
+      block,
+      small,
+      regular,
+      verticalSpacing,
+    } = this.props;
+
+    const displayValue = this.getDateString(date);
+
+    return (
+      <SingleDatePickerInput
+        id={id}
+        placeholder={placeholder}
+        focused={focused}
+        isFocused={isFocused}
+        disabled={disabled}
+        required={required}
+        readOnly={readOnly}
+        openDirection={openDirection}
+        showCaret={showCaret}
+        onClearDate={this.clearDate}
+        showClearDate={showClearDate}
+        showDefaultInputIcon={showDefaultInputIcon}
+        inputIconPosition={inputIconPosition}
+        customCloseIcon={customCloseIcon}
+        customInputIcon={customInputIcon}
+        displayValue={displayValue}
+        onChange={this.onChange}
+        onFocus={this.onFocus}
+        onKeyDownShiftTab={this.onClearFocus}
+        onKeyDownTab={this.onClearFocus}
+        onKeyDownArrowDown={onKeyDownArrowDown}
+        onKeyDownQuestionMark={onKeyDownQuestionMark}
+        screenReaderMessage={screenReaderMessage}
+        phrases={phrases}
+        isRTL={isRTL}
+        noBorder={noBorder}
+        block={block}
+        small={small}
+        regular={regular}
+        verticalSpacing={verticalSpacing}
+      />
+    );
+  }
+}
+
+SingleDatePickerInputController.propTypes = propTypes;
+SingleDatePickerInputController.defaultProps = defaultProps;

--- a/test/components/SingleDatePickerInputController_spec.jsx
+++ b/test/components/SingleDatePickerInputController_spec.jsx
@@ -1,0 +1,369 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon-sandbox';
+import moment from 'moment';
+
+import SingleDatePickerInput from '../../src/components/SingleDatePickerInput';
+import SingleDatePickerInputController from '../../src/components/SingleDatePickerInputController';
+
+import isSameDay from '../../src/utils/isSameDay';
+
+// Set to noon to mimic how days in the picker are configured internally
+const today = moment().startOf('day').hours(12);
+
+describe('SingleDatePickerInputController', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('renders a SingleDatePickerInput', () => {
+    const wrapper = shallow((
+      <SingleDatePickerInputController
+        id="date"
+        onDateChange={() => {}}
+        onFocusChange={() => {}}
+      />
+    ));
+    expect(wrapper.find(SingleDatePickerInput)).to.have.lengthOf(1);
+  });
+
+  describe('#onChange', () => {
+    describe('valid future date string', () => {
+      const futureDateString = moment().add(10, 'days').format('YYYY-MM-DD');
+      it('calls props.onDateChange once', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        expect(onDateChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onDateChange with date as arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        const newDate = onDateChangeStub.getCall(0).args[0];
+        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
+      });
+
+      it('calls props.onFocusChange once', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onFocusChange with { focused: false } as arg', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
+      });
+
+      it('calls props.onClose once', () => {
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        expect(onCloseStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onClose with { date } as arg', () => {
+        const onCloseStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+            onClose={onCloseStub}
+          />
+        ));
+        wrapper.instance().onChange(futureDateString);
+        const newDate = onCloseStub.getCall(0).args[0].date;
+        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
+      });
+    });
+
+    describe('matches custom display format', () => {
+      const customFormat = 'YY|MM[foobar]DD';
+      const customFormatDateString = moment().add(5, 'days').format(customFormat);
+      it('calls props.onDateChange once', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            displayFormat={customFormat}
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+          />
+        ));
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onDateChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onDateChange with date as arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            displayFormat={customFormat}
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+          />
+        ));
+        wrapper.instance().onChange(customFormatDateString);
+        const formattedFirstArg = onDateChangeStub.getCall(0).args[0].format(customFormat);
+        expect(formattedFirstArg).to.equal(customFormatDateString);
+      });
+
+      it('calls props.onFocusChange once', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            displayFormat={customFormat}
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+          />
+        ));
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onFocusChange with { focused: false } as arg', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            displayFormat={customFormat}
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+          />
+        ));
+        wrapper.instance().onChange(customFormatDateString);
+        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
+      });
+    });
+
+    describe('invalid date string', () => {
+      const invalidDateString = 'foobar';
+      it('calls props.onDateChange once', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+        ));
+        wrapper.instance().onChange(invalidDateString);
+        expect(onDateChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onDateChange with null as arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+        ));
+        wrapper.instance().onChange(invalidDateString);
+        expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
+      });
+
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
+        ));
+        wrapper.instance().onChange(invalidDateString);
+        expect(onFocusChangeStub.callCount).to.equal(0);
+      });
+    });
+
+    describe('date string outside range', () => {
+      const isOutsideRangeStub = sinon.stub().returns(true);
+      const todayDateString = today.toISOString();
+
+      it('calls props.onDateChange once', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+            isOutsideRange={isOutsideRangeStub}
+          />
+        ));
+        wrapper.instance().onChange(todayDateString);
+        expect(onDateChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onDateChange with null as arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+            isOutsideRange={isOutsideRangeStub}
+          />
+        ));
+        wrapper.instance().onChange(todayDateString);
+        expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
+      });
+
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            isOutsideRange={isOutsideRangeStub}
+          />
+        ));
+        wrapper.instance().onChange(todayDateString);
+        expect(onFocusChangeStub.callCount).to.equal(0);
+      });
+    });
+  });
+
+  describe('#onFocus', () => {
+    it('calls props.onFocusChange once', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow((
+        <SingleDatePickerInputController id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
+      ));
+      wrapper.instance().onFocus();
+      expect(onFocusChangeStub.callCount).to.equal(1);
+    });
+
+    it('calls props.onFocusChange with { focused: true } as arg', () => {
+      const onFocusChangeStub = sinon.stub();
+      const wrapper = shallow((
+        <SingleDatePickerInputController id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
+      ));
+      wrapper.instance().onFocus();
+      expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(true);
+    });
+
+    describe('props.disabled = true', () => {
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            disabled
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+          />
+        ));
+        wrapper.instance().onFocus();
+        expect(onFocusChangeStub).to.have.property('callCount', 0);
+      });
+    });
+  });
+
+  describe('#onClearFocus', () => {
+    describe('props.focused = false', () => {
+      it('does not call props.onFocusChange', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused={false}
+          />
+        ));
+        wrapper.instance().onClearFocus();
+        expect(onFocusChangeStub.callCount).to.equal(0);
+      });
+    });
+
+    describe('props.focused = true', () => {
+      it('calls props.onFocusChange once', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused
+          />
+        ));
+        wrapper.instance().onClearFocus();
+        expect(onFocusChangeStub.callCount).to.equal(1);
+      });
+
+      it('calls props.onFocusChange with { focused: false } as arg', () => {
+        const onFocusChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={onFocusChangeStub}
+            focused
+          />
+        ));
+        wrapper.instance().onClearFocus();
+        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
+      });
+    });
+  });
+
+  describe('#clearDate', () => {
+    describe('props.reopenPickerOnClearDate is truthy', () => {
+      describe('props.onFocusChange', () => {
+        it('is called once', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <SingleDatePickerInputController
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={onFocusChangeStub}
+              reopenPickerOnClearDate
+            />
+          ));
+          wrapper.instance().clearDate();
+          expect(onFocusChangeStub.callCount).to.equal(1);
+        });
+      });
+    });
+
+    describe('props.reopenPickerOnClearDate is falsy', () => {
+      describe('props.onFocusChange', () => {
+        it('is not called', () => {
+          const onFocusChangeStub = sinon.stub();
+          const wrapper = shallow((
+            <SingleDatePickerInputController
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={onFocusChangeStub}
+            />
+          ));
+          wrapper.instance().clearDate();
+          expect(onFocusChangeStub.callCount).to.equal(0);
+        });
+      });
+    });
+
+    it('calls props.onDateChange with null date', () => {
+      const onDateChangeStub = sinon.stub();
+      const wrapper = shallow((
+        <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+      ));
+      wrapper.instance().clearDate();
+      expect(onDateChangeStub.callCount).to.equal(1);
+    });
+  });
+});

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -2,20 +2,14 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon-sandbox';
-import moment from 'moment';
 import { Portal } from 'react-portal';
 
 import CloseButton from '../../src/components/CloseButton';
 import DayPickerSingleDateController from '../../src/components/DayPickerSingleDateController';
-import SingleDatePickerInput from '../../src/components/SingleDatePickerInput';
+import SingleDatePickerInputController from '../../src/components/SingleDatePickerInputController';
 import SingleDatePicker, { PureSingleDatePicker } from '../../src/components/SingleDatePicker';
 
-import isSameDay from '../../src/utils/isSameDay';
-
 const describeIfWindow = typeof document === 'undefined' ? describe.skip : describe;
-
-// Set to noon to mimic how days in the picker are configured internally
-const today = moment().startOf('day').hours(12);
 
 describe('SingleDatePicker', () => {
   afterEach(() => {
@@ -23,7 +17,7 @@ describe('SingleDatePicker', () => {
   });
 
   describe('#render', () => {
-    it('renders a SingleDatePickerInput', () => {
+    it('renders a SingleDatePickerInputController', () => {
       const wrapper = shallow((
         <SingleDatePicker
           id="date"
@@ -31,7 +25,7 @@ describe('SingleDatePicker', () => {
           onFocusChange={() => {}}
         />
       )).dive();
-      expect(wrapper.find(SingleDatePickerInput)).to.have.lengthOf(1);
+      expect(wrapper.find(SingleDatePickerInputController)).to.have.lengthOf(1);
     });
 
     describe('DayPickerSingleDateController', () => {
@@ -204,7 +198,7 @@ describe('SingleDatePicker', () => {
 
         it('ignores click events from inside picker', () => {
           const event = { target: instance.dayPickerContainer };
-          instance.onClearFocus(event);
+          instance.onOutsideClick(event);
           expect(onCloseStub.callCount).to.equal(0);
         });
 
@@ -223,216 +217,7 @@ describe('SingleDatePicker', () => {
     });
   });
 
-  describe('#onChange', () => {
-    describe('valid future date string', () => {
-      const futureDateString = moment().add(10, 'days').format('YYYY-MM-DD');
-      it('calls props.onDateChange once', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        expect(onDateChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onDateChange with date as arg', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        const newDate = onDateChangeStub.getCall(0).args[0];
-        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
-      });
-
-      it('calls props.onFocusChange once', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        expect(onFocusChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onFocusChange with { focused: false } as arg', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
-      });
-
-      it('calls props.onClose once', () => {
-        const onCloseStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            onDateChange={() => {}}
-            onFocusChange={() => {}}
-            onClose={onCloseStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        expect(onCloseStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onClose with { date } as arg', () => {
-        const onCloseStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            onDateChange={() => {}}
-            onFocusChange={() => {}}
-            onClose={onCloseStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(futureDateString);
-        const newDate = onCloseStub.getCall(0).args[0].date;
-        expect(isSameDay(newDate, moment(futureDateString))).to.equal(true);
-      });
-    });
-
-    describe('matches custom display format', () => {
-      const customFormat = 'YY|MM[foobar]DD';
-      const customFormatDateString = moment().add(5, 'days').format(customFormat);
-      it('calls props.onDateChange once', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            displayFormat={customFormat}
-            onDateChange={onDateChangeStub}
-            onFocusChange={() => {}}
-          />
-        )).dive();
-        wrapper.instance().onChange(customFormatDateString);
-        expect(onDateChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onDateChange with date as arg', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            displayFormat={customFormat}
-            onDateChange={onDateChangeStub}
-            onFocusChange={() => {}}
-          />
-        )).dive();
-        wrapper.instance().onChange(customFormatDateString);
-        const formattedFirstArg = onDateChangeStub.getCall(0).args[0].format(customFormat);
-        expect(formattedFirstArg).to.equal(customFormatDateString);
-      });
-
-      it('calls props.onFocusChange once', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            displayFormat={customFormat}
-            onDateChange={() => {}}
-            onFocusChange={onFocusChangeStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(customFormatDateString);
-        expect(onFocusChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onFocusChange with { focused: false } as arg', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            displayFormat={customFormat}
-            onDateChange={() => {}}
-            onFocusChange={onFocusChangeStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(customFormatDateString);
-        expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
-      });
-    });
-
-    describe('invalid date string', () => {
-      const invalidDateString = 'foobar';
-      it('calls props.onDateChange once', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
-        )).dive();
-        wrapper.instance().onChange(invalidDateString);
-        expect(onDateChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onDateChange with null as arg', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
-        )).dive();
-        wrapper.instance().onChange(invalidDateString);
-        expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
-      });
-
-      it('does not call props.onFocusChange', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
-        )).dive();
-        wrapper.instance().onChange(invalidDateString);
-        expect(onFocusChangeStub.callCount).to.equal(0);
-      });
-    });
-
-    describe('date string outside range', () => {
-      const isOutsideRangeStub = sinon.stub().returns(true);
-      const todayDateString = today.toISOString();
-
-      it('calls props.onDateChange once', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            onDateChange={onDateChangeStub}
-            onFocusChange={() => {}}
-            isOutsideRange={isOutsideRangeStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(todayDateString);
-        expect(onDateChangeStub.callCount).to.equal(1);
-      });
-
-      it('calls props.onDateChange with null as arg', () => {
-        const onDateChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            onDateChange={onDateChangeStub}
-            onFocusChange={() => {}}
-            isOutsideRange={isOutsideRangeStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(todayDateString);
-        expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
-      });
-
-      it('does not call props.onFocusChange', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            onDateChange={() => {}}
-            onFocusChange={onFocusChangeStub}
-            isOutsideRange={isOutsideRangeStub}
-          />
-        )).dive();
-        wrapper.instance().onChange(todayDateString);
-        expect(onFocusChangeStub.callCount).to.equal(0);
-      });
-    });
-  });
-
-  describe('#onFocus', () => {
+  describe('#onInputFocus', () => {
     let onDayPickerFocusSpy;
     let onDayPickerBlurSpy;
     beforeEach(() => {
@@ -445,7 +230,7 @@ describe('SingleDatePicker', () => {
       const wrapper = shallow((
         <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onFocusChangeStub.callCount).to.equal(1);
     });
 
@@ -454,7 +239,7 @@ describe('SingleDatePicker', () => {
       const wrapper = shallow((
         <SingleDatePicker id="date" onDateChange={() => {}} onFocusChange={onFocusChangeStub} />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(true);
     });
 
@@ -466,7 +251,7 @@ describe('SingleDatePicker', () => {
           withPortal
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -478,7 +263,7 @@ describe('SingleDatePicker', () => {
           withFullScreenPortal
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -490,7 +275,7 @@ describe('SingleDatePicker', () => {
           readOnly
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -502,7 +287,7 @@ describe('SingleDatePicker', () => {
         />
       )).dive();
       wrapper.instance().isTouchDevice = true;
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -515,7 +300,7 @@ describe('SingleDatePicker', () => {
         />
       )).dive();
       wrapper.instance().isTouchDevice = true;
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerBlurSpy.callCount).to.equal(1);
     });
 
@@ -528,7 +313,7 @@ describe('SingleDatePicker', () => {
         />
       )).dive();
       wrapper.instance().isTouchDevice = true;
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerBlurSpy.callCount).to.equal(1);
     });
 
@@ -541,7 +326,7 @@ describe('SingleDatePicker', () => {
           withFullScreenPortal
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -555,7 +340,7 @@ describe('SingleDatePicker', () => {
           withFullScreenPortal
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
@@ -566,28 +351,12 @@ describe('SingleDatePicker', () => {
           onFocusChange={sinon.stub()}
         />
       )).dive();
-      wrapper.instance().onFocus();
+      wrapper.instance().onInputFocus({ focused: true });
       expect(onDayPickerBlurSpy.callCount).to.equal(1);
-    });
-
-    describe('props.disabled = true', () => {
-      it('does not call props.onFocusChange', () => {
-        const onFocusChangeStub = sinon.stub();
-        const wrapper = shallow((
-          <SingleDatePicker
-            id="date"
-            disabled
-            onDateChange={() => {}}
-            onFocusChange={onFocusChangeStub}
-          />
-        )).dive();
-        wrapper.instance().onFocus();
-        expect(onFocusChangeStub).to.have.property('callCount', 0);
-      });
     });
   });
 
-  describe('#onClearFocus', () => {
+  describe('#onOutsideClick', () => {
     describe('props.focused = false', () => {
       it('does not call props.onFocusChange', () => {
         const onFocusChangeStub = sinon.stub();
@@ -599,7 +368,7 @@ describe('SingleDatePicker', () => {
             focused={false}
           />
         )).dive();
-        wrapper.instance().onClearFocus();
+        wrapper.instance().onOutsideClick();
         expect(onFocusChangeStub.callCount).to.equal(0);
       });
     });
@@ -616,7 +385,7 @@ describe('SingleDatePicker', () => {
         wrapper.setState({
           isDayPickerFocused: true,
         });
-        wrapper.instance().onClearFocus();
+        wrapper.instance().onOutsideClick();
         expect(wrapper.state().isDayPickerFocused).to.equal(false);
       });
 
@@ -631,7 +400,7 @@ describe('SingleDatePicker', () => {
         wrapper.setState({
           isInputFocused: true,
         });
-        wrapper.instance().onClearFocus();
+        wrapper.instance().onOutsideClick();
         expect(wrapper.state().isInputFocused).to.equal(false);
       });
 
@@ -645,7 +414,7 @@ describe('SingleDatePicker', () => {
             focused
           />
         )).dive();
-        wrapper.instance().onClearFocus();
+        wrapper.instance().onOutsideClick();
         expect(onFocusChangeStub.callCount).to.equal(1);
       });
 
@@ -659,7 +428,7 @@ describe('SingleDatePicker', () => {
             focused
           />
         )).dive();
-        wrapper.instance().onClearFocus();
+        wrapper.instance().onOutsideClick();
         expect(onFocusChangeStub.getCall(0).args[0].focused).to.equal(false);
       });
     });
@@ -794,51 +563,6 @@ describe('SingleDatePicker', () => {
       });
       wrapper.instance().showKeyboardShortcutsPanel();
       expect(wrapper.state().showKeyboardShortcuts).to.equal(true);
-    });
-  });
-
-  describe('#clearDate', () => {
-    describe('props.reopenPickerOnClearDate is truthy', () => {
-      describe('props.onFocusChange', () => {
-        it('is called once', () => {
-          const onFocusChangeStub = sinon.stub();
-          const wrapper = shallow((
-            <SingleDatePicker
-              onDateChange={() => {}}
-              onFocusChange={onFocusChangeStub}
-              reopenPickerOnClearDate
-            />
-          )).dive();
-          wrapper.instance().clearDate();
-          expect(onFocusChangeStub.callCount).to.equal(1);
-        });
-      });
-    });
-
-    describe('props.reopenPickerOnClearDate is falsy', () => {
-      describe('props.onFocusChange', () => {
-        it('is not called', () => {
-          const onFocusChangeStub = sinon.stub();
-          const wrapper = shallow((
-            <SingleDatePicker
-              id="date"
-              onDateChange={() => {}}
-              onFocusChange={onFocusChangeStub}
-            />
-          )).dive();
-          wrapper.instance().clearDate();
-          expect(onFocusChangeStub.callCount).to.equal(0);
-        });
-      });
-    });
-
-    it('calls props.onDateChange with null date', () => {
-      const onDateChangeStub = sinon.stub();
-      const wrapper = shallow((
-        <SingleDatePicker id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
-      )).dive();
-      wrapper.instance().clearDate();
-      expect(onDateChangeStub.callCount).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
This is the first step to creating a component structure that will allow consumers to asynchronously load the picker.

Basically, this creates an input controller component similar to the DateRangePickerInputController that takes care of everything related to input and input validation. There should be no functional change to any of the main components. 

to: @ljharb @lencioni @noratarano