### PR TITLE
Clarify VoiceOver text for dates selected as check-in and check-out

### DIFF
--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -30,6 +30,8 @@ const chooseAvailableEndDate = ({ date }) => `Choose ${date} as your check-out d
 const chooseAvailableDate = ({ date }) => date;
 const dateIsUnavailable = ({ date }) => `Not available. ${date}`;
 const dateIsSelected = ({ date }) => `Selected. ${date}`;
+const dateIsSelectedAsCheckin = ({ date }) => `Selected for check-in. ${date}`;
+const dateIsSelectedAsCheckout = ({ date }) => `Selected for check-out. ${date}`;
 
 export default {
   calendarLabel,
@@ -62,6 +64,8 @@ export default {
   chooseAvailableEndDate,
   dateIsUnavailable,
   dateIsSelected,
+  dateIsSelectedAsCheckin,
+  dateIsSelectedAsCheckout,
 };
 
 export const DateRangePickerPhrases = {
@@ -93,6 +97,8 @@ export const DateRangePickerPhrases = {
   chooseAvailableEndDate,
   dateIsUnavailable,
   dateIsSelected,
+  dateIsSelectedAsCheckin,
+  dateIsSelectedAsCheckout,
 };
 
 export const DateRangePickerInputPhrases = {
@@ -128,6 +134,8 @@ export const SingleDatePickerPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
+  dateIsSelectedAsCheckin,
+  dateIsSelectedAsCheckout,
 };
 
 export const SingleDatePickerInputPhrases = {
@@ -161,6 +169,8 @@ export const DayPickerPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
+  dateIsSelectedAsCheckin,
+  dateIsSelectedAsCheckout,
 };
 
 export const DayPickerKeyboardShortcutsPhrases = {
@@ -192,4 +202,6 @@ export const CalendarDayPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
+  dateIsSelectedAsCheckin,
+  dateIsSelectedAsCheckout,
 };

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -30,8 +30,8 @@ const chooseAvailableEndDate = ({ date }) => `Choose ${date} as your check-out d
 const chooseAvailableDate = ({ date }) => date;
 const dateIsUnavailable = ({ date }) => `Not available. ${date}`;
 const dateIsSelected = ({ date }) => `Selected. ${date}`;
-const dateIsSelectedAsCheckin = ({ date }) => `Selected for check-in. ${date}`;
-const dateIsSelectedAsCheckout = ({ date }) => `Selected for check-out. ${date}`;
+const dateIsSelectedAsStartDate = ({ date }) => `Selected as start date. ${date}`;
+const dateIsSelectedAsEndDate = ({ date }) => `Selected as end date. ${date}`;
 
 export default {
   calendarLabel,
@@ -64,8 +64,8 @@ export default {
   chooseAvailableEndDate,
   dateIsUnavailable,
   dateIsSelected,
-  dateIsSelectedAsCheckin,
-  dateIsSelectedAsCheckout,
+  dateIsSelectedAsStartDate,
+  dateIsSelectedAsEndDate,
 };
 
 export const DateRangePickerPhrases = {
@@ -97,8 +97,8 @@ export const DateRangePickerPhrases = {
   chooseAvailableEndDate,
   dateIsUnavailable,
   dateIsSelected,
-  dateIsSelectedAsCheckin,
-  dateIsSelectedAsCheckout,
+  dateIsSelectedAsStartDate,
+  dateIsSelectedAsEndDate,
 };
 
 export const DateRangePickerInputPhrases = {
@@ -134,8 +134,6 @@ export const SingleDatePickerPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
-  dateIsSelectedAsCheckin,
-  dateIsSelectedAsCheckout,
 };
 
 export const SingleDatePickerInputPhrases = {
@@ -169,8 +167,8 @@ export const DayPickerPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
-  dateIsSelectedAsCheckin,
-  dateIsSelectedAsCheckout,
+  dateIsSelectedAsStartDate,
+  dateIsSelectedAsEndDate,
 };
 
 export const DayPickerKeyboardShortcutsPhrases = {
@@ -202,6 +200,6 @@ export const CalendarDayPhrases = {
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
-  dateIsSelectedAsCheckin,
-  dateIsSelectedAsCheckout,
+  dateIsSelectedAsStartDate,
+  dateIsSelectedAsEndDate,
 };

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -6,8 +6,8 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
     chooseAvailableDate,
     dateIsUnavailable,
     dateIsSelected,
-    dateIsSelectedAsCheckin,
-    dateIsSelectedAsCheckout,
+    dateIsSelectedAsStartDate,
+    dateIsSelectedAsEndDate,
   } = phrases;
 
   const daySizeStyles = {
@@ -38,10 +38,10 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
 
   let ariaLabel = getPhrase(chooseAvailableDate, formattedDate);
   if (selected) {
-    if (modifiers.has('selected-start')) {
-      ariaLabel = getPhrase(dateIsSelectedAsCheckin, formattedDate);
-    } else if (modifiers.has('selected-end')) {
-      ariaLabel = getPhrase(dateIsSelectedAsCheckout, formattedDate);
+    if (modifiers.has('selected-start') && dateIsSelectedAsStartDate) {
+      ariaLabel = getPhrase(dateIsSelectedAsStartDate, formattedDate);
+    } else if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
+      ariaLabel = getPhrase(dateIsSelectedAsEndDate, formattedDate);
     } else {
       ariaLabel = getPhrase(dateIsSelected, formattedDate);
     }

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -6,6 +6,8 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
     chooseAvailableDate,
     dateIsUnavailable,
     dateIsSelected,
+    dateIsSelectedAsCheckin,
+    dateIsSelectedAsCheckout,
   } = phrases;
 
   const daySizeStyles = {
@@ -36,7 +38,13 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
 
   let ariaLabel = getPhrase(chooseAvailableDate, formattedDate);
   if (selected) {
-    ariaLabel = getPhrase(dateIsSelected, formattedDate);
+    if (modifiers.has('selected-start')) {
+      ariaLabel = getPhrase(dateIsSelectedAsCheckin, formattedDate);
+    } else if (modifiers.has('selected-end')) {
+      ariaLabel = getPhrase(dateIsSelectedAsCheckout, formattedDate);
+    } else {
+      ariaLabel = getPhrase(dateIsSelected, formattedDate);
+    }
   } else if (modifiers.has(BLOCKED_MODIFIER)) {
     ariaLabel = getPhrase(dateIsUnavailable, formattedDate);
   }

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -61,8 +61,8 @@ describe('CalendarDay', () => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
         phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
         phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
-        phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
-        phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
+        phrases.dateIsSelectedAsStartDate = sinon.stub().returns('dateIsSelectedAsStartDate text');
+        phrases.dateIsSelectedAsEndDate = sinon.stub().returns('dateIsSelectedAsEndDate text');
       });
 
       it('is formatted with the chooseAvailableDate phrase function when day is available', () => {
@@ -93,7 +93,7 @@ describe('CalendarDay', () => {
         expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
       });
 
-      it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected for check in', () => {
+      it('is formatted with the dateIsSelectedAsStartDate phrase function when day is selected as the start date', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
 
         const wrapper = shallow((
@@ -104,10 +104,10 @@ describe('CalendarDay', () => {
           />
         )).dive();
 
-        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckin text');
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsStartDate text');
       });
 
-      it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected for check out', () => {
+      it('is formatted with the dateIsSelectedAsEndDate phrase function when day is selected as the end date', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
 
         const wrapper = shallow((
@@ -118,7 +118,7 @@ describe('CalendarDay', () => {
           />
         )).dive();
 
-        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckout text');
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsEndDate text');
       });
 
       it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -61,6 +61,8 @@ describe('CalendarDay', () => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
         phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
         phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
+        phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
+        phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
       });
 
       it('is formatted with the chooseAvailableDate phrase function when day is available', () => {
@@ -78,21 +80,45 @@ describe('CalendarDay', () => {
       });
 
       it('is formatted with the dateIsSelected phrase function when day is selected', () => {
-        const selectedModifiers = new Set(['selected', 'selected-start', 'selected-end']);
+        const modifiers = new Set(['selected']);
 
-        selectedModifiers.forEach((selectedModifier) => {
-          const modifiers = new Set([selectedModifier]);
+        const wrapper = shallow((
+          <CalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
 
-          const wrapper = shallow((
-            <CalendarDay
-              modifiers={modifiers}
-              phrases={phrases}
-              day={day}
-            />
-          )).dive();
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
+      });
 
-          expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
-        });
+      it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected for check in', () => {
+        const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
+
+        const wrapper = shallow((
+          <CalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
+
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckin text');
+      });
+
+      it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected for check out', () => {
+        const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
+
+        const wrapper = shallow((
+          <CalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
+
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckout text');
       });
 
       it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -62,8 +62,8 @@ describe('CustomizableCalendarDay', () => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
         phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
         phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
-        phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
-        phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
+        phrases.dateIsSelectedAsStartDate = sinon.stub().returns('dateIsSelectedAsStartDate text');
+        phrases.dateIsSelectedAsEndDate = sinon.stub().returns('dateIsSelectedAsEndDate text');
       });
 
       it('is formatted with the chooseAvailableDate phrase function when day is available', () => {
@@ -94,7 +94,7 @@ describe('CustomizableCalendarDay', () => {
         expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
       });
 
-      it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected for check in', () => {
+      it('is formatted with the dateIsSelectedAsStartDate phrase function when day is selected as the start date', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
 
         const wrapper = shallow((
@@ -105,10 +105,10 @@ describe('CustomizableCalendarDay', () => {
           />
         )).dive();
 
-        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckin text');
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsStartDate text');
       });
 
-      it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected for check out', () => {
+      it('is formatted with the dateIsSelectedAsEndDate phrase function when day is selected as the end date', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
 
         const wrapper = shallow((
@@ -119,7 +119,7 @@ describe('CustomizableCalendarDay', () => {
           />
         )).dive();
 
-        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckout text');
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsEndDate text');
       });
 
       it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -62,6 +62,8 @@ describe('CustomizableCalendarDay', () => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
         phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
         phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
+        phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
+        phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
       });
 
       it('is formatted with the chooseAvailableDate phrase function when day is available', () => {
@@ -79,21 +81,45 @@ describe('CustomizableCalendarDay', () => {
       });
 
       it('is formatted with the dateIsSelected phrase function when day is selected', () => {
-        const selectedModifiers = new Set(['selected', 'selected-start', 'selected-end']);
+        const modifiers = new Set(['selected']);
 
-        selectedModifiers.forEach((selectedModifier) => {
-          const modifiers = new Set([selectedModifier]);
+        const wrapper = shallow((
+          <CustomizableCalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
 
-          const wrapper = shallow((
-            <CustomizableCalendarDay
-              modifiers={modifiers}
-              phrases={phrases}
-              day={day}
-            />
-          )).dive();
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
+      });
 
-          expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
-        });
+      it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected for check in', () => {
+        const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
+
+        const wrapper = shallow((
+          <CustomizableCalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
+
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckin text');
+      });
+
+      it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected for check out', () => {
+        const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
+
+        const wrapper = shallow((
+          <CustomizableCalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
+
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelectedAsCheckout text');
       });
 
       it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {

--- a/test/utils/getCalendarDaySettings_spec.js
+++ b/test/utils/getCalendarDaySettings_spec.js
@@ -14,8 +14,8 @@ const testPhrases = {
   chooseAvailableDate: sinon.stub(),
   dateIsSelected: sinon.stub(),
   dateIsUnavailable: sinon.stub(),
-  dateIsSelectedAsCheckin: sinon.stub(),
-  dateIsSelectedAsCheckout: sinon.stub(),
+  dateIsSelectedAsStartDate: sinon.stub(),
+  dateIsSelectedAsEndDate: sinon.stub(),
 };
 
 describe('getCalendarDaySettings', () => {
@@ -184,8 +184,8 @@ describe('getCalendarDaySettings', () => {
       phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
       phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
       phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
-      phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
-      phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
+      phrases.dateIsSelectedAsStartDate = sinon.stub().returns('dateIsSelectedAsStartDate text');
+      phrases.dateIsSelectedAsEndDate = sinon.stub().returns('dateIsSelectedAsEndDate text');
     });
 
     afterEach(() => {
@@ -222,7 +222,7 @@ describe('getCalendarDaySettings', () => {
       expect(ariaLabel).to.equal('dateIsSelected text');
     });
 
-    it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected as checkin', () => {
+    it('is formatted with the dateIsSelectedAsStartDate phrase function when day is selected as the start date', () => {
       const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
 
       const { ariaLabel } = getCalendarDaySettings(
@@ -233,11 +233,11 @@ describe('getCalendarDaySettings', () => {
         phrases,
       );
 
-      expect(phrases.dateIsSelectedAsCheckin.calledWith(expectedFormattedDay)).to.equal(true);
-      expect(ariaLabel).to.equal('dateIsSelectedAsCheckin text');
+      expect(phrases.dateIsSelectedAsStartDate.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelectedAsStartDate text');
     });
 
-    it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected as checkout', () => {
+    it('is formatted with the dateIsSelectedAsEndDate phrase function when day is selected as the end date', () => {
       const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
 
       const { ariaLabel } = getCalendarDaySettings(
@@ -248,8 +248,28 @@ describe('getCalendarDaySettings', () => {
         phrases,
       );
 
-      expect(phrases.dateIsSelectedAsCheckout.calledWith(expectedFormattedDay)).to.equal(true);
-      expect(ariaLabel).to.equal('dateIsSelectedAsCheckout text');
+      expect(phrases.dateIsSelectedAsEndDate.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelectedAsEndDate text');
+    });
+
+    it('is formatted with the dateIsSelected phrase function when day is selected as the start or end date and no selected start or end date phrase function is specified', () => {
+      phrases.dateIsSelectedAsStartDate = null;
+      phrases.dateIsSelectedAsEndDate = null;
+      const selectedModifiers = new Set(['selected-end', 'selected-start']);
+
+      selectedModifiers.forEach((selectedModifier) => {
+        const modifiers = new Set([selectedModifier]);
+        const { ariaLabel } = getCalendarDaySettings(
+          testDay,
+          testAriaLabelFormat,
+          testDaySize,
+          modifiers,
+          phrases,
+        );
+
+        expect(phrases.dateIsSelected.calledWith(expectedFormattedDay)).to.equal(true);
+        expect(ariaLabel).to.equal('dateIsSelected text');
+      });
     });
 
     it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {

--- a/test/utils/getCalendarDaySettings_spec.js
+++ b/test/utils/getCalendarDaySettings_spec.js
@@ -14,6 +14,8 @@ const testPhrases = {
   chooseAvailableDate: sinon.stub(),
   dateIsSelected: sinon.stub(),
   dateIsUnavailable: sinon.stub(),
+  dateIsSelectedAsCheckin: sinon.stub(),
+  dateIsSelectedAsCheckout: sinon.stub(),
 };
 
 describe('getCalendarDaySettings', () => {
@@ -182,6 +184,8 @@ describe('getCalendarDaySettings', () => {
       phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
       phrases.dateIsSelected = sinon.stub().returns('dateIsSelected text');
       phrases.dateIsUnavailable = sinon.stub().returns('dateIsUnavailable text');
+      phrases.dateIsSelectedAsCheckin = sinon.stub().returns('dateIsSelectedAsCheckin text');
+      phrases.dateIsSelectedAsCheckout = sinon.stub().returns('dateIsSelectedAsCheckout text');
     });
 
     afterEach(() => {
@@ -204,22 +208,48 @@ describe('getCalendarDaySettings', () => {
     });
 
     it('is formatted with the dateIsSelected phrase function when day is selected', () => {
-      const selectedModifiers = new Set(['selected', 'selected-start', 'selected-end']);
+      const modifiers = new Set(['selected']);
 
-      selectedModifiers.forEach((selectedModifier) => {
-        const modifiers = new Set().add(selectedModifier);
+      const { ariaLabel } = getCalendarDaySettings(
+        testDay,
+        testAriaLabelFormat,
+        testDaySize,
+        modifiers,
+        phrases,
+      );
 
-        const { ariaLabel } = getCalendarDaySettings(
-          testDay,
-          testAriaLabelFormat,
-          testDaySize,
-          modifiers,
-          phrases,
-        );
+      expect(phrases.dateIsSelected.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelected text');
+    });
 
-        expect(phrases.dateIsSelected.calledWith(expectedFormattedDay)).to.equal(true);
-        expect(ariaLabel).to.equal('dateIsSelected text');
-      });
+    it('is formatted with the dateIsSelectedAsCheckin phrase function when day is selected as checkin', () => {
+      const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
+
+      const { ariaLabel } = getCalendarDaySettings(
+        testDay,
+        testAriaLabelFormat,
+        testDaySize,
+        modifiers,
+        phrases,
+      );
+
+      expect(phrases.dateIsSelectedAsCheckin.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelectedAsCheckin text');
+    });
+
+    it('is formatted with the dateIsSelectedAsCheckout phrase function when day is selected as checkout', () => {
+      const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-end');
+
+      const { ariaLabel } = getCalendarDaySettings(
+        testDay,
+        testAriaLabelFormat,
+        testDaySize,
+        modifiers,
+        phrases,
+      );
+
+      expect(phrases.dateIsSelectedAsCheckout.calledWith(expectedFormattedDay)).to.equal(true);
+      expect(ariaLabel).to.equal('dateIsSelectedAsCheckout text');
     });
 
     it('is formatted with the dateIsUnavailable phrase function when day is not available', () => {
@@ -235,21 +265,6 @@ describe('getCalendarDaySettings', () => {
 
       expect(phrases.dateIsUnavailable.calledWith(expectedFormattedDay)).to.equal(true);
       expect(ariaLabel).to.equal('dateIsUnavailable text');
-    });
-
-    it('is formatted with the dateIsSelected phrase function when day is selected for check in', () => {
-      const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
-
-      const { ariaLabel } = getCalendarDaySettings(
-        testDay,
-        testAriaLabelFormat,
-        testDaySize,
-        modifiers,
-        phrases,
-      );
-
-      expect(phrases.dateIsSelected.calledWith(expectedFormattedDay)).to.equal(true);
-      expect(ariaLabel).to.equal('dateIsSelected text');
     });
   });
 });


### PR DESCRIPTION
This PR adds clarity to the VO text for dates selected as check-in and check-out. Previously, the VO text for all selected dates was "Selected. ${date}", and I have updated it so that if the date is selected for check-in it is "Selected for check-in. ${date}" and if it is selected for check-out it is "Selected for check-out. ${date}".

jira ticket: https://jira.airbnb.biz/browse/PRODUCT-56423