### PR TITLE
Feature: Add mindate maxdate props to daterangepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ renderMonthElement: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'r
 hideKeyboardShortcutsPanel: PropTypes.bool,
 
 // navigation related props
+minDate: momentPropTypes.momentObj,
+maxDate: momentPropTypes.momentObj,
 navPrev: PropTypes.node,
 navNext: PropTypes.node,
 onPrevMonthClick: PropTypes.func,
@@ -315,6 +317,8 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
   noBorder: PropTypes.bool,
 
   // navigation related props
+  minDate: momentPropTypes.momentObj,
+  maxDate: momentPropTypes.momentObj,
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -97,6 +97,8 @@ const defaultProps = {
   horizontalMonthPadding: undefined,
 
   // navigation related props
+  minDate: null,
+  maxDate: null,
   navPrev: null,
   navNext: null,
 
@@ -438,6 +440,8 @@ class DateRangePicker extends React.PureComponent {
       horizontalMonthPadding,
       small,
       disabled,
+      minDate,
+      maxDate,
       theme: { reactDates },
     } = this.props;
 
@@ -524,6 +528,8 @@ class DateRangePicker extends React.PureComponent {
           transitionDuration={transitionDuration}
           disabled={disabled}
           horizontalMonthPadding={horizontalMonthPadding}
+          minDate={minDate}
+          maxDate={maxDate}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -77,6 +77,8 @@ export default {
   horizontalMonthPadding: nonNegativeInteger,
 
   // navigation related props
+  minDate: momentPropTypes.momentObj,
+  maxDate: momentPropTypes.momentObj,
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
   onPrevMonthClick: PropTypes.func,

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -117,4 +117,13 @@ storiesOf('DateRangePicker (DRP)', module)
       orientation={VERTICAL_ORIENTATION}
       verticalHeight={568}
     />
-  )));
+  ))).add('with navigation disabled for minDate and maxDate', withInfo()(() => {
+    const minDate = moment()
+    const maxDate = moment().add(2, 'month')
+    return (
+      <DateRangePickerWrapper
+        maxDate={maxDate}
+        minDate={minDate}
+      />
+    )
+  }));

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -741,4 +741,42 @@ describe('DateRangePicker', () => {
       });
     });
   });
+
+  describe('minDate and maxDate', () => {
+    describe('minDate is passed in', () => {
+      it('Should pass minDate to DayPickerRangeController', () => {
+        const minDate = moment('2018-10-17');
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            minDate={minDate}
+          />
+        )).dive();
+
+        const dayPicker = wrapper.find(DayPickerRangeController);
+        const dayPickerMinDate = dayPicker.props().minDate;
+
+        expect(dayPickerMinDate.format()).to.equal(minDate.format());
+      });
+    });
+
+    describe('maxDate is passed in', () => {
+      it('Should pass maxDate to DayPickerRangeController', () => {
+        const maxDate = moment('2018-10-17').add(1, 'month');
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            maxDate={maxDate}
+          />
+        )).dive();
+
+        const dayPicker = wrapper.find(DayPickerRangeController);
+        const dayPickerMaxDate = dayPicker.props().maxDate;
+
+        expect(dayPickerMaxDate.format()).to.equal(maxDate.format());
+      });
+    });
+  });
 });


### PR DESCRIPTION
Adding `minDate` and `maxDate` props to the `DateRangePicker` component, to be able to disable navigation in the calendar.

The functionality was only implemented in the `DateRangePickerController`, which is rendered from `DateRangePicker`. This PR just adds the ability to set this props in the main react-dates component