### PR TITLE
fix(DayPickerSingleDateController): Add missing modifiers when loading more months in `VERTICAL_SCROLLABLE` orientation

### DIFF
--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -183,6 +183,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
 
+    this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
@@ -449,6 +450,22 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     });
   }
 
+  onMultiplyScrollableMonths() {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const numberOfVisibleMonths = Object.keys(visibleDays).length;
+    const nextMonth = currentMonth.clone().add(numberOfVisibleMonths, 'month');
+    const newVisibleDays = getVisibleDays(nextMonth, numberOfMonths, enableOutsideDays, true);
+
+    this.setState({
+      visibleDays: {
+        ...visibleDays,
+        ...this.getModifiers(newVisibleDays),
+      },
+    });
+  }
+
   getFirstFocusableDay(newMonth) {
     const { date, numberOfMonths } = this.props;
 
@@ -497,13 +514,16 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       date,
       numberOfMonths,
       enableOutsideDays,
+      orientation,
     } = nextProps;
     const initialVisibleMonthThunk = initialVisibleMonth || (date ? () => date : () => this.today);
     const currentMonth = initialVisibleMonthThunk();
+    const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
     const visibleDays = this.getModifiers(getVisibleDays(
       currentMonth,
       numberOfMonths,
       enableOutsideDays,
+      withoutTransitionMonths,
     ));
     return { currentMonth, visibleDays };
   }
@@ -696,6 +716,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         onNextMonthClick={this.onNextMonthClick}
         onMonthChange={this.onMonthChange}
         onYearChange={this.onYearChange}
+        onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
         monthFormat={monthFormat}
         withPortal={withPortal}
         hidden={!focused}

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -1165,6 +1165,29 @@ describe('DayPickerSingleDateController', () => {
       const modifiers = wrapper.instance().addModifier(updatedDays, nextMonth, modifierToAdd);
       expect(Array.from(modifiers[nextMonthISO][nextMonthDayISO])).to.contain(modifierToAdd);
     });
+
+    it('return value now has modifier arg for day after multiplying number of months', () => {
+      const modifierToAdd = 'foo';
+      const futureDateAfterMultiply = today.clone().add(4, 'months');
+      const monthISO = toISOMonthString(futureDateAfterMultiply);
+      const todayISO = toISODateString(futureDateAfterMultiply);
+      const updatedDays = {
+        [monthISO]: { [todayISO]: new Set(['bar', 'baz']) },
+      };
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          numberOfMonths={3}
+          orientation={VERTICAL_SCROLLABLE}
+        />
+      )).instance();
+      let modifiers = wrapper.addModifier(updatedDays, futureDateAfterMultiply, modifierToAdd);
+      expect(Array.from(modifiers[monthISO][todayISO])).to.not.contain(modifierToAdd);
+      wrapper.onMultiplyScrollableMonths();
+      modifiers = wrapper.addModifier(updatedDays, futureDateAfterMultiply, modifierToAdd);
+      expect(Array.from(modifiers[monthISO][todayISO])).to.contain(modifierToAdd);
+    });
   });
 
   describe('#deleteModifier', () => {


### PR DESCRIPTION
### Bug

Right now, when we use `DayPickerSingleDateController with `orientation: 'verticalScrollable'`, when i.e. your start date is 15 Feb 2019 and have `numberOfMonths: 3`, it will correctly show additional months from May to July, but when you want to hover with mouse any month days in June (interesting note: it happens only for the 2nd appended month, so no May or July in this example), it will return bunch of errors like those:

![image](https://user-images.githubusercontent.com/44373826/53344293-45804080-390a-11e9-9c23-d6fb52fecce0.png)

```
DayPickerSingleDateController.js:781 Uncaught TypeError: Cannot read property '2019-06-01' of undefined
    at DayPickerSingleDateController.addModifier (DayPickerSingleDateController.js:781)
    at DayPickerSingleDateController.onDayMouseEnter (DayPickerSingleDateController.js:525)
    at CalendarDay.onDayMouseEnter (CalendarDay.js:165)
    at onMouseEnter (CalendarDay.js:236)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:270)
    at executeDispatch (react-dom.development.js:561)
    at executeDispatchesInOrder (react-dom.development.js:583)
```

### Fix

I noticed that even though DayPickerSingleDateController and DayPickerRangeController have very similar logic to each other, the DateRangePickerInputController has the logic for updating modifiers in `onMultiplyScrollableMonths` ( https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerRangeController.jsx#L779-L793 ), but DayPickerSingleDateController lacks it.

So basing on that code, I added this functionality (and test) to DayPickerSingleDateController as well, using almost the same code.