### PR TITLE
Fix issues with Portal not including container elements.

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -563,7 +563,6 @@ class DateRangePicker extends React.PureComponent {
       isOutsideRange,
       minimumNights,
       withPortal,
-      appendToBody,
       withFullScreenPortal,
       displayFormat,
       reopenPickerOnClearDates,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -631,7 +631,7 @@ class DateRangePicker extends React.PureComponent {
       </DateRangePickerInputController>
     );
 
-    return this.maybeWithPortal(
+    return this.maybeWithPortal((
       <div
         ref={this.setContainerRef}
         {...css(
@@ -645,8 +645,8 @@ class DateRangePicker extends React.PureComponent {
           </OutsideClickHandler>
         )}
         {enableOutsideClick || input}
-      </div>,
-    );
+      </div>
+    ));
   }
 }
 

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -363,22 +363,29 @@ class DateRangePicker extends React.PureComponent {
     });
   }
 
-  maybeRenderDayPickerWithPortal() {
-    const { withPortal, withFullScreenPortal, appendToBody } = this.props;
-
+  maybeRenderDayPicker() {
     if (!this.isOpened()) {
       return null;
     }
 
+    return this.renderDayPicker();
+  }
+
+  maybeWithPortal(children) {
+    // Use the <Portal> component when requested to hoist the element as a
+    // direct child of document.body.
+
+    const { withPortal, withFullScreenPortal, appendToBody } = this.props;
+
     if (withPortal || withFullScreenPortal || appendToBody) {
       return (
         <Portal>
-          {this.renderDayPicker()}
+          {children}
         </Portal>
       );
     }
 
-    return this.renderDayPicker();
+    return children;
   }
 
   renderDayPicker() {
@@ -556,6 +563,7 @@ class DateRangePicker extends React.PureComponent {
       isOutsideRange,
       minimumNights,
       withPortal,
+      appendToBody,
       withFullScreenPortal,
       displayFormat,
       reopenPickerOnClearDates,
@@ -619,11 +627,11 @@ class DateRangePicker extends React.PureComponent {
         regular={regular}
         verticalSpacing={verticalSpacing}
       >
-        {this.maybeRenderDayPickerWithPortal()}
+        {this.maybeRenderDayPicker()}
       </DateRangePickerInputController>
     );
 
-    return (
+    return this.maybeWithPortal(
       <div
         ref={this.setContainerRef}
         {...css(
@@ -637,7 +645,7 @@ class DateRangePicker extends React.PureComponent {
           </OutsideClickHandler>
         )}
         {enableOutsideClick || input}
-      </div>
+      </div>,
     );
   }
 }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -253,17 +253,17 @@ class SingleDatePicker extends React.PureComponent {
   }
 
   setDayPickerContainerRef(ref) {
-    this.dayPickerContainer = ref;
-  }
-
-  setContainerRef(ref) {
-    if (ref === this.container) return;
+    if (ref === this.dayPickerContainer) return;
     this.removeEventListeners();
 
-    this.container = ref;
+    this.dayPickerContainer = ref;
     if (!ref) return;
 
     this.addEventListeners();
+  }
+
+  setContainerRef(ref) {
+    this.container = ref;
   }
 
   addEventListeners() {
@@ -271,7 +271,7 @@ class SingleDatePicker extends React.PureComponent {
     // Keep an eye on https://github.com/facebook/react/issues/6410 for updates
     // We use "blur w/ useCapture param" vs "onfocusout" for FF browser support
     this.removeFocusOutEventListener = addEventListener(
-      this.container,
+      this.dayPickerContainer,
       'focusout',
       this.onFocusOut,
     );
@@ -307,6 +307,7 @@ class SingleDatePicker extends React.PureComponent {
       appendToBody,
       focused,
     } = this.props;
+
     const { dayPickerContainerStyles } = this.state;
 
     if (!focused) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -348,27 +348,43 @@ class SingleDatePicker extends React.PureComponent {
     });
   }
 
-  maybeRenderDayPickerWithPortal() {
+  maybeRenderDayPicker() {
     const {
       focused,
-      withPortal,
-      withFullScreenPortal,
-      appendToBody,
     } = this.props;
 
     if (!focused) {
       return null;
     }
 
+    return this.renderDayPicker();
+  }
+
+  maybeWithPortal(children) {
+    const {
+      withPortal,
+      withFullScreenPortal,
+      appendToBody,
+    } = this.props;
+
     if (withPortal || withFullScreenPortal || appendToBody) {
-      return (
-        <Portal>
-          {this.renderDayPicker()}
-        </Portal>
-      );
+      return <Portal>{children}</Portal>;
     }
 
-    return this.renderDayPicker();
+    return children;
+  }
+
+  maybeWithOutsideClickHandler(children) {
+    const { withPortal, withFullScreenPortal } = this.props;
+    const enableOutsideClick = !withPortal && !withFullScreenPortal;
+
+    if (!enableOutsideClick) return children;
+
+    return (
+      <OutsideClickHandler onOutsideClick={this.onOutsideClick}>
+        {children}
+      </OutsideClickHandler>
+    );
   }
 
   renderDayPicker() {
@@ -417,6 +433,7 @@ class SingleDatePicker extends React.PureComponent {
       small,
       theme: { reactDates },
     } = this.props;
+
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
     const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onOutsideClick : undefined;
@@ -542,8 +559,6 @@ class SingleDatePicker extends React.PureComponent {
 
     const { isInputFocused } = this.state;
 
-    const enableOutsideClick = (!withPortal && !withFullScreenPortal);
-
     const hideFang = verticalSpacing < FANG_HEIGHT_PX;
 
     const input = (
@@ -580,7 +595,7 @@ class SingleDatePicker extends React.PureComponent {
         reopenPickerOnClearDate={reopenPickerOnClearDate}
         keepOpenOnDateSelect={keepOpenOnDateSelect}
       >
-        {this.maybeRenderDayPickerWithPortal()}
+        {this.maybeRenderDayPicker()}
       </SingleDatePickerInputController>
     );
 
@@ -592,12 +607,7 @@ class SingleDatePicker extends React.PureComponent {
           block && styles.SingleDatePicker__block,
         )}
       >
-        {enableOutsideClick && (
-          <OutsideClickHandler onOutsideClick={this.onOutsideClick}>
-            {input}
-          </OutsideClickHandler>
-        )}
-        {enableOutsideClick || input}
+        {this.maybeWithPortal(this.maybeWithOutsideClickHandler(input))}
       </div>
     );
   }

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -206,7 +206,6 @@ function SingleDatePickerInput({
       )}
 
       {inputIconPosition === ICON_AFTER_POSITION && inputIcon}
-
     </div>
   );
 }

--- a/src/utils/getDetachedContainerStyles.js
+++ b/src/utils/getDetachedContainerStyles.js
@@ -22,6 +22,7 @@ import { OPEN_UP, ANCHOR_RIGHT } from '../constants';
  */
 export default function getDetachedContainerStyles(openDirection, anchorDirection, referenceEl) {
   const referenceRect = referenceEl.getBoundingClientRect();
+
   let offsetX = referenceRect.left;
   let offsetY = referenceRect.top;
 


### PR DESCRIPTION
After the 18.4.1 patch, we an issue has occurred where `focusout` always causes the day picker to close when a click occurs anywhere on the page - even within the day picker itself. This is because the `<Portal>` is being placed around the day picker instead of it's containers. This PR fixes that issue.

Thanks to @alvaro-cuesta for discovering this one and letting us know; fixes #1522