### PR TITLE
Stop calendar blinking on DateRangePickerInput focus switch (fixes #1523)

### DIFF
--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -190,7 +190,11 @@ function DateRangePickerInput({
     />
   );
 
-  const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
+  const screenReaderStartDateText = screenReaderMessage
+    || phrases.keyboardForwardNavigationInstructions;
+  const screenReaderEndDateText = screenReaderMessage
+    || phrases.keyboardBackwardNavigationInstructions;
+
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
     <button
       {...css(styles.DateRangePickerInput_calendarIcon)}
@@ -224,7 +228,7 @@ function DateRangePickerInput({
         placeholder={startDatePlaceholderText}
         ariaLabel={startDateAriaLabel}
         displayValue={startDate}
-        screenReaderMessage={screenReaderText}
+        screenReaderMessage={screenReaderStartDateText}
         focused={isStartDateFocused}
         isFocused={isFocused}
         disabled={startDateDisabled}
@@ -242,6 +246,8 @@ function DateRangePickerInput({
         regular={regular}
       />
 
+      {children}
+
       {
         <div
           {...css(styles.DateRangePickerInput_arrow)}
@@ -252,14 +258,12 @@ function DateRangePickerInput({
         </div>
       }
 
-      {isStartDateFocused && children}
-
       <DateInput
         id={endDateId}
         placeholder={endDatePlaceholderText}
         ariaLabel={endDateAriaLabel}
         displayValue={endDate}
-        screenReaderMessage={screenReaderText}
+        screenReaderMessage={screenReaderEndDateText}
         focused={isEndDateFocused}
         isFocused={isFocused}
         disabled={endDateDisabled}
@@ -277,7 +281,6 @@ function DateRangePickerInput({
         regular={regular}
       />
 
-      {isEndDateFocused && children}
 
       {showClearDates && (
         <button

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -139,7 +139,7 @@ function SingleDatePickerInput({
     />
   );
 
-  const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
+  const screenReaderText = screenReaderMessage || phrases.keyboardForwardNavigationInstructions;
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
     <button
       {...css(styles.SingleDatePickerInput_calendarIcon)}

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -22,8 +22,8 @@ const moveFocusByOneWeek = 'Move backward (up) and forward (down) by one week.';
 const moveFocusByOneMonth = 'Switch months.';
 const moveFocustoStartAndEndOfWeek = 'Go to the first or last day of a week.';
 const returnFocusToInput = 'Return to the date input field.';
-const keyboardNavigationInstructions = `Press the down arrow key to interact with the calendar and
-  select a date. Press the question mark key to get the keyboard shortcuts for changing dates.`;
+const keyboardForwardNavigationInstructions = 'Navigate forward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.';
+const keyboardBackwardNavigationInstructions = 'Navigate backward to interact with the calendar and select a date. Press the question mark key to get the keyboard shortcuts for changing dates.';
 
 const chooseAvailableStartDate = ({ date }) => `Choose ${date} as your check-in date. It’s available.`;
 const chooseAvailableEndDate = ({ date }) => `Choose ${date} as your check-out date. It’s available.`;
@@ -58,7 +58,8 @@ export default {
   moveFocusByOneMonth,
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
-  keyboardNavigationInstructions,
+  keyboardForwardNavigationInstructions,
+  keyboardBackwardNavigationInstructions,
 
   chooseAvailableStartDate,
   chooseAvailableEndDate,
@@ -92,7 +93,8 @@ export const DateRangePickerPhrases = {
   moveFocusByOneMonth,
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
-  keyboardNavigationInstructions,
+  keyboardForwardNavigationInstructions,
+  keyboardBackwardNavigationInstructions,
   chooseAvailableStartDate,
   chooseAvailableEndDate,
   dateIsUnavailable,
@@ -104,7 +106,8 @@ export const DateRangePickerPhrases = {
 export const DateRangePickerInputPhrases = {
   focusStartDate,
   clearDates,
-  keyboardNavigationInstructions,
+  keyboardForwardNavigationInstructions,
+  keyboardBackwardNavigationInstructions,
 };
 
 export const SingleDatePickerPhrases = {
@@ -130,7 +133,8 @@ export const SingleDatePickerPhrases = {
   moveFocusByOneMonth,
   moveFocustoStartAndEndOfWeek,
   returnFocusToInput,
-  keyboardNavigationInstructions,
+  keyboardForwardNavigationInstructions,
+  keyboardBackwardNavigationInstructions,
   chooseAvailableDate,
   dateIsUnavailable,
   dateIsSelected,
@@ -138,7 +142,8 @@ export const SingleDatePickerPhrases = {
 
 export const SingleDatePickerInputPhrases = {
   clearDate,
-  keyboardNavigationInstructions,
+  keyboardForwardNavigationInstructions,
+  keyboardBackwardNavigationInstructions,
 };
 
 export const DayPickerPhrases = {

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -49,6 +49,15 @@ describe('DateRangePickerInput', () => {
         });
       });
     });
+
+    describe('props.children', () => {
+      it('should unconditionally render children when provided', () => {
+        const Child = () => <div>CHILD</div>;
+
+        const wrapper = shallow(<DateRangePickerInput><Child /></DateRangePickerInput>).dive();
+        expect(wrapper.find('Child')).to.have.lengthOf(1);
+      });
+    });
   });
 
   describe('props.customArrowIcon', () => {

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -4,6 +4,8 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon-sandbox';
 
 import SingleDatePickerInput from '../../src/components/SingleDatePickerInput';
+import DateInput from '../../src/components/DateInput';
+import { SingleDatePickerInputPhrases } from '../../src/defaultPhrases';
 
 describe('SingleDatePickerInput', () => {
   describe('render', () => {
@@ -92,6 +94,35 @@ describe('SingleDatePickerInput', () => {
         const clearDateWrapper = wrapper.find('button');
         clearDateWrapper.simulate('click');
         expect(onClearDateSpy).to.have.property('called', true);
+      });
+    });
+  });
+
+  describe('screen reader message', () => {
+    describe('props.screenReaderMessage is falsy', () => {
+      it('default value is passed to DateInput', () => {
+        const wrapper = shallow(<SingleDatePickerInput id="date" />).dive();
+        const dateInput = wrapper.find(DateInput);
+        expect(dateInput).to.have.lengthOf(1);
+        expect(dateInput.props()).to.have.property(
+          'screenReaderMessage',
+          SingleDatePickerInputPhrases.keyboardForwardNavigationInstructions,
+        );
+      });
+    });
+
+    describe('props.screenReaderMessage is truthy', () => {
+      it('prop value is passed to DateInput', () => {
+        const message = 'test message';
+        const wrapper = shallow((
+          <SingleDatePickerInput
+            id="date"
+            screenReaderMessage={message}
+          />
+        )).dive();
+        const dateInput = wrapper.find(DateInput);
+        expect(dateInput).to.have.lengthOf(1);
+        expect(dateInput.props()).to.have.property('screenReaderMessage', message);
       });
     });
   });


### PR DESCRIPTION
Using `isStartDateFocused` and `isEndDateFocused` to conditionally render `children` causes the calendar to disappear and reappear whenever the focus switches from the start date input to end date input.

This pr adopts same approach as dd9d6b27b300dc8e31d89fcd982d525845e9c698 by skipping the focus check and just rendering the children.