### PR TITLE
Add disabledPrev and disabledNext props to DayPickerSingleDateController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - []  ([#](https://github.com/airbnb/react-dates/pull/))
 -->
 
-## [Unreleased]
-- [fix] Fix date selection in the SDP ([#1530])
+## 20.1.1
+- [fix] add disabledPrev and disabledNext props to DayPickerSingleDateController
 
 
 ## 20.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dates",
-  "version": "20.1.0",
+  "version": "20.1.1",
   "description": "A responsive and accessible date range picker component built with React",
   "main": "index.js",
   "scripts": {
@@ -110,7 +110,7 @@
     "why-did-you-update": "^1.0.6"
   },
   "dependencies": {
-    "airbnb-prop-types": "2.13.1",
+    "airbnb-prop-types": "^2.10.0",
     "consolidated-events": "^1.1.1 || ^2.0.0",
     "is-touch-device": "^1.0.1",
     "lodash": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "why-did-you-update": "^1.0.6"
   },
   "dependencies": {
-    "airbnb-prop-types": "^2.10.0",
+    "airbnb-prop-types": "2.13.1",
     "consolidated-events": "^1.1.1 || ^2.0.0",
     "is-touch-device": "^1.0.1",
     "lodash": "^4.1.1",

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -63,6 +63,8 @@ const propTypes = forbidExtraProps({
 
   navPrev: PropTypes.node,
   navNext: PropTypes.node,
+  disablePrev: PropTypes.node,
+  disableNext: PropTypes.node,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
@@ -119,6 +121,8 @@ const defaultProps = {
 
   navPrev: null,
   navNext: null,
+  disablePrev: false,
+  disableNext: false,
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -653,6 +657,8 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       renderMonthText,
       navPrev,
       navNext,
+      disablePrev,
+      disableNext,
       onOutsideClick,
       onShiftTab,
       onTab,
@@ -705,6 +711,8 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         onOutsideClick={onOutsideClick}
         navPrev={navPrev}
         navNext={navNext}
+        disablePrev={disablePrev}
+        disableNext={disableNext}
         renderMonthText={renderMonthText}
         renderCalendarDay={renderCalendarDay}
         renderDayContents={renderDayContents}

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -203,9 +203,8 @@ storiesOf('DayPickerSingleDateController', module)
       onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
-      isOutsideRange={day =>
-        !isInclusivelyAfterDay(day, moment()) ||
-        isInclusivelyAfterDay(day, moment().add(2, 'weeks'))
+      isOutsideRange={day => !isInclusivelyAfterDay(day, moment())
+        || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))
       }
     />
   )))
@@ -291,5 +290,15 @@ storiesOf('DayPickerSingleDateController', module)
       onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
       verticalBorderSpacing={16}
+    />
+  )))
+  .add('with previous and next buttons disabled', withInfo()(() => (
+    <DayPickerSingleDateControllerWrapper
+      onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
+      verticalBorderSpacing={16}
+      disablePrev
+      disableNext
     />
   )));

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -761,6 +761,19 @@ describe('DayPickerSingleDateController', () => {
       expect(onPrevMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
       expect(onPrevMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
     });
+    it('disables PrevMonthClick', () => {
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          disablePrev
+        />
+      ));
+      wrapper.setState({
+        currentMonth: today,
+      });
+      expect(wrapper.instance().onPrevMonthClick()).to.equal(undefined);
+    });
   });
 
   describe('#onNextMonthClick', () => {
@@ -842,6 +855,19 @@ describe('DayPickerSingleDateController', () => {
       expect(onNextMonthClickStub.callCount).to.equal(1);
       expect(onNextMonthClickStub.firstCall.args[0].year()).to.equal(newMonth.year());
       expect(onNextMonthClickStub.firstCall.args[0].month()).to.equal(newMonth.month());
+    });
+    it('disables NextMonthClick', () => {
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          disableNext
+        />
+      ));
+      wrapper.setState({
+        currentMonth: today,
+      });
+      expect(wrapper.instance().onNextMonthClick()).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
Currently DayPickerSingleDateController does not support disabledPrev and disabledNext props. This PR will add the ability to provide that support.