### PR TITLE
[a11y] expose a callback for when the user hits tab or shift tab inside the day picker

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -99,6 +99,8 @@ const propTypes = forbidExtraProps({
   getFirstFocusableDay: PropTypes.func,
   onBlur: PropTypes.func,
   showKeyboardShortcuts: PropTypes.bool,
+  onTab: PropTypes.func,
+  onShiftTab: PropTypes.func,
 
   // internationalization
   monthFormat: PropTypes.string,
@@ -155,6 +157,8 @@ export const defaultProps = {
   getFirstFocusableDay: null,
   onBlur() {},
   showKeyboardShortcuts: false,
+  onTab() {},
+  onShiftTab() {},
 
   // internationalization
   monthFormat: 'MMMM YYYY',
@@ -356,7 +360,12 @@ class DayPicker extends BaseClass {
   onFinalKeyDown(e) {
     this.setState({ withMouseInteractions: false });
 
-    const { onBlur, isRTL } = this.props;
+    const {
+      onBlur,
+      onTab,
+      onShiftTab,
+      isRTL,
+    } = this.props;
     const { focusedDate, showKeyboardShortcuts } = this.state;
     if (!focusedDate) return;
 
@@ -431,6 +440,14 @@ class DayPicker extends BaseClass {
           this.closeKeyboardShortcutsPanel();
         } else {
           onBlur();
+        }
+        break;
+
+      case 'Tab':
+        if (e.shiftKey) {
+          onShiftTab();
+        } else {
+          onTab();
         }
         break;
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -92,6 +92,8 @@ const propTypes = forbidExtraProps({
   onBlur: PropTypes.func,
   isFocused: PropTypes.bool,
   showKeyboardShortcuts: PropTypes.bool,
+  onTab: PropTypes.func,
+  onShiftTab: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -154,6 +156,8 @@ const defaultProps = {
   onBlur() {},
   isFocused: false,
   showKeyboardShortcuts: false,
+  onTab() {},
+  onShiftTab() {},
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -626,7 +630,7 @@ export default class DayPickerRangeController extends BaseClass {
     modifiers = this.deleteModifier(modifiers, hoverDate, 'hovered');
 
     if (dateOffset) {
-      modifiers = this.deleteModifierFromRange(modifiers, this.state.dateOffset.start, this.state.dateOffset.end, 'hovered-offset');
+      modifiers = this.deleteModifierFromRange(modifiers, dateOffset.start, dateOffset.end, 'hovered-offset');
     }
 
     if (startDate && !endDate && isAfterDay(hoverDate, startDate)) {
@@ -1065,6 +1069,8 @@ export default class DayPickerRangeController extends BaseClass {
       renderMonthElement,
       calendarInfoPosition,
       onBlur,
+      onShiftTab,
+      onTab,
       isFocused,
       showKeyboardShortcuts,
       isRTL,
@@ -1091,6 +1097,8 @@ export default class DayPickerRangeController extends BaseClass {
         onPrevMonthClick={this.onPrevMonthClick}
         onNextMonthClick={this.onNextMonthClick}
         onMonthChange={this.onMonthChange}
+        onTab={onTab}
+        onShiftTab={onShiftTab}
         onYearChange={this.onYearChange}
         onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
         monthFormat={monthFormat}

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -77,6 +77,8 @@ const propTypes = forbidExtraProps({
   onBlur: PropTypes.func,
   isFocused: PropTypes.bool,
   showKeyboardShortcuts: PropTypes.bool,
+  onTab: PropTypes.func,
+  onShiftTab: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -133,6 +135,8 @@ const defaultProps = {
   onBlur() {},
   isFocused: false,
   showKeyboardShortcuts: false,
+  onTab() {},
+  onShiftTab() {},
 
   // i18n
   monthFormat: 'MMMM YYYY',
@@ -652,6 +656,8 @@ export default class DayPickerSingleDateController extends BaseClass {
       navPrev,
       navNext,
       onOutsideClick,
+      onShiftTab,
+      onTab,
       withPortal,
       focused,
       enableOutsideDays,
@@ -710,6 +716,8 @@ export default class DayPickerSingleDateController extends BaseClass {
         isFocused={isFocused}
         getFirstFocusableDay={this.getFirstFocusableDay}
         onBlur={onBlur}
+        onTab={onTab}
+        onShiftTab={onShiftTab}
         phrases={phrases}
         daySize={daySize}
         isRTL={isRTL}

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -397,27 +397,34 @@ describe('DayPicker', () => {
           expect(onBlurStub.callCount).to.equal(1);
         });
       });
+
+      describe('Tab', () => {
+        it('triggers onShiftTab when shift tab is pressed', () => {
+          const onTabStub = sinon.stub();
+          const onShiftTabStub = sinon.stub();
+          const wrapper = shallow(
+            <DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />,
+          ).dive();
+          wrapper.setState({ focusedDate: today });
+          wrapper.instance().onKeyDown({ ...event, key: 'Tab', shiftKey: true });
+          expect(onTabStub.callCount).to.equal(0);
+          expect(onShiftTabStub.callCount).to.equal(1);
+        });
+
+        it('triggers onTab', () => {
+          const onTabStub = sinon.stub();
+          const onShiftTabStub = sinon.stub();
+          const wrapper = shallow(
+            <DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />,
+          ).dive();
+          wrapper.setState({ focusedDate: today });
+          wrapper.instance().onKeyDown({ ...event, key: 'Tab' });
+          expect(onTabStub.callCount).to.equal(1);
+          expect(onShiftTabStub.callCount).to.equal(0);
+        });
+      });
     });
 
-    describe('Tab', () => {
-      describe('triggers onShiftTab when shift tab is pressed', () => {
-        const onTabStub = sinon.stub();
-        const onShiftTabStub = sinon.stub();
-        const wrapper = shallow(<DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />).dive();
-        wrapper.instance().onKeyDown({ ...event, key: 'Tab', shiftKey: true });
-        expect(onTabStub.callCount).to.equal(0);
-        expect(onShiftTabStub.callCount).to.equal(1);
-      });
-
-      describe('triggers onTab', () => {
-        const onTabStub = sinon.stub();
-        const onShiftTabStub = sinon.stub();
-        const wrapper = shallow(<DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />).dive();
-        wrapper.instance().onKeyDown({ ...event, key: 'Tab' });
-        expect(onTabStub.callCount).to.equal(1);
-        expect(onShiftTabStub.callCount).to.equal(0);
-      });
-    });
 
     describe('focusedDate is falsy', () => {
       it('does not call maybeTransitionPrevMonth', () => {

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -399,6 +399,26 @@ describe('DayPicker', () => {
       });
     });
 
+    describe('Tab', () => {
+      describe('triggers onShiftTab when shift tab is pressed', () => {
+        const onTabStub = sinon.stub();
+        const onShiftTabStub = sinon.stub();
+        const wrapper = shallow(<DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />).dive();
+        wrapper.instance().onKeyDown({ ...event, key: 'Tab', shiftKey: true });
+        expect(onTabStub.callCount).to.equal(0);
+        expect(onShiftTabStub.callCount).to.equal(1);
+      });
+
+      describe('triggers onTab', () => {
+        const onTabStub = sinon.stub();
+        const onShiftTabStub = sinon.stub();
+        const wrapper = shallow(<DayPicker onTab={onTabStub} onShiftTab={onShiftTabStub} />).dive();
+        wrapper.instance().onKeyDown({ ...event, key: 'Tab' });
+        expect(onTabStub.callCount).to.equal(1);
+        expect(onShiftTabStub.callCount).to.equal(0);
+      });
+    });
+
     describe('focusedDate is falsy', () => {
       it('does not call maybeTransitionPrevMonth', () => {
         const maybeTransitionPrevMonthSpy = sinon.spy(PureDayPicker.prototype, 'maybeTransitionPrevMonth');


### PR DESCRIPTION
For an upcoming refactor, we need to be able to listen for when the user
hits tab inside the day picker. This is to support an a11y change in
which the daypicker will become an immediate sibling of the date input
so the user can just naturally tab into it. The problem is that when the
user hits tab to exit the day picker, we need to close the calendar,
which is currently done inside the DateRangePickerInputController. The bigger
refactor will be done in another pr

Testing
======
Npm linked this change and then tested e2e refactor. Also added a spec

Reviewers
========
@majapw 