### PR TITLE
Pass `isOutsideRange` prop to input controller

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -507,6 +507,7 @@ class SingleDatePicker extends BaseClass {
       reopenPickerOnClearDate,
       keepOpenOnDateSelect,
       styles,
+      isOutsideRange,
     } = this.props;
 
     const { isInputFocused } = this.state;
@@ -529,6 +530,7 @@ class SingleDatePicker extends BaseClass {
         showClearDate={showClearDate}
         showDefaultInputIcon={showDefaultInputIcon}
         inputIconPosition={inputIconPosition}
+        isOutsideRange={isOutsideRange}
         customCloseIcon={customCloseIcon}
         customInputIcon={customInputIcon}
         date={date}

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -17,15 +17,32 @@ describe('SingleDatePicker', () => {
   });
 
   describe('#render', () => {
-    it('renders a SingleDatePickerInputController', () => {
-      const wrapper = shallow((
-        <SingleDatePicker
-          id="date"
-          onDateChange={() => {}}
-          onFocusChange={() => {}}
-        />
-      )).dive();
-      expect(wrapper.find(SingleDatePickerInputController)).to.have.lengthOf(1);
+    describe('SingleDatePickerInputController', () => {
+      it('renders a SingleDatePickerInputController', () => {
+        const wrapper = shallow((
+          <SingleDatePicker
+            id="date"
+            onDateChange={() => {}}
+            onFocusChange={() => {}}
+          />
+        )).dive();
+        expect(wrapper.find(SingleDatePickerInputController)).to.have.lengthOf(1);
+      });
+
+      describe('props.isOutsideRange is defined', () => {
+        it('should pass props.isOutsideRange to <SingleDatePickerInputController>', () => {
+          const isOutsideRange = sinon.stub();
+          const wrapper = shallow((
+            <SingleDatePicker
+              id="date"
+              onDateChange={() => {}}
+              onFocusChange={() => {}}
+              isOutsideRange={isOutsideRange}
+            />
+          )).dive();
+          expect(wrapper.find(SingleDatePickerInputController).prop('isOutsideRange')).to.equal(isOutsideRange);
+        });
+      });
     });
 
     describe('DayPickerSingleDateController', () => {


### PR DESCRIPTION
### Description

The `SingleDatePicker` component isn't passing the `isOutsideRange` prop down to the `SingleDatePickerInputController` so `SingleDatePickerInputController` ends up using the default range. This results in valid dates outside in the past to not get recognized by the calendar. By passing the prop down we can allow for dates in the past. You can see the behavior by entering in a date in the past in the [Storybook example](http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Day%20Props&selectedStory=allows%20all%20days%2C%20including%20past%20days&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) (notice it doesn't highlight the past-date - it does work for days in the future).

### Before
![](http://stuff.k-create.com/c0ecb4f1a585/Screen%252520Recording%2525202018-09-21%252520at%25252002.47%252520PM.gif)

### After
![](http://stuff.k-create.com/cca101e00e1e/Screen%252520Recording%2525202018-09-21%252520at%25252002.49%252520PM.gif)
