### PR TITLE
Fix VO issue for date ranges

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -136,7 +136,7 @@ class CalendarDay extends React.PureComponent {
           modifiers.has('last-in-range') && styles.CalendarDay__last_in_range,
           modifiers.has('selected-start') && styles.CalendarDay__selected_start,
           modifiers.has('selected-end') && styles.CalendarDay__selected_end,
-          selected && styles.CalendarDay__selected,
+          selected && !modifiers.has('selected-span') && styles.CalendarDay__selected,
           isOutsideRange && styles.CalendarDay__blocked_out_of_range,
           daySizeStyles,
         )}

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -1,6 +1,24 @@
 import getPhrase from './getPhrase';
 import { BLOCKED_MODIFIER } from '../constants';
 
+function isSelected(modifiers) {
+  return modifiers.has('selected')
+  || modifiers.has('selected-span')
+  || modifiers.has('selected-start')
+  || modifiers.has('selected-end');
+}
+
+function shouldUseDefaultCursor(modifiers) {
+  return modifiers.has('blocked-minimum-nights')
+  || modifiers.has('blocked-calendar')
+  || modifiers.has('blocked-out-of-range');
+}
+
+function isHoveredSpan(modifiers) {
+  if (isSelected(modifiers)) return false;
+  return modifiers.has('hovered-span') || modifiers.has('after-hovered-start');
+}
+
 function getAriaLabel(phrases, modifiers, day, ariaLabelFormat) {
   const {
     chooseAvailableDate,
@@ -18,30 +36,13 @@ function getAriaLabel(phrases, modifiers, day, ariaLabelFormat) {
     return getPhrase(dateIsSelectedAsStartDate, formattedDate);
   } if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
     return getPhrase(dateIsSelectedAsEndDate, formattedDate);
-  } if (modifiers.has('selected') && dateIsSelected) {
+  } if (isSelected(modifiers) && dateIsSelected) {
     return getPhrase(dateIsSelected, formattedDate);
   } if (modifiers.has(BLOCKED_MODIFIER)) {
     return getPhrase(dateIsUnavailable, formattedDate);
   }
 
   return getPhrase(chooseAvailableDate, formattedDate);
-}
-
-function isSelected(modifiers) {
-  return modifiers.has('selected')
-  || modifiers.has('selected-start')
-  || modifiers.has('selected-end');
-}
-
-function shouldUseDefaultCursor(modifiers) {
-  return modifiers.has('blocked-minimum-nights')
-  || modifiers.has('blocked-calendar')
-  || modifiers.has('blocked-out-of-range');
-}
-
-function isHoveredSpan(modifiers) {
-  if (isSelected(modifiers)) return false;
-  return modifiers.has('hovered-span') || modifiers.has('after-hovered-start');
 }
 
 export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases) {

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -1,7 +1,7 @@
 import getPhrase from './getPhrase';
 import { BLOCKED_MODIFIER } from '../constants';
 
-export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases) {
+function getAriaLabel(phrases, modifiers, day, ariaLabelFormat) {
   const {
     chooseAvailableDate,
     dateIsUnavailable,
@@ -10,51 +10,51 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
     dateIsSelectedAsEndDate,
   } = phrases;
 
-  const daySizeStyles = {
-    width: daySize,
-    height: daySize - 1,
+  const formattedDate = {
+    date: day.format(ariaLabelFormat),
   };
 
-  const useDefaultCursor = (
-    modifiers.has('blocked-minimum-nights')
-    || modifiers.has('blocked-calendar')
-    || modifiers.has('blocked-out-of-range')
-  );
-
-  const selected = (
-    modifiers.has('selected')
-    || modifiers.has('selected-start')
-    || modifiers.has('selected-end')
-  );
-
-  const hoveredSpan = !selected && (
-    modifiers.has('hovered-span')
-    || modifiers.has('after-hovered-start')
-  );
-
-  const isOutsideRange = modifiers.has('blocked-out-of-range');
-
-  const formattedDate = { date: day.format(ariaLabelFormat) };
-
-  let ariaLabel = getPhrase(chooseAvailableDate, formattedDate);
-  if (selected) {
-    if (modifiers.has('selected-start') && dateIsSelectedAsStartDate) {
-      ariaLabel = getPhrase(dateIsSelectedAsStartDate, formattedDate);
-    } else if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
-      ariaLabel = getPhrase(dateIsSelectedAsEndDate, formattedDate);
-    } else {
-      ariaLabel = getPhrase(dateIsSelected, formattedDate);
-    }
-  } else if (modifiers.has(BLOCKED_MODIFIER)) {
-    ariaLabel = getPhrase(dateIsUnavailable, formattedDate);
+  if (modifiers.has('selected-start') && dateIsSelectedAsStartDate) {
+    return getPhrase(dateIsSelectedAsStartDate, formattedDate);
+  } if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
+    return getPhrase(dateIsSelectedAsEndDate, formattedDate);
+  } if (modifiers.has('selected') && dateIsSelected) {
+    return getPhrase(dateIsSelected, formattedDate);
+  } if (modifiers.has(BLOCKED_MODIFIER)) {
+    return getPhrase(dateIsUnavailable, formattedDate);
   }
 
+  return getPhrase(chooseAvailableDate, formattedDate);
+}
+
+function isSelected(modifiers) {
+  return modifiers.has('selected')
+  || modifiers.has('selected-start')
+  || modifiers.has('selected-end');
+}
+
+function shouldUseDefaultCursor(modifiers) {
+  return modifiers.has('blocked-minimum-nights')
+  || modifiers.has('blocked-calendar')
+  || modifiers.has('blocked-out-of-range');
+}
+
+function isHoveredSpan(modifiers) {
+  if (isSelected(modifiers)) return false;
+  return modifiers.has('hovered-span') || modifiers.has('after-hovered-start');
+}
+
+export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases) {
   return {
-    daySizeStyles,
-    useDefaultCursor,
-    selected,
-    hoveredSpan,
-    isOutsideRange,
-    ariaLabel,
+    ariaLabel: getAriaLabel(phrases, modifiers, day, ariaLabelFormat),
+    hoveredSpan: isHoveredSpan(modifiers),
+    isOutsideRange: modifiers.has('blocked-out-of-range'),
+    selected: isSelected(modifiers),
+    useDefaultCursor: shouldUseDefaultCursor(modifiers),
+
+    daySizeStyles: {
+      width: daySize,
+      height: daySize - 1,
+    },
   };
 }

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -93,6 +93,20 @@ describe('CalendarDay', () => {
         expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
       });
 
+      it('is formatted with the dateIsSelected phrase function when day is selected in a span', () => {
+        const modifiers = new Set(['selected-span']);
+
+        const wrapper = shallow((
+          <CalendarDay
+            modifiers={modifiers}
+            phrases={phrases}
+            day={day}
+          />
+        )).dive();
+
+        expect(wrapper.prop('aria-label')).to.equal('dateIsSelected text');
+      });
+
       it('is formatted with the dateIsSelectedAsStartDate phrase function when day is selected as the start date', () => {
         const modifiers = new Set().add(BLOCKED_MODIFIER).add('selected-start');
 


### PR DESCRIPTION
This fixes an issue where VoiceOver and other accessibility tools don't let people know that dates are selected when they are somewhere between the start and end date of a date range/span.