### PR TITLE
Move the call to onDatesChange before the call to onFocusChange

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -490,6 +490,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     if (startDateOffset || endDateOffset) {
       startDate = getSelectedDateOffset(startDateOffset, day);
       endDate = getSelectedDateOffset(endDateOffset, day);
+      onDatesChange({ startDate, endDate });
 
       if (this.isBlocked(startDate) || this.isBlocked(endDate)) {
         return;
@@ -512,6 +513,8 @@ export default class DayPickerRangeController extends React.PureComponent {
         }
       }
 
+      onDatesChange({ startDate, endDate });
+
       if (isEndDateDisabled && !isStartDateAfterEndDate) {
         onFocusChange(null);
         onClose({ startDate, endDate });
@@ -523,9 +526,11 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       if (!startDate) {
         endDate = day;
+        onDatesChange({ startDate, endDate });
         onFocusChange(START_DATE);
       } else if (isInclusivelyAfterDay(day, firstAllowedEndDate)) {
         endDate = day;
+        onDatesChange({ startDate, endDate });
         if (!keepOpenOnDateSelect) {
           onFocusChange(null);
           onClose({ startDate, endDate });
@@ -533,10 +538,14 @@ export default class DayPickerRangeController extends React.PureComponent {
       } else if (disabled !== START_DATE) {
         startDate = day;
         endDate = null;
+        onDatesChange({ startDate, endDate });
+      } else {
+        onDatesChange({ startDate, endDate });
       }
+    } else {
+      onDatesChange({ startDate, endDate });
     }
 
-    onDatesChange({ startDate, endDate });
     onBlur();
   }
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -490,11 +490,12 @@ export default class DayPickerRangeController extends React.PureComponent {
     if (startDateOffset || endDateOffset) {
       startDate = getSelectedDateOffset(startDateOffset, day);
       endDate = getSelectedDateOffset(endDateOffset, day);
-      onDatesChange({ startDate, endDate });
 
       if (this.isBlocked(startDate) || this.isBlocked(endDate)) {
         return;
       }
+
+      onDatesChange({ startDate, endDate });
 
       if (!keepOpenOnDateSelect) {
         onFocusChange(null);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1635,7 +1635,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(clickDate.clone().format());
         expect(args.endDate).to.equal(null);
@@ -1652,7 +1652,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate).to.equal(null);
         expect(args.endDate.format()).to.equal(clickDate.clone().format());
@@ -1671,7 +1671,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(startDate.clone().format());
         expect(args.endDate.format()).to.equal(clickDate.clone().format());
@@ -1690,7 +1690,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(clickDate.clone().format());
         expect(args.endDate).to.equal(null);
@@ -1711,7 +1711,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(startDate.clone().format());
         expect(args.endDate).to.equal(null);
@@ -1727,7 +1727,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(clickDate.clone().subtract(2, 'days').format());
         expect(args.endDate.format()).to.equal(clickDate.clone().format());
@@ -1743,7 +1743,7 @@ describe('DayPickerRangeController', () => {
           />
         ));
         wrapper.instance().onDayClick(clickDate);
-        expect(onDatesChangeStub.callCount).to.equal(1);
+        expect(onDatesChangeStub).to.have.property('callCount', 1);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate.format()).to.equal(clickDate.clone().format());
         expect(args.endDate.format()).to.equal(clickDate.clone().add(4, 'days').format());

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1779,10 +1779,8 @@ describe('DayPickerRangeController', () => {
             focusedInput={START_DATE}
           />
         ));
-        // The first day click sets preventFocusChange to true, but it doesn't take effect until the
-        // second day click because onFocusChange is called before onDatesChange
         wrapper.instance().onDayClick(clickDate);
-        expect(focusedInput).to.equal(END_DATE);
+        expect(focusedInput).to.equal(START_DATE);
         wrapper.instance().onDayClick(clickDate.clone().add(1, 'days'));
         expect(focusedInput).to.equal(END_DATE);
       });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1623,6 +1623,133 @@ describe('DayPickerRangeController', () => {
       });
     });
 
+    describe('props.onDatesChange only called once in onDayClick', () => {
+      it('calls props.onDatesChange once when focusedInput === START_DATE', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            focusedInput={START_DATE}
+            endDate={null}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().format());
+        expect(args.endDate).to.equal(null);
+      });
+
+      it('calls props.onDatesChange once when focusedInput === END_DATE and there is no startDate', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            focusedInput={END_DATE}
+            startDate={null}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate).to.equal(null);
+        expect(args.endDate.format()).to.equal(clickDate.clone().format());
+      });
+
+      it('calls props.onDatesChange once when focusedInput === END_DATE and the day is a valid endDate', () => {
+        const clickDate = moment(today);
+        const startDate = clickDate.clone().subtract(2, 'days');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            focusedInput={END_DATE}
+            minimumNights={2}
+            startDate={startDate}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(startDate.clone().format());
+        expect(args.endDate.format()).to.equal(clickDate.clone().format());
+      });
+
+      it('calls props.onDatesChange once when focusedInput === END_DATE, the day is an invalid endDate, and disabled !== START_DATE', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            focusedInput={END_DATE}
+            minimumNights={2}
+            startDate={clickDate.clone().add(1, 'days')}
+            endDate={null}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().format());
+        expect(args.endDate).to.equal(null);
+      });
+
+      it('calls props.onDatesChange once when focusedInput === END_DATE and the day is an invalid endDate', () => {
+        const clickDate = moment(today);
+        const startDate = clickDate.clone().add(1, 'days');
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            focusedInput={END_DATE}
+            disabled={START_DATE}
+            minimumNights={2}
+            startDate={startDate}
+            endDate={null}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(startDate.clone().format());
+        expect(args.endDate).to.equal(null);
+      });
+
+      it('calls props.onDatesChange once when there is a startDateOffset', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            startDateOffset={day => day.subtract(2, 'days')}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().subtract(2, 'days').format());
+        expect(args.endDate.format()).to.equal(clickDate.clone().format());
+      });
+
+      it('calls props.onDatesChange once when there is a endDateOffset', () => {
+        const clickDate = moment(today);
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DayPickerRangeController
+            onDatesChange={onDatesChangeStub}
+            endDateOffset={day => day.add(4, 'days')}
+          />
+        ));
+        wrapper.instance().onDayClick(clickDate);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.startDate.format()).to.equal(clickDate.clone().format());
+        expect(args.endDate.format()).to.equal(clickDate.clone().add(4, 'days').format());
+      });
+    });
+
     describe('logic in props.onDatesChange affects props.onFocusChange', () => {
       let preventFocusChange;
       let focusedInput;


### PR DESCRIPTION
This PR moves the call to `onDatesChange` before `onFocusChange`. The purpose of this change is to allow the logic of `onDatesChange` to potentially affect the logic of `onFocusChange`. 

For example, I would like to allow users to click on certain unavailable dates and then show them a corresponding error state. When such a date is clicked, I do not want the focus to change because the date they clicked would not actually be selected. The logic of whether or not to change focus needs to occur in `onDatesChange`, so this function needs to be called before `onFocusChange`.