### PR TITLE
Fix Calendar ICON block styling

### DIFF
--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -181,7 +181,10 @@ function DateRangePickerInput({
   const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
     <button
-      {...css(styles.DateRangePickerInput_calendarIcon)}
+      {...css(
+        styles.DateRangePickerInput_calendarIcon,
+        block && styles.DateRangePickerInput_calendarIcon__block,
+      )}
       type="button"
       disabled={disabled}
       aria-label={phrases.focusStartDate}
@@ -389,6 +392,13 @@ export default withStyles(({ reactDates: { border, color, sizing } }) => ({
     verticalAlign: 'middle',
     padding: 10,
     margin: '0 5px 0 10px',
+  },
+
+  DateRangePickerInput_calendarIcon__block: {
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
   },
 
   DateRangePickerInput_calendarIcon_svg: {

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -136,7 +136,10 @@ function SingleDatePickerInput({
   const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
     <button
-      {...css(styles.SingleDatePickerInput_calendarIcon)}
+      {...css(
+        styles.SingleDatePickerInput_calendarIcon,
+        block && styles.SingleDatePickerInput_calendarIcon__block,
+      )}
       type="button"
       disabled={disabled}
       aria-label={phrases.focusStartDate}
@@ -299,6 +302,13 @@ export default withStyles(({ reactDates: { border, color } }) => ({
     verticalAlign: 'middle',
     padding: 10,
     margin: '0 5px 0 10px',
+  },
+
+  SingleDatePickerInput_calendarIcon__block: {
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
   },
 
   SingleDatePickerInput_calendarIcon_svg: {


### PR DESCRIPTION
When adding `block` prop to the `DateInput` Component, the Calendar ICON should move to the right side.

Styling Issue:
![screenshot-airbnb io-2018 09 24-19-47-52](https://user-images.githubusercontent.com/13184350/45985135-c91fc380-c032-11e8-95e7-c44388703a7d.png)

Output:
![screenshot-localhost-6006-2018 09 24-19-52-06](https://user-images.githubusercontent.com/13184350/45985252-65e26100-c033-11e8-8c2b-9f179071efbc.png)
