### PR TITLE
Focus ring now shows up around custom navigation buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ yarn.lock
 package-lock.json
 
 css/styles.css
+
+# Cache
+.cache/

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -128,7 +128,7 @@ function DayPickerNavigation({
       )}
     >
       {!isVerticalScrollable && (
-        <div
+        <div // eslint-disable-line jsx-a11y/interactive-supports-focus
           role="button"
           {...navPrevTabIndex}
           {...css(
@@ -166,7 +166,7 @@ function DayPickerNavigation({
         </div>
       )}
 
-      <div
+      <div // eslint-disable-line jsx-a11y/interactive-supports-focus
         role="button"
         {...navNextTabIndex}
         {...css(

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -70,7 +70,10 @@ function DayPickerNavigation({
   let navNextIcon = navNext;
   let isDefaultNavPrev = false;
   let isDefaultNavNext = false;
+  let navPrevTabIndex = {};
+  let navNextTabIndex = {};
   if (!navPrevIcon) {
+    navPrevTabIndex = { tabIndex: '0' };
     isDefaultNavPrev = true;
     let Icon = isVertical ? ChevronUp : LeftArrow;
     if (isRTL && !isVertical) {
@@ -88,6 +91,7 @@ function DayPickerNavigation({
   }
 
   if (!navNextIcon) {
+    navNextTabIndex = { tabIndex: '0' };
     isDefaultNavNext = true;
     let Icon = isVertical ? ChevronDown : RightArrow;
     if (isRTL && !isVertical) {
@@ -126,7 +130,7 @@ function DayPickerNavigation({
       {!isVerticalScrollable && (
         <div
           role="button"
-          tabIndex={isDefaultNavPrev ? '0' : null}
+          {...navPrevTabIndex}
           {...css(
             styles.DayPickerNavigation_button,
             isDefaultNavPrev && styles.DayPickerNavigation_button__default,
@@ -164,7 +168,7 @@ function DayPickerNavigation({
 
       <div
         role="button"
-        tabIndex={isDefaultNavNext ? '0' : null}
+        {...navNextTabIndex}
         {...css(
           styles.DayPickerNavigation_button,
           isDefaultNavNext && styles.DayPickerNavigation_button__default,

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -126,7 +126,7 @@ function DayPickerNavigation({
       {!isVerticalScrollable && (
         <div
           role="button"
-          tabIndex="0"
+          tabIndex={isDefaultNavPrev ? '0' : null}
           {...css(
             styles.DayPickerNavigation_button,
             isDefaultNavPrev && styles.DayPickerNavigation_button__default,
@@ -164,7 +164,7 @@ function DayPickerNavigation({
 
       <div
         role="button"
-        tabIndex="0"
+        tabIndex={isDefaultNavNext ? '0' : null}
         {...css(
           styles.DayPickerNavigation_button,
           isDefaultNavNext && styles.DayPickerNavigation_button__default,

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -10,29 +10,37 @@ import {
 } from '../src/constants';
 
 const TestPrevIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
+      left: '24px',
       padding: '3px',
+      position: 'absolute',
+      width: '40px',
     }}
+    tabindex="0"
   >
     Prev
-  </span>
+  </div>
 );
 
 const TestNextIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
       padding: '3px',
+      position: 'absolute',
+      right: '24px',
+      width: '40px',
     }}
+    tabindex="0"
   >
     Next
-  </span>
+  </div>
 );
 
 const TestCustomInfoPanel = () => (

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -26,10 +26,23 @@ describe('DayPickerNavigation', () => {
       expect(nextMonthButton.prop('tabIndex')).to.equal('0');
     });
 
-    it('tabindex is present when custom buttons are used', () => {
+    it('tabindex is not present when custom buttons are used', () => {
       const wrapper = shallow(<DayPickerNavigation navNext={<div />} navPrev={<div />} />).dive();
       const prevMonthButton = wrapper.find('[role="button"]').at(0);
       const nextMonthButton = wrapper.find('[role="button"]').at(1);
+      expect(prevMonthButton.prop('tabIndex')).to.equal(undefined);
+      expect(nextMonthButton.prop('tabIndex')).to.equal(undefined);
+    });
+
+    it('tabindex is present when custom buttons are used and provide a tabIndex', () => {
+      const wrapper = shallow(
+        <DayPickerNavigation
+          navNext={<div id="navNext" tabIndex="0" />} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+          navPrev={<div id="navPrev" tabIndex="0" />} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+        />,
+      ).dive();
+      const prevMonthButton = wrapper.find('#navPrev');
+      const nextMonthButton = wrapper.find('#navNext');
       expect(prevMonthButton.prop('tabIndex')).to.equal('0');
       expect(nextMonthButton.prop('tabIndex')).to.equal('0');
     });


### PR DESCRIPTION
This PR fixes an issue where when custom navigation buttons are provided, the focus ring for keyboard-only users did not appear around the custom buttons. This issue is fixed by only supplying a `tabindex` when the default navigation buttons are used. This means that in order for custom navigation buttons to receive keyboard focus a `tabindex` must be specified on the object passed in. 

#### Before
![calendar_tabbing_before](https://user-images.githubusercontent.com/14023505/53372781-9727cb80-3908-11e9-9bfb-ac4d2779b438.gif)

#### After
![calendar_tabbing_after](https://user-images.githubusercontent.com/14023505/53372794-9e4ed980-3908-11e9-9530-b1ec7b6e46db.gif)
