### PR TITLE
[a11y] Remove space/enter onKeyDown handling for open/close keyboard shortcuts panel

### DIFF
--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -105,9 +105,6 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
     // amounts to a very basic focus trap. The user can exit the panel by "pressing" the
     // close button or hitting escape
     switch (e.key) {
-      case 'Enter':
-      case ' ':
-      case 'Spacebar': // for older browsers
       case 'Escape':
         closeKeyboardShortcutsPanel();
         break;
@@ -190,13 +187,6 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
           type="button"
           aria-label={toggleButtonText}
           onClick={this.onShowKeyboardShortcutsButtonClick}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              e.preventDefault();
-            } else if (e.key === 'Space') {
-              this.onShowKeyboardShortcutsButtonClick(e);
-            }
-          }}
           onMouseUp={(e) => {
             e.currentTarget.blur();
           }}

--- a/test/components/DayPickerKeyboardShortcuts_spec.jsx
+++ b/test/components/DayPickerKeyboardShortcuts_spec.jsx
@@ -124,17 +124,6 @@ describe('DayPickerKeyboardShortcuts', () => {
           buttonWrapper.simulate('click');
           expect(openKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
-
-        it('onKeyDown Space calls onShowKeyboardShortcutsButtonClick', () => {
-          buttonWrapper.prop('onKeyDown')({ ...event, key: 'Space' });
-          expect(openKeyboardShortcutsPanelStub.callCount).to.equal(1);
-        });
-
-        it('onKeyDown Enter calls e.preventDefault and NOT onShowKeyboardShortcutsButtonClick', () => {
-          buttonWrapper.prop('onKeyDown')({ ...event, key: 'Enter' });
-          expect(event.preventDefault.callCount).to.equal(1);
-          expect(openKeyboardShortcutsPanelStub.notCalled).to.equal(true);
-        });
       });
 
       describe('when Mouse Up', () => {
@@ -215,10 +204,10 @@ describe('DayPickerKeyboardShortcuts', () => {
           expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
 
-        it('onKeyDown Space calls e.stopPropagation and onShowKeyboardShortcutsButtonClick', () => {
+        it('onKeyDown calls e.stopPropagation and NOT onShowKeyboardShortcutsButtonClick', () => {
           closeButton.prop('onKeyDown')({ ...event, key: ' ' });
           expect(event.stopPropagation.callCount).to.equal(1);
-          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
+          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(0);
         });
 
         it('onKeyDown Escape calls e.stopPropagation and onShowKeyboardShortcutsButtonClick', () => {
@@ -227,10 +216,10 @@ describe('DayPickerKeyboardShortcuts', () => {
           expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
         });
 
-        it('onKeyDown Enter calls e.stopPropagation and onShowKeyboardShortcutsButtonClick', () => {
+        it('onKeyDown calls e.stopPropagation and NOT onShowKeyboardShortcutsButtonClick', () => {
           closeButton.prop('onKeyDown')({ ...event, key: 'Enter' });
           expect(event.stopPropagation.callCount).to.equal(1);
-          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(1);
+          expect(closeKeyboardShortcutsPanelStub.callCount).to.equal(0);
         });
 
         it('onKeyDown Tab calls e.stopPropagation and e.preventDefault and NOT onShowKeyboardShortcutsButtonClick', () => {


### PR DESCRIPTION
## Summary

This is to fix an issue where trying to close the keyboard shortcuts panel with the Space and Enter keys doesn't work in Firefox or IE. Pressing space opens and closes the panel immediately and pressing enter seems to do nothing.

As far as I can tell it looks like the `onKeyDown` event is handled on the close button, but then because the focus is set to the "?" button that opens the panel, the corresponding `onKeyUp` event triggers an `onClick` and re-opens the panel.

So – I've removed the `Enter` and `Spacebar` handling from the close button's `onKeyUp` handler, which should just allow `onClick` to do its thing. Similarly, I removed the `onKeyDown` handler on the open button (if there's more context on disabling the enter key for that button let me know, but that seemed weird to me).

## Gifs

Using [keycastr](https://github.com/keycastr/keycastr) to display keystrokes:

- `␣` = `Space`
- `↵` = `Enter`
- `⎋` = `Esc`

### Before
![before](https://user-images.githubusercontent.com/2136754/48378469-920a7d80-e685-11e8-8e5d-94f7be9baca6.gif)

### After
![after](https://user-images.githubusercontent.com/2136754/48378488-a2baf380-e685-11e8-9de1-373c78559a6a.gif)

## Reviewers 🙏

@majapw @backwardok 