### PR TITLE
Add aria-disabled prop to CalendarDay and CustomizableCalendarDay

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -142,6 +142,7 @@ class CalendarDay extends React.PureComponent {
         )}
         role="button" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         ref={this.setButtonRef}
+        aria-disabled={modifiers.has('blocked')}
         aria-label={ariaLabel}
         onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}
         onMouseLeave={(e) => { this.onDayMouseLeave(day, e); }}

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -335,6 +335,7 @@ class CustomizableCalendarDay extends React.PureComponent {
         )}
         role="button" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         ref={this.setButtonRef}
+        aria-disabled={modifiers.has('blocked')}
         aria-label={ariaLabel}
         onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}
         onMouseLeave={(e) => { this.onDayMouseLeave(day, e); }}


### PR DESCRIPTION
This PR adds the prop `aria-disabled` to `CalendarDay` and `CustomizableCalendarDay` so that days that are unavailable have the "dimmed" label. The unavailable dates are still perceivable by VO. 

#### Reviewers
@majapw @ljharb @backwardok 