### PR TITLE
[RTL] Fix the SDP and DRP noflip util function

### DIFF
--- a/src/utils/noflip.js
+++ b/src/utils/noflip.js
@@ -4,7 +4,7 @@ const NOFLIP = '/* @noflip */';
 // flipped in RTL contexts. This should be used only in situations where the style must remain
 // unflipped regardless of direction context. See: https://github.com/kentcdodds/rtl-css-js#usage
 export default function noflip(value) {
-  if (typeof value === 'number') return `${value}px`;
+  if (typeof value === 'number') return `${value}px ${NOFLIP}`;
   if (typeof value === 'string') return `${value} ${NOFLIP}`;
 
   throw new TypeError('noflip expects a string or a number');

--- a/test/utils/noflip_spec.js
+++ b/test/utils/noflip_spec.js
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+
+import noflip from '../../src/utils/noflip';
+
+describe('noflip', () => {
+  it('appends a noflip comment to a number', () => {
+    expect(noflip(42)).to.equal('42px /* @noflip */');
+  });
+
+  it('appends a noflip comment to a string', () => {
+    expect(noflip('foo')).to.equal('foo /* @noflip */');
+  });
+
+  it('throws when value is unexpected type', () => {
+    expect(() => {
+      noflip([]);
+    }).to.throw(TypeError);
+  });
+});


### PR DESCRIPTION
### Summary
In #1482 we added compatibility with react-with-direction. In the process we
created a helper utility `noflip` to make it so that react-with-direction
wouldn't interfere with the preexisting `isRTL` flag. This PR fixes the noflip
behavior for Numbers, and adds unit tests.

to: @majapw @ljharb @airbnb/ui-frameworks

### Screenshot
example: DateRangePicker: with DirectionProvider

_before_
![image](https://user-images.githubusercontent.com/6600720/49905109-577d3780-fe21-11e8-80f8-b7593ab49d13.png)

_after_
![image](https://user-images.githubusercontent.com/6600720/49905099-4af8df00-fe21-11e8-899f-1c574395c831.png)
