### PR TITLE
Disable navigation outside of range

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -511,7 +511,6 @@ class DateRangePicker extends React.PureComponent {
       openDirection,
       phrases,
       isOutsideRange,
-      disableOutsideRangeNavigation,
       minimumNights,
       withPortal,
       withFullScreenPortal,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -108,6 +108,7 @@ const defaultProps = {
   enableOutsideDays: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  disableOutsideRangeNavigation: false,
   isDayHighlighted: () => false,
 
   // internationalization
@@ -347,6 +348,7 @@ class DateRangePicker extends React.PureComponent {
       isDayBlocked,
       isDayHighlighted,
       isOutsideRange,
+      disableOutsideRangeNavigation,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -450,6 +452,7 @@ class DateRangePicker extends React.PureComponent {
           navNext={navNext}
           minimumNights={minimumNights}
           isOutsideRange={isOutsideRange}
+          disableOutsideRangeNavigation={disableOutsideRangeNavigation}
           isDayHighlighted={isDayHighlighted}
           isDayBlocked={isDayBlocked}
           keepOpenOnDateSelect={keepOpenOnDateSelect}
@@ -508,6 +511,7 @@ class DateRangePicker extends React.PureComponent {
       openDirection,
       phrases,
       isOutsideRange,
+      disableOutsideRangeNavigation,
       minimumNights,
       withPortal,
       withFullScreenPortal,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -74,6 +74,8 @@ const propTypes = forbidExtraProps({
   // navigation props
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  renderPrev: PropTypes.bool,
+  renderNext: PropTypes.bool,
   noNavButtons: PropTypes.bool,
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
@@ -132,6 +134,8 @@ export const defaultProps = {
   // navigation props
   navPrev: null,
   navNext: null,
+  renderPrev: true,
+  renderNext: true,
   noNavButtons: false,
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -809,6 +813,8 @@ class DayPicker extends React.PureComponent {
     const {
       navPrev,
       navNext,
+      renderPrev,
+      renderNext,
       noNavButtons,
       orientation,
       phrases,
@@ -829,6 +835,8 @@ class DayPicker extends React.PureComponent {
         onNextMonthClick={onNextMonthClick}
         navPrev={navPrev}
         navNext={navNext}
+        renderPrev={renderPrev}
+        renderNext={renderNext}
         orientation={orientation}
         phrases={phrases}
         isRTL={isRTL}

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -35,6 +35,8 @@ const propTypes = forbidExtraProps({
 const defaultProps = {
   navPrev: null,
   navNext: null,
+  renderPrev: true,
+  renderNext: true,
   orientation: HORIZONTAL_ORIENTATION,
 
   onPrevMonthClick() {},
@@ -50,6 +52,8 @@ function DayPickerNavigation({
   navNext,
   onPrevMonthClick,
   onNextMonthClick,
+  renderPrev,
+  renderNext,
   orientation,
   phrases,
   isRTL,
@@ -114,7 +118,7 @@ function DayPickerNavigation({
         ] : []),
       )}
     >
-      {!isVerticalScrollable && (
+      {!isVerticalScrollable && renderPrev && (
         <div
           role="button"
           tabIndex="0"
@@ -151,43 +155,45 @@ function DayPickerNavigation({
         </div>
       )}
 
-      <div
-        role="button"
-        tabIndex="0"
-        {...css(
-          styles.DayPickerNavigation_button,
-          isDefaultNavNext && styles.DayPickerNavigation_button__default,
-          ...(isHorizontal ? [
-            styles.DayPickerNavigation_button__horizontal,
-            ...(isDefaultNavNext ? [
-              styles.DayPickerNavigation_button__horizontalDefault,
-              isRTL && styles.DayPickerNavigation_leftButton__horizontalDefault,
-              !isRTL && styles.DayPickerNavigation_rightButton__horizontalDefault,
+      {renderNext && (
+        <div
+          role="button"
+          tabIndex="0"
+          {...css(
+            styles.DayPickerNavigation_button,
+            isDefaultNavNext && styles.DayPickerNavigation_button__default,
+            ...(isHorizontal ? [
+              styles.DayPickerNavigation_button__horizontal,
+              ...(isDefaultNavNext ? [
+                styles.DayPickerNavigation_button__horizontalDefault,
+                isRTL && styles.DayPickerNavigation_leftButton__horizontalDefault,
+                !isRTL && styles.DayPickerNavigation_rightButton__horizontalDefault,
+              ] : []),
             ] : []),
-          ] : []),
-          ...(isVertical ? [
-            styles.DayPickerNavigation_button__vertical,
-            styles.DayPickerNavigation_nextButton__vertical,
-            ...(isDefaultNavNext ? [
-              styles.DayPickerNavigation_button__verticalDefault,
-              styles.DayPickerNavigation_nextButton__verticalDefault,
-              isVerticalScrollable
-                && styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
+            ...(isVertical ? [
+              styles.DayPickerNavigation_button__vertical,
+              styles.DayPickerNavigation_nextButton__vertical,
+              ...(isDefaultNavNext ? [
+                styles.DayPickerNavigation_button__verticalDefault,
+                styles.DayPickerNavigation_nextButton__verticalDefault,
+                isVerticalScrollable
+                  && styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
+              ] : []),
             ] : []),
-          ] : []),
-        )}
-        aria-label={phrases.jumpToNextMonth}
-        onClick={onNextMonthClick}
-        onKeyUp={(e) => {
-          const { key } = e;
-          if (key === 'Enter' || key === ' ') onNextMonthClick(e);
-        }}
-        onMouseUp={(e) => {
-          e.currentTarget.blur();
-        }}
-      >
-        {navNextIcon}
-      </div>
+          )}
+          aria-label={phrases.jumpToNextMonth}
+          onClick={onNextMonthClick}
+          onKeyUp={(e) => {
+            const { key } = e;
+            if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+          }}
+          onMouseUp={(e) => {
+            e.currentTarget.blur();
+          }}
+        >
+          {navNextIcon}
+        </div>)
+      }
     </div>
   );
 }

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -21,6 +21,8 @@ const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  renderPrev: PropTypes.bool,
+  renderNext: PropTypes.bool,
   orientation: ScrollableOrientationShape,
 
   onPrevMonthClick: PropTypes.func,

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -246,6 +246,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       focusedInput,
       minimumNights,
       isOutsideRange,
+      disableOutsideRangeNavigation,
       isDayBlocked,
       isDayHighlighted,
       phrases,
@@ -260,6 +261,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       focusedInput: prevFocusedInput,
       minimumNights: prevMinimumNights,
       isOutsideRange: prevIsOutsideRange,
+      disableOutsideRangeNavigation: prevDisableOutsideRangeNavigation,
       isDayBlocked: prevIsDayBlocked,
       isDayHighlighted: prevIsDayHighlighted,
       phrases: prevPhrases,
@@ -305,13 +307,17 @@ export default class DayPickerRangeController extends React.PureComponent {
         && !prevFocusedInput
         && didFocusChange
       )
+      || disableOutsideRangeNavigation !== prevDisableOutsideRangeNavigation
+      || recomputeOutsideRange
     ) {
       const newMonthState = this.getStateForNewMonth(nextProps);
-      const { currentMonth } = newMonthState;
+      const { currentMonth, renderPrev, renderNext } = newMonthState;
       ({ visibleDays } = newMonthState);
       this.setState({
         currentMonth,
         visibleDays,
+        renderPrev,
+        renderNext
       });
     }
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -308,7 +308,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         && didFocusChange
       )
       || disableOutsideRangeNavigation !== prevDisableOutsideRangeNavigation
-      || recomputeOutsideRange
+      || (isOutsideRange !== prevIsOutsideRange && disableOutsideRangeNavigation)
     ) {
       const newMonthState = this.getStateForNewMonth(nextProps);
       const { currentMonth, renderPrev, renderNext } = newMonthState;

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -317,7 +317,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         currentMonth,
         visibleDays,
         renderPrev,
-        renderNext
+        renderNext,
       });
     }
 
@@ -697,7 +697,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
-      renderPrev: renderPrev,
+      renderPrev,
       renderNext: true,
     }, () => {
       onPrevMonthClick(newCurrentMonth.clone());
@@ -731,7 +731,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
-      renderNext: renderNext,
+      renderNext,
       renderPrev: true,
     }, () => {
       onNextMonthClick(newCurrentMonth.clone());
@@ -862,14 +862,19 @@ export default class DayPickerRangeController extends React.PureComponent {
     ));
     let renderPrev = true;
     let renderNext = true;
-    if(disableOutsideRangeNavigation) {
+    if (disableOutsideRangeNavigation) {
       const prevMonth = moment(currentMonth).subtract(1, 'month');
       renderPrev = !isOutsideRange(prevMonth);
       const nextMonth = moment(currentMonth).add(numberOfMonths, 'month');
       renderNext = !isOutsideRange(nextMonth);
     }
 
-    return { currentMonth, visibleDays, renderPrev, renderNext };
+    return {
+      currentMonth,
+      visibleDays,
+      renderPrev,
+      renderNext,
+    };
   }
 
   addModifier(updatedDays, day, modifier) {
@@ -1099,7 +1104,6 @@ export default class DayPickerRangeController extends React.PureComponent {
       renderMonthText,
       navPrev,
       navNext,
-      isOutsideRange,
       noNavButtons,
       onOutsideClick,
       withPortal,
@@ -1133,7 +1137,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       phrases,
       visibleDays,
       renderPrev,
-      renderNext
+      renderNext,
     } = this.state;
 
     return (

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -430,7 +430,9 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
     const nextMonth = currentMonth.clone().add(numberOfMonths, 'month');
     const nextMonthVisibleDays = getVisibleDays(nextMonth, 1, enableOutsideDays);
-    const renderNext = disableOutsideRangeNavigation ? !isOutsideRange(nextMonth) : true;
+
+    const newNextMonth = nextMonth.clone().add(1, 'month');
+    const renderNext = disableOutsideRangeNavigation ? !isOutsideRange(newNextMonth) : true;
 
     const newCurrentMonth = currentMonth.clone().add(1, 'month');
     this.setState({

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -406,7 +406,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         ...newVisibleDays,
         ...this.getModifiers(prevMonthVisibleDays),
       },
-      renderPrev: renderPrev,
+      renderPrev,
       renderNext: true,
     }, () => {
       onPrevMonthClick(prevMonth.clone());
@@ -439,7 +439,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         ...newVisibleDays,
         ...this.getModifiers(nextMonthVisibleDays),
       },
-      renderNext: renderNext,
+      renderNext,
       renderPrev: true,
     }, () => {
       onNextMonthClick(newCurrentMonth.clone());
@@ -538,13 +538,18 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     ));
     let renderPrev = true;
     let renderNext = true;
-    if(disableOutsideRangeNavigation) {
+    if (disableOutsideRangeNavigation) {
       const prevMonth = moment(currentMonth).subtract(1, 'month');
       renderPrev = !isOutsideRange(prevMonth);
       const nextMonth = moment(currentMonth).add(numberOfMonths, 'month');
       renderNext = !isOutsideRange(nextMonth);
     }
-    return { currentMonth, visibleDays, renderPrev, renderNext };
+    return {
+      currentMonth,
+      visibleDays,
+      renderPrev,
+      renderNext,
+    };
   }
 
   addModifier(updatedDays, day, modifier) {
@@ -720,7 +725,12 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       horizontalMonthPadding,
     } = this.props;
 
-    const { currentMonth, visibleDays, renderPrev, renderNext } = this.state;
+    const {
+      currentMonth,
+      visibleDays,
+      renderPrev,
+      renderNext,
+    } = this.state;
 
     return (
       <DayPicker

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -104,6 +104,7 @@ const defaultProps = {
   enableOutsideDays: false,
   isDayBlocked: () => false,
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  disableOutsideRangeNavigation: false,
   isDayHighlighted: () => {},
 
   // internationalization props
@@ -374,6 +375,7 @@ class SingleDatePicker extends React.PureComponent {
       daySize,
       isRTL,
       isOutsideRange,
+      disableOutsideRangeNavigation,
       isDayBlocked,
       isDayHighlighted,
       weekDayFormat,

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -452,6 +452,7 @@ class SingleDatePicker extends React.PureComponent {
           daySize={daySize}
           isRTL={isRTL}
           isOutsideRange={isOutsideRange}
+          disableOutsideRangeNavigation={disableOutsideRangeNavigation}
           isDayBlocked={isDayBlocked}
           isDayHighlighted={isDayHighlighted}
           firstDayOfWeek={firstDayOfWeek}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -85,7 +85,7 @@ export default {
   enableOutsideDays: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
-  disableOutsideRangeNavigation: PropTypes.func,
+  disableOutsideRangeNavigation: PropTypes.bool,
   isDayHighlighted: PropTypes.func,
 
   // internationalization props

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -85,6 +85,7 @@ export default {
   enableOutsideDays: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
+  disableOutsideRangeNavigation: PropTypes.func,
   isDayHighlighted: PropTypes.func,
 
   // internationalization props

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -78,6 +78,7 @@ export default {
   enableOutsideDays: PropTypes.bool,
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
+  disableOutsideRangeNavigation: PropTypes.bool,
   isDayHighlighted: PropTypes.func,
 
   // internationalization props


### PR DESCRIPTION
Addresses issue #647 

Adds property ```disableOutsideRangeNavigation``` (as suggested by @majapw in [this thread](https://github.com/airbnb/react-dates/issues/631)) to ```SingleDatePicker``` and ```DateRangePicker``` components, which when set to ```true```, removes navigation to months outside of the range specified by the ```isOutsideRange``` function.
