### PR TITLE
[a11y] Fix lack of visible focus in Firefox and IE on "?" keyboard shortcuts button

### DIFF
--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -285,40 +285,62 @@ export default withStyles(({ reactDates: { color, font, zIndex } }) => ({
   },
 
   DayPickerKeyboardShortcuts_show: {
-    width: 22,
+    width: 33,
+    height: 26,
     position: 'absolute',
     zIndex: zIndex + 2,
+
+    '::before': {
+      content: '""',
+      display: 'block',
+      position: 'absolute',
+    },
   },
 
   DayPickerKeyboardShortcuts_show__bottomRight: {
-    borderTop: '26px solid transparent',
-    borderRight: `33px solid ${color.core.primary}`,
     bottom: 0,
     right: 0,
 
-    ':hover': {
+    '::before': {
+      borderTop: '26px solid transparent',
+      borderRight: `33px solid ${color.core.primary}`,
+      bottom: 0,
+      right: 0,
+    },
+
+    ':hover::before': {
       borderRight: `33px solid ${color.core.primary_dark}`,
     },
   },
 
   DayPickerKeyboardShortcuts_show__topRight: {
-    borderBottom: '26px solid transparent',
-    borderRight: `33px solid ${color.core.primary}`,
     top: 0,
     right: 0,
 
-    ':hover': {
+    '::before': {
+      borderBottom: '26px solid transparent',
+      borderRight: `33px solid ${color.core.primary}`,
+      top: 0,
+      right: 0,
+    },
+
+    ':hover::before': {
       borderRight: `33px solid ${color.core.primary_dark}`,
     },
   },
 
   DayPickerKeyboardShortcuts_show__topLeft: {
-    borderBottom: '26px solid transparent',
-    borderLeft: `33px solid ${color.core.primary}`,
     top: 0,
     left: 0,
 
-    ':hover': {
+    '::before': {
+      borderBottom: '26px solid transparent',
+      borderLeft: `33px solid ${color.core.primary}`,
+      top: 0,
+      left: 0,
+    },
+
+    ':hover::before': {
       borderLeft: `33px solid ${color.core.primary_dark}`,
     },
   },
@@ -330,17 +352,17 @@ export default withStyles(({ reactDates: { color, font, zIndex } }) => ({
 
   DayPickerKeyboardShortcuts_showSpan__bottomRight: {
     bottom: 0,
-    right: -28,
+    right: 5,
   },
 
   DayPickerKeyboardShortcuts_showSpan__topRight: {
     top: 1,
-    right: -28,
+    right: 5,
   },
 
   DayPickerKeyboardShortcuts_showSpan__topLeft: {
     top: 1,
-    left: -28,
+    left: 5,
   },
 
   DayPickerKeyboardShortcuts_panel: {


### PR DESCRIPTION
## Summary
This moves the border styles that makes the triangular shape to a `::before` pseudo element and sets a specific height and width on the button itself. Also adjusts the absolute positioning on the `?` accordingly now that the dimensions have changed.

## Screenshots

### Win10, IE11, default

- [before](https://user-images.githubusercontent.com/2136754/48374733-967d6900-e67a-11e8-8289-9e95170c547c.png)
- after:<br>![after](https://user-images.githubusercontent.com/2136754/48374734-9715ff80-e67a-11e8-8bab-779c5085c203.png)

### Firefox, MacOS, vertical

- [before](https://user-images.githubusercontent.com/2136754/48374731-967d6900-e67a-11e8-9de8-6613162268d2.png)
- after:<br>![after](https://user-images.githubusercontent.com/2136754/48374732-967d6900-e67a-11e8-9eef-4a5948876974.png)

### Firefox, MacOS, vertical with fullscreen portal

- [before](https://user-images.githubusercontent.com/2136754/48374728-967d6900-e67a-11e8-859f-93d8d68b4f29.png)
- after:<br>![after](https://user-images.githubusercontent.com/2136754/48374730-967d6900-e67a-11e8-8b76-9cdf30ada1b1.png)

