### PR TITLE
Remove `darken` function from css

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -658,12 +658,10 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     zIndex: zIndex + 2,
 
     ':hover': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
       textDecoration: 'none',
     },
 
     ':focus': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
       textDecoration: 'none',
     },
   },

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -633,12 +633,10 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     zIndex: zIndex + 2,
 
     ':hover': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
       textDecoration: 'none',
     },
 
     ':focus': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
       textDecoration: 'none',
     },
   },


### PR DESCRIPTION
Currently, this breaks the processing chain when importing of css when importing via ` @import 'react-dates/lib/css/_datepicker';`. For example, I have a component library that imports styles via the method above. When the compiled css (via postcss) is imported as a dependency, it throws a syntax error.

Removing the lines, without replacing, because the styles don't appear to do anything since the icon is an SVG and not text.