### PR TITLE
Fix incorrect VO for selected check-in date

### DIFF
--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -35,7 +35,9 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
   const formattedDate = { date: day.format(ariaLabelFormat) };
 
   let ariaLabel = getPhrase(chooseAvailableDate, formattedDate);
-  if (modifiers.has(BLOCKED_MODIFIER)) {
+  if (modifiers.has(BLOCKED_MODIFIER) && selected) {
+    ariaLabel = getPhrase(dateIsSelected, formattedDate);
+  } else if (modifiers.has(BLOCKED_MODIFIER)) {
     ariaLabel = getPhrase(dateIsUnavailable, formattedDate);
   } else if (selected) {
     ariaLabel = getPhrase(dateIsSelected, formattedDate);

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -35,12 +35,10 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
   const formattedDate = { date: day.format(ariaLabelFormat) };
 
   let ariaLabel = getPhrase(chooseAvailableDate, formattedDate);
-  if (modifiers.has(BLOCKED_MODIFIER) && selected) {
+  if (selected) {
     ariaLabel = getPhrase(dateIsSelected, formattedDate);
   } else if (modifiers.has(BLOCKED_MODIFIER)) {
     ariaLabel = getPhrase(dateIsUnavailable, formattedDate);
-  } else if (selected) {
-    ariaLabel = getPhrase(dateIsSelected, formattedDate);
   }
 
   return {

--- a/test/utils/getCalendarDaySettings_spec.js
+++ b/test/utils/getCalendarDaySettings_spec.js
@@ -236,5 +236,20 @@ describe('getCalendarDaySettings', () => {
       expect(phrases.dateIsUnavailable.calledWith(expectedFormattedDay)).to.equal(true);
       expect(ariaLabel).to.equal('dateIsUnavailable text');
     });
+
+    it('is formatted with the dateIsSelected phrase function when day is selected for check in', () => {
+      const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
+
+      const { ariaLabel } = getCalendarDaySettings(
+        testDay,
+        testAriaLabelFormat,
+        testDaySize,
+        modifiers,
+        phrases,
+      );
+
+      expect(phrases.dateIsSelected.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelected text');
+    });
   });
 });


### PR DESCRIPTION
This PR fixes an accessibility bug where VO incorrectly defines a selected check-in date in calendar as unavailable. This is fixed by checking if the day is both blocked and selected, and if this is true the phrase should be `dateIsSelected`.