### PR TITLE
Add positioning to custom navigation in stories

### DIFF
--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -9,7 +9,7 @@ import DateRangePickerWrapper from '../examples/DateRangePickerWrapper';
 
 function CustomMonthNav({ children, style }) {
   return (
-    <span
+    <div
       style={{
         border: '1px solid #dce0e0',
         borderRadius: 2,
@@ -21,12 +21,12 @@ function CustomMonthNav({ children, style }) {
         marginTop: -2,
         top: 19,
         left: 13,
-        outline: 'inherit',
         ...style,
       }}
+      tabindex="0"
     >
       {children}
-    </span>
+    </div>
   );
 }
 

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -19,8 +19,8 @@ function CustomMonthNav({ children, style }) {
         padding: '0 3px',
         position: 'absolute',
         marginTop: -2,
-        top: 30,
-        left: 26,
+        top: 19,
+        left: 13,
         outline: 'inherit',
         ...style,
       }}
@@ -131,7 +131,7 @@ storiesOf('DRP - Calendar Props', module)
   .add('with custom month navigation', withInfo()(() => (
     <DateRangePickerWrapper
       navPrev={<CustomMonthNav>&#8249;</CustomMonthNav>}
-      navNext={<CustomMonthNav style={{ left: 48 }}>&#8250;</CustomMonthNav>}
+      navNext={<CustomMonthNav style={{ left: 33 }}>&#8250;</CustomMonthNav>}
       numberOfMonths={1}
       autoFocus
     />
@@ -140,7 +140,7 @@ storiesOf('DRP - Calendar Props', module)
     <DateRangePickerWrapper
       orientation={VERTICAL_ORIENTATION}
       navPrev={<CustomMonthNav>&#8249;</CustomMonthNav>}
-      navNext={<CustomMonthNav style={{ left: 48 }}>&#8250;</CustomMonthNav>}
+      navNext={<CustomMonthNav style={{ left: 33 }}>&#8250;</CustomMonthNav>}
       autoFocus
     />
   )))

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -15,9 +15,10 @@ const TestPrevIcon = () => (
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
-      left: '24px',
+      left: '22px',
       padding: '3px',
       position: 'absolute',
+      top: '20px',
       width: '40px',
     }}
     tabindex="0"
@@ -34,7 +35,8 @@ const TestNextIcon = () => (
       color: '#484848',
       padding: '3px',
       position: 'absolute',
-      right: '24px',
+      right: '22px',
+      top: '20px',
       width: '40px',
     }}
     tabindex="0"

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -31,7 +31,7 @@ const dayPickerRangeControllerInfo = `The ${monospace('DayPickerRangeController'
   implement your own inputs.`;
 
 const TestPrevIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -41,13 +41,14 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
+    tabindex="0"
   >
     Prev
-  </span>
+  </div>
 );
 
 const TestNextIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -57,9 +58,10 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
+    tabindex="0"
   >
     Next
-  </span>
+  </div>
 );
 
 const TestCustomInfoPanel = () => (

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -36,7 +36,10 @@ const TestPrevIcon = () => (
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
+      left: '22px',
       padding: '3px',
+      position: 'absolute',
+      top: '20px',
     }}
   >
     Prev
@@ -50,6 +53,9 @@ const TestNextIcon = () => (
       backgroundColor: '#fff',
       color: '#484848',
       padding: '3px',
+      position: 'absolute',
+      right: '22px',
+      top: '20px',
     }}
   >
     Next

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -37,7 +37,10 @@ const TestPrevIcon = () => (
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
+      left: '22px',
       padding: '3px',
+      position: 'absolute',
+      top: '20px',
     }}
   >
     Prev
@@ -51,6 +54,9 @@ const TestNextIcon = () => (
       backgroundColor: '#fff',
       color: '#484848',
       padding: '3px',
+      position: 'absolute',
+      right: '22px',
+      top: '20px',
     }}
   >
     Next

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -32,7 +32,7 @@ const dayPickerSingleDateControllerInfo = `The ${monospace('DayPickerSingleDateC
   implement your own input.`;
 
 const TestPrevIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -42,13 +42,14 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
+    tabindex="0"
   >
     Prev
-  </span>
+  </div>
 );
 
 const TestNextIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -58,9 +59,10 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
+    tabindex="0"
   >
     Next
-  </span>
+  </div>
 );
 
 const TestCustomInfoPanel = () => (

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -13,7 +13,10 @@ const TestPrevIcon = () => (
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
       color: '#484848',
+      left: '22px',
       padding: '3px',
+      position: 'absolute',
+      top: '20px',
     }}
   >
     Prev
@@ -27,6 +30,9 @@ const TestNextIcon = () => (
       backgroundColor: '#fff',
       color: '#484848',
       padding: '3px',
+      position: 'absolute',
+      right: '22px',
+      top: '20px',
     }}
   >
     Next
@@ -149,7 +155,7 @@ storiesOf('SDP - Calendar Props', module)
   .add('with info panel default', withInfo()(() => (
     <SingleDatePickerWrapper
       renderCalendarInfo={() => (
-        <TestCustomInfoPanel borderPosition='borderBottom'/>
+        <TestCustomInfoPanel borderPosition='borderBottom' />
       )}
       autoFocus
     />

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -8,7 +8,7 @@ import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
 import { VERTICAL_ORIENTATION, ANCHOR_RIGHT, OPEN_UP } from '../src/constants';
 
 const TestPrevIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -18,13 +18,14 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
+    tabindex="0"
   >
     Prev
-  </span>
+  </div>
 );
 
 const TestNextIcon = () => (
-  <span
+  <div
     style={{
       border: '1px solid #dce0e0',
       backgroundColor: '#fff',
@@ -34,9 +35,10 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
+    tabindex="0"
   >
     Next
-  </span>
+  </div>
 );
 
 const TestCustomInfoPanel = () => (


### PR DESCRIPTION
Hi all, first time contributing here.

#1204 removed default styling on custom navigation buttons. This PR just fixes the positioning of all stories that have custom nav buttons by adding the positions to each example.

Closes #1532.

Before:
![image](https://user-images.githubusercontent.com/1811583/53932079-12009b80-40ec-11e9-9d76-af878f530bbe.png)

After:
![image](https://user-images.githubusercontent.com/1811583/53932096-25ac0200-40ec-11e9-823e-4098a6c04654.png)

**Affected stories:**
[SDP - Calendar Props - with custom arrows](http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Calendar%20Props&selectedStory=with%20custom%20arrows&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DayPicker - with custom arrows](http://airbnb.io/react-dates/?selectedKind=DayPicker&selectedStory=with%20custom%20arrows&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DRP - Calendar Props - with custom month navigation](http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Calendar%20Props&selectedStory=with%20custom%20month%20navigation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DRP - Calendar Props - vertical with custom month navigation](http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Calendar%20Props&selectedStory=vertical%20with%20custom%20month%20navigation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DayPickerSingleDateController - with custom month navigation](http://airbnb.io/react-dates/?selectedKind=DayPickerSingleDateController&selectedStory=with%20custom%20month%20navigation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DayPickerRangeController - with custom navigation](http://airbnb.io/react-dates/?selectedKind=DayPickerRangeController&selectedStory=with%20custom%20month%20navigation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)
[DayPickerRangeController - with custom navigation and blocked navigation](http://airbnb.io/react-dates/?selectedKind=DayPickerRangeController&selectedStory=with%20custom%20month%20navigation&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)

Happy to do more clean ups in this area as well if desired. #1563 added a tabindex to custom nav elements but only one of the examples, and also a lot of the repeated 'prev' & 'next' styles can be DRY'ed up.