### PR TITLE
Enable treeShaking import in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "20.0.0",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
+  "module": "esm/index.js",
+  "sideEffects": [
+    "*.css",
+    "*initialize.js"
+  ],
   "scripts": {
     "prebuild": "npm run clean",
     "build": "npm run build:cjs && npm run build:esm && npm run build:css -- --optimize ",


### PR DESCRIPTION
As webpack (create react app) have enable treeshaking feature to minimize the bundling size.
(https://webpack.js.org/guides/tree-shaking/)
(https://github.com/webpack/webpack/blob/master/lib/optimize/SideEffectsFlagPlugin.js)

It would be good if react-dates can support this feature