### PR TITLE
Feature/auto focus date range picker

### DIFF
--- a/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
+++ b/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
@@ -1,1 +1,0 @@
-{"value":{"success":true,"data":{"latest":{"version":"4.0.0","info":{"plain":"- upgrade webpack & babel to latest\n- new addParameters and third argument to .add to pass data to addons\n- added the ability to theme storybook\n- improved ui for mobile devices\n- improved performance of addon-knobs"}}},"time":1542989334198},"type":"Object"}

--- a/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
+++ b/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
@@ -1,0 +1,1 @@
+{"value":{"success":true,"data":{"latest":{"version":"4.0.0","info":{"plain":"- upgrade webpack & babel to latest\n- new addParameters and third argument to .add to pass data to addons\n- added the ability to theme storybook\n- improved ui for mobile devices\n- improved performance of addon-knobs"}}},"time":1542989334198},"type":"Object"}

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -125,8 +125,8 @@ class DateRangePickerWrapper extends React.Component {
   render() {
     const { autoFocus, focusedInput, startDate, endDate } = this.state;
 
-    // autoFocus, autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
-    // example wrapper but are not props on the SingleDatePicker itself and
+    // autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
+    // example wrapper but are not props on the DateRangePicker itself and
     // thus, have to be omitted.
     const props = omit(this.props, [
       'autoFocusEndDate',

--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -123,13 +123,12 @@ class DateRangePickerWrapper extends React.Component {
   }
 
   render() {
-    const { focusedInput, startDate, endDate } = this.state;
+    const { autoFocus, focusedInput, startDate, endDate } = this.state;
 
     // autoFocus, autoFocusEndDate, initialStartDate and initialEndDate are helper props for the
     // example wrapper but are not props on the SingleDatePicker itself and
     // thus, have to be omitted.
     const props = omit(this.props, [
-      'autoFocus',
       'autoFocusEndDate',
       'initialStartDate',
       'initialEndDate',
@@ -145,6 +144,7 @@ class DateRangePickerWrapper extends React.Component {
           focusedInput={focusedInput}
           startDate={startDate}
           endDate={endDate}
+          autoFocus={autoFocus}
         />
       </div>
     );

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -65,6 +65,7 @@ const defaultProps = {
   small: false,
   regular: false,
   keepFocusOnInput: false,
+  autoFocus: false,
 
   // calendar presentation and interaction related props
   renderMonthText: null,
@@ -153,8 +154,8 @@ class DateRangePicker extends React.PureComponent {
     this.responsivizePickerPosition();
     this.disableScroll();
 
-    const { focusedInput } = this.props;
-    if (focusedInput) {
+    const { autoFocus, focusedInput } = this.props;
+    if (autoFocus && focusedInput) {
       this.setState({
         isDateRangePickerInputFocused: true,
       });

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -45,6 +45,7 @@ export default {
   small: PropTypes.bool,
   regular: PropTypes.bool,
   keepFocusOnInput: PropTypes.bool,
+  autoFocus: PropTypes.bool,
 
   // calendar presentation and interaction related props
   renderMonthText: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),


### PR DESCRIPTION
The current `DateRangePickerWrapper` example utilizes the `autoFocus` prop to set the `focusedInput` prop of the `DateRangePicker` to `null`, however, the `FocusedInputShape` declares its prop type as:

`PropTypes.oneOf([START_DATE, END_DATE]); `

`null` is not part of this enumeration. The purpose of this pull request is to add an `autoFocus` prop to the `DateRangePicker` shape, which allows users to follow the standard set by using `PropTypes.oneOf([...])` while still allowing them to disable focus in `componentDidMount`.

Side note: I discovered this issue by passing `null` as the `focusedInput` in my work project, and noticed Facebooks' `react-scripts` complain about `null` not being a part of the above enumeration.