### PR TITLE
Fixed error message reporting verticalScrollable is not a valid orientation

### DIFF
--- a/src/shapes/OrientationShape.js
+++ b/src/shapes/OrientationShape.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE
 } from '../constants';
 
-export default PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION]);
+export default PropTypes.oneOf([HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE]);


### PR DESCRIPTION
Title is self-descriptive. Got this error bugging me around and only could fix it that way.