### PR TITLE
Avoid some unnecessary re-rendering of CalendarDays

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -143,15 +143,16 @@ class DayPickerRangeControllerWrapper extends React.Component {
 
     return (
       <div style={{ height: '100%' }}>
-        {showInputs &&
+        {showInputs && (
           <div style={{ marginBottom: 16 }}>
             <input type="text" name="start date" value={startDateString} readOnly />
             <input type="text" name="end date" value={endDateString} readOnly />
           </div>
-        }
+        )}
 
         <DayPickerRangeController
           {...props}
+          id="storybook-example"
           onDatesChange={this.onDatesChange}
           onFocusChange={this.onFocusChange}
           focusedInput={focusedInput}

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -5,8 +5,6 @@ import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
-import { CalendarDayPhrases } from '../defaultPhrases';
-import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 import getCalendarDaySettings from '../utils/getCalendarDaySettings';
 import ModifiersShape from '../shapes/ModifiersShape';
 
@@ -24,10 +22,7 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderDayContents: PropTypes.func,
-  ariaLabelFormat: PropTypes.string,
-
-  // internationalization
-  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
+  ariaLabel: PropTypes.string.isRequired,
 });
 
 const defaultProps = {
@@ -41,10 +36,6 @@ const defaultProps = {
   onDayMouseEnter() {},
   onDayMouseLeave() {},
   renderDayContents: null,
-  ariaLabelFormat: 'dddd, LL',
-
-  // internationalization
-  phrases: CalendarDayPhrases,
 };
 
 class CalendarDay extends React.PureComponent {
@@ -94,14 +85,13 @@ class CalendarDay extends React.PureComponent {
   render() {
     const {
       day,
-      ariaLabelFormat,
       daySize,
       isOutsideDay,
       modifiers,
       renderDayContents,
       tabIndex,
       styles,
-      phrases,
+      ariaLabel,
     } = this.props;
 
     if (!day) return <td />;
@@ -112,8 +102,7 @@ class CalendarDay extends React.PureComponent {
       selected,
       hoveredSpan,
       isOutsideRange,
-      ariaLabel,
-    } = getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases);
+    } = getCalendarDaySettings(daySize, modifiers);
 
     return (
       <td

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -22,7 +22,7 @@ const propTypes = forbidExtraProps({
   onDayMouseEnter: PropTypes.func,
   onDayMouseLeave: PropTypes.func,
   renderDayContents: PropTypes.func,
-  ariaLabel: PropTypes.string.isRequired,
+  ariaLabelledby: PropTypes.string.isRequired,
 });
 
 const defaultProps = {
@@ -91,7 +91,7 @@ class CalendarDay extends React.PureComponent {
       renderDayContents,
       tabIndex,
       styles,
-      ariaLabel,
+      ariaLabelledby,
     } = this.props;
 
     if (!day) return <td />;
@@ -131,7 +131,7 @@ class CalendarDay extends React.PureComponent {
         role="button" // eslint-disable-line jsx-a11y/no-noninteractive-element-to-interactive-role
         ref={this.setButtonRef}
         aria-disabled={modifiers.has('blocked')}
-        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
         onMouseEnter={(e) => { this.onDayMouseEnter(day, e); }}
         onMouseLeave={(e) => { this.onDayMouseLeave(day, e); }}
         onMouseUp={(e) => { e.currentTarget.blur(); }}

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -7,9 +7,6 @@ import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'ai
 import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
-import { CalendarDayPhrases } from '../defaultPhrases';
-import getPhrasePropTypes from '../utils/getPhrasePropTypes';
-
 import CalendarWeek from './CalendarWeek';
 import CalendarDay from './CalendarDay';
 
@@ -27,48 +24,7 @@ import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_SCROLLABLE,
   DAY_SIZE,
-  BLOCKED_MODIFIER,
 } from '../constants';
-import getPhrase from '../utils/getPhrase';
-import { isSelected } from '../utils/getCalendarDaySettings';
-
-function getAriaLabel(phrases, modifiers, day, ariaLabelFormat) {
-  if (!day) {
-    return '';
-  }
-
-  const {
-    chooseAvailableDate,
-    dateIsUnavailable,
-    dateIsSelected,
-    dateIsSelectedAsStartDate,
-    dateIsSelectedAsEndDate,
-  } = phrases;
-
-  const formattedDate = {
-    date: day.format(ariaLabelFormat),
-  };
-
-  if (modifiers) {
-    if (modifiers.has('selected-start') && dateIsSelectedAsStartDate) {
-      return getPhrase(dateIsSelectedAsStartDate, formattedDate);
-    }
-
-    if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
-      return getPhrase(dateIsSelectedAsEndDate, formattedDate);
-    }
-
-    if (isSelected(modifiers) && dateIsSelected) {
-      return getPhrase(dateIsSelected, formattedDate);
-    }
-
-    if (modifiers.has(BLOCKED_MODIFIER)) {
-      return getPhrase(dateIsUnavailable, formattedDate);
-    }
-  }
-
-  return getPhrase(chooseAvailableDate, formattedDate);
-}
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -97,8 +53,7 @@ const propTypes = forbidExtraProps({
 
   // i18n
   monthFormat: PropTypes.string,
-  phrases: PropTypes.shape(getPhrasePropTypes(CalendarDayPhrases)),
-  dayAriaLabelFormat: PropTypes.string,
+  dayLabelledbyId: PropTypes.string.isRequired,
 });
 
 const defaultProps = {
@@ -126,8 +81,6 @@ const defaultProps = {
 
   // i18n
   monthFormat: 'MMMM YYYY', // english locale
-  phrases: CalendarDayPhrases,
-  dayAriaLabelFormat: 'dddd, LL',
   verticalBorderSpacing: undefined,
 };
 
@@ -193,7 +146,7 @@ class CalendarMonth extends React.PureComponent {
 
   render() {
     const {
-      dayAriaLabelFormat,
+      dayLabelledbyId,
       daySize,
       focusedDate,
       horizontalMonthPadding,
@@ -208,7 +161,6 @@ class CalendarMonth extends React.PureComponent {
       onMonthSelect,
       onYearSelect,
       orientation,
-      phrases,
       renderCalendarDay,
       renderDayContents,
       renderMonthElement,
@@ -262,23 +214,20 @@ class CalendarMonth extends React.PureComponent {
           <tbody>
             {weeks.map((week, i) => (
               <CalendarWeek key={i}>
-                {week.map((day, dayOfWeek) => {
-                  const dayModifiers = modifiers[toISODateString(day)];
-                  return renderCalendarDay({
-                    key: dayOfWeek,
-                    day,
-                    daySize,
-                    isOutsideDay: !day || day.month() !== month.month(),
-                    tabIndex: isVisible && isSameDay(day, focusedDate) ? 0 : -1,
-                    isFocused,
-                    onDayMouseEnter,
-                    onDayMouseLeave,
-                    onDayClick,
-                    renderDayContents,
-                    ariaLabel: getAriaLabel(phrases, dayModifiers, day, dayAriaLabelFormat),
-                    modifiers: dayModifiers,
-                  });
-                })}
+                {week.map((day, dayOfWeek) => renderCalendarDay({
+                  key: dayOfWeek,
+                  day,
+                  daySize,
+                  isOutsideDay: !day || day.month() !== month.month(),
+                  tabIndex: isVisible && isSameDay(day, focusedDate) ? 0 : -1,
+                  isFocused,
+                  onDayMouseEnter,
+                  onDayMouseLeave,
+                  onDayClick,
+                  renderDayContents,
+                  ariaLabelledby: dayLabelledbyId,
+                  modifiers: modifiers[toISODateString(day)],
+                }))}
               </CalendarWeek>
             ))}
           </tbody>

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -388,6 +388,7 @@ class DateRangePicker extends React.PureComponent {
 
   renderDayPicker() {
     const {
+      startDateId,
       anchorDirection,
       openDirection,
       isDayBlocked,
@@ -478,6 +479,7 @@ class DateRangePicker extends React.PureComponent {
         onClick={onOutsideClick}
       >
         <DayPickerRangeController
+          id={`daypickerrange-${startDateId}`}
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
           numberOfMonths={numberOfMonths}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -98,6 +98,7 @@ const propTypes = forbidExtraProps({
   onDayMouseLeave: PropTypes.func,
 
   // accessibility props
+  id: PropTypes.string.isRequired,
   isFocused: PropTypes.bool,
   getFirstFocusableDay: PropTypes.func,
   onBlur: PropTypes.func,
@@ -918,6 +919,7 @@ class DayPicker extends React.PureComponent {
     } = this.state;
 
     const {
+      id,
       enableOutsideDays,
       numberOfMonths,
       orientation,
@@ -1082,6 +1084,7 @@ class DayPicker extends React.PureComponent {
                 ref={this.setTransitionContainerRef}
               >
                 <CalendarMonthGrid
+                  id={id}
                   setMonthTitleHeight={!monthTitleHeight ? this.setMonthTitleHeight : undefined}
                   translationValue={translationValue}
                   enableOutsideDays={enableOutsideDays}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -191,6 +191,7 @@ export default class DayPickerRangeController extends React.PureComponent {
 
     this.isTouchDevice = isTouchDevice();
     this.today = moment();
+    this.modifiersCache = new Map();
     this.modifiers = {
       today: day => this.isToday(day),
       blocked: day => this.isBlocked(day),
@@ -944,8 +945,19 @@ export default class DayPickerRangeController extends React.PureComponent {
     return modifiers;
   }
 
+  getCachedModifiers(modifiersArray) {
+    const cacheKey = modifiersArray.join('!');
+
+    if (!this.modifiersCache.has(cacheKey)) {
+      this.modifiersCache.set(cacheKey, new Set(modifiersArray));
+    }
+
+    return this.modifiersCache.get(cacheKey);
+  }
+
   getModifiersForDay(day) {
-    return new Set(Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day)));
+    const modifiers = Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day));
+    return this.getCachedModifiers(modifiers);
   }
 
   getStateForNewMonth(nextProps) {
@@ -1013,7 +1025,7 @@ export default class DayPickerRangeController extends React.PureComponent {
           ...days,
           [monthIso]: {
             ...month,
-            [iso]: modifiers,
+            [iso]: this.getCachedModifiers(Array.from(modifiers)),
           },
         };
       }, updatedDaysAfterAddition);
@@ -1027,7 +1039,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         ...updatedDaysAfterAddition,
         [monthIso]: {
           ...month,
-          [iso]: modifiers,
+          [iso]: this.getCachedModifiers(Array.from(modifiers)),
         },
       };
     }
@@ -1078,7 +1090,7 @@ export default class DayPickerRangeController extends React.PureComponent {
           ...days,
           [monthIso]: {
             ...month,
-            [iso]: modifiers,
+            [iso]: this.getCachedModifiers(Array.from(modifiers)),
           },
         };
       }, updatedDaysAfterDeletion);
@@ -1092,7 +1104,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         ...updatedDaysAfterDeletion,
         [monthIso]: {
           ...month,
-          [iso]: modifiers,
+          [iso]: this.getCachedModifiers(Array.from(modifiers)),
         },
       };
     }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -41,6 +41,7 @@ import {
 import DayPicker from './DayPicker';
 
 const propTypes = forbidExtraProps({
+  id: PropTypes.string.isRequired,
   startDate: momentPropTypes.momentObj,
   endDate: momentPropTypes.momentObj,
   onDatesChange: PropTypes.func,
@@ -1237,6 +1238,7 @@ export default class DayPickerRangeController extends React.PureComponent {
 
   render() {
     const {
+      id,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -1282,6 +1284,7 @@ export default class DayPickerRangeController extends React.PureComponent {
 
     return (
       <DayPicker
+        id={id}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
         modifiers={visibleDays}

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -73,6 +73,7 @@ const propTypes = forbidExtraProps({
   calendarInfoPosition: CalendarInfoPositionShape,
 
   // accessibility
+  id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   isFocused: PropTypes.bool,
   showKeyboardShortcuts: PropTypes.bool,
@@ -659,6 +660,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
   render() {
     const {
+      id,
       numberOfMonths,
       orientation,
       monthFormat,
@@ -697,6 +699,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
     return (
       <DayPicker
+        id={id}
         orientation={orientation}
         enableOutsideDays={enableOutsideDays}
         modifiers={visibleDays}

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -153,6 +153,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     this.isTouchDevice = false;
     this.today = moment();
 
+    this.modifiersCache = new Map();
     this.modifiers = {
       today: day => this.isToday(day),
       blocked: day => this.isBlocked(day),
@@ -487,8 +488,19 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     return modifiers;
   }
 
+  getCachedModifiers(modifiersArray) {
+    const cacheKey = modifiersArray.join('!');
+
+    if (!this.modifiersCache.has(cacheKey)) {
+      this.modifiersCache.set(cacheKey, new Set(modifiersArray));
+    }
+
+    return this.modifiersCache.get(cacheKey);
+  }
+
   getModifiersForDay(day) {
-    return new Set(Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day)));
+    const modifiers = Object.keys(this.modifiers).filter(modifier => this.modifiers[modifier](day));
+    return this.getCachedModifiers(modifiers);
   }
 
   getStateForNewMonth(nextProps) {
@@ -540,7 +552,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
           ...days,
           [monthIso]: {
             ...month,
-            [iso]: modifiers,
+            [iso]: this.getCachedModifiers(Array.from(modifiers)),
           },
         };
       }, updatedDaysAfterAddition);
@@ -554,7 +566,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         ...updatedDaysAfterAddition,
         [monthIso]: {
           ...month,
-          [iso]: modifiers,
+          [iso]: this.getCachedModifiers(Array.from(modifiers)),
         },
       };
     }
@@ -594,7 +606,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
           ...days,
           [monthIso]: {
             ...month,
-            [iso]: modifiers,
+            [iso]: this.getCachedModifiers(Array.from(modifiers)),
           },
         };
       }, updatedDaysAfterDeletion);
@@ -608,7 +620,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         ...updatedDaysAfterDeletion,
         [monthIso]: {
           ...month,
-          [iso]: modifiers,
+          [iso]: this.getCachedModifiers(Array.from(modifiers)),
         },
       };
     }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -384,6 +384,7 @@ class SingleDatePicker extends React.PureComponent {
 
   renderDayPicker() {
     const {
+      id,
       anchorDirection,
       openDirection,
       onDateChange,
@@ -462,6 +463,7 @@ class SingleDatePicker extends React.PureComponent {
         onClick={onOutsideClick}
       >
         <DayPickerSingleDateController
+          id={`daypickersingle-${id}`}
           date={date}
           onDateChange={onDateChange}
           onFocusChange={onFocusChange}

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -1,7 +1,4 @@
-import getPhrase from './getPhrase';
-import { BLOCKED_MODIFIER } from '../constants';
-
-function isSelected(modifiers) {
+export function isSelected(modifiers) {
   return modifiers.has('selected')
   || modifiers.has('selected-span')
   || modifiers.has('selected-start')
@@ -19,35 +16,8 @@ function isHoveredSpan(modifiers) {
   return modifiers.has('hovered-span') || modifiers.has('after-hovered-start');
 }
 
-function getAriaLabel(phrases, modifiers, day, ariaLabelFormat) {
-  const {
-    chooseAvailableDate,
-    dateIsUnavailable,
-    dateIsSelected,
-    dateIsSelectedAsStartDate,
-    dateIsSelectedAsEndDate,
-  } = phrases;
-
-  const formattedDate = {
-    date: day.format(ariaLabelFormat),
-  };
-
-  if (modifiers.has('selected-start') && dateIsSelectedAsStartDate) {
-    return getPhrase(dateIsSelectedAsStartDate, formattedDate);
-  } if (modifiers.has('selected-end') && dateIsSelectedAsEndDate) {
-    return getPhrase(dateIsSelectedAsEndDate, formattedDate);
-  } if (isSelected(modifiers) && dateIsSelected) {
-    return getPhrase(dateIsSelected, formattedDate);
-  } if (modifiers.has(BLOCKED_MODIFIER)) {
-    return getPhrase(dateIsUnavailable, formattedDate);
-  }
-
-  return getPhrase(chooseAvailableDate, formattedDate);
-}
-
-export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases) {
+export default function getCalendarDaySettings(daySize, modifiers) {
   return {
-    ariaLabel: getAriaLabel(phrases, modifiers, day, ariaLabelFormat),
     hoveredSpan: isHoveredSpan(modifiers),
     isOutsideRange: modifiers.has('blocked-out-of-range'),
     selected: isSelected(modifiers),

--- a/stories/DayPicker.js
+++ b/stories/DayPicker.js
@@ -20,7 +20,7 @@ const TestPrevIcon = () => (
       position: 'absolute',
       width: '40px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Prev
   </div>
@@ -37,7 +37,7 @@ const TestNextIcon = () => (
       right: '24px',
       width: '40px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Next
   </div>
@@ -57,19 +57,20 @@ const TestCustomInfoPanel = () => (
 
 storiesOf('DayPicker', module)
   .add('default', withInfo()(() => (
-    <DayPicker />
+    <DayPicker id="storybook-daypicker" />
   )))
   .add('with custom day size', withInfo()(() => (
-    <DayPicker daySize={50} />
+    <DayPicker id="storybook-daypicker" daySize={50} />
   )))
   .add('single month', withInfo()(() => (
-    <DayPicker numberOfMonths={1} />
+    <DayPicker id="storybook-daypicker" numberOfMonths={1} />
   )))
   .add('3 months', withInfo()(() => (
-    <DayPicker numberOfMonths={3} />
+    <DayPicker id="storybook-daypicker" numberOfMonths={3} />
   )))
   .add('vertical', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
     />
@@ -82,6 +83,7 @@ storiesOf('DayPicker', module)
       }}
     >
       <DayPicker
+        id="storybook-daypicker"
         numberOfMonths={12}
         orientation={VERTICAL_SCROLLABLE}
       />
@@ -89,6 +91,7 @@ storiesOf('DayPicker', module)
   )))
   .add('vertical with custom day size', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
       daySize={50}
@@ -96,6 +99,7 @@ storiesOf('DayPicker', module)
   )))
   .add('vertical with custom height', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       numberOfMonths={2}
       orientation={VERTICAL_ORIENTATION}
       verticalHeight={568}
@@ -104,6 +108,7 @@ storiesOf('DayPicker', module)
   .add('vertical with DirectionProvider', withInfo()(() => (
     <DirectionProvider direction={DIRECTIONS.RTL}>
       <DayPicker
+        id="storybook-daypicker"
         numberOfMonths={2}
         orientation={VERTICAL_ORIENTATION}
         isRTL
@@ -119,6 +124,7 @@ storiesOf('DayPicker', module)
         }}
       >
         <DayPicker
+          id="storybook-daypicker"
           numberOfMonths={12}
           orientation={VERTICAL_SCROLLABLE}
         />
@@ -127,18 +133,21 @@ storiesOf('DayPicker', module)
   )))
   .add('with custom arrows', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       navPrev={<TestPrevIcon />}
       navNext={<TestNextIcon />}
     />
   )))
   .add('with custom details', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       renderDayContents={day => (day.day() % 6 === 5 ? '😻' : day.format('D'))}
     />
   )))
   .add('vertical with fixed-width container', withInfo()(() => (
     <div style={{ width: '400px' }}>
       <DayPicker
+        id="storybook-daypicker"
         numberOfMonths={2}
         orientation={VERTICAL_ORIENTATION}
       />
@@ -146,6 +155,7 @@ storiesOf('DayPicker', module)
   )))
   .add('with info panel', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       renderCalendarInfo={() => (
         <TestCustomInfoPanel />
       )}
@@ -153,14 +163,16 @@ storiesOf('DayPicker', module)
   )))
   .add('with custom week day format', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       weekDayFormat="ddd"
     />
   )))
   .add('with no animation', withInfo()(() => (
     <DayPicker
+      id="storybook-daypicker"
       transitionDuration={0}
     />
   )))
   .add('noBorder', withInfo()(() => (
-    <DayPicker noBorder />
+    <DayPicker id="storybook-daypicker" noBorder />
   )));


### PR DESCRIPTION
I have been investigating performance and noticed that when selecting a
date, all of the days for all of the months end up re-rendering. I
discovered that there are two causes for this currently:

1. All of the phrases are passed down to the CalendarDay components, and
   the phrases object can be different when selecting dates because of
   code like this, which toggles one translation back and forth:

   https://github.com/airbnb/react-dates/blob/888f6505/src/components/DayPickerRangeController.jsx#L501-L508

2. Similarly, all of the modifiers end up being different by reference
   because we end up creating new Sets for them every time, even if the
   sets are deeply equal.

To address the first issue, I decided to simplify the API of CalendarDay
a little, so that it takes an ariaLabel prop which is a simple string,
instead of a phrases prop. This allows us to prevent the changing of the
phrases object from automatically deoptimizing our leaf components.

And, to address the second issue, I introduced a simple cache for
modifier Sets. This allows the downstream components to perform a simple
referential equality check on them to avoid re-rendering, which we get
for free with PureComponent.

These two optimizations prevent many dates from re-rendering, namely
dates that are blocked and out of range. In storybook on my Macbook pro
(non-production React) this seems to bring down the time it takes to
update DayPickerRangeController when selecting dates from ~150ms to
~110ms. I think this will have a positive effect on some other
operations or other types of datepickers, but I didn't profile them.

It is worth noting that there is still a lot of re-rendering happening,
but that is because the value of ariaLabel ends up changing while you
select dates from:

> Choose Thursday, May 30, 2019 as your check-in date. It’s available.

to:

> Choose Thursday, May 30, 2019 as your check-out date. It’s available.

This seems important for accessibility, and I don't have any good ideas
at this moment of how to avoid this yet.

Before:
![image](https://user-images.githubusercontent.com/195534/58577080-91d56800-81fa-11e9-9408-1978e90a7a4a.png)


After:
![image](https://user-images.githubusercontent.com/195534/58577260-f42e6880-81fa-11e9-85d4-dc59d5b2f0d3.png)


It looks like there might be a good opportunity to optimize DayPickerRangeController#componentWillReceiveProps--this is where the modifiers are all built on every update.

---
Convert CalendarDay's aria-label to aria-labelledby

I've been working to improve performance of react-dates, and I noticed
that on many interactions every single date ends up being re-rendered.
In my previous commit, I partly fixed this by avoiding passing the
always-new phrases object down to CalendarDay, and to memoize modifiers
so they also don't deoptimize the pure components at the edges.

However, this still left one phrase that always changes when
selecting start and end dates which still caused most dates to be
re-rendered.

To avoid this, instead of passing an aria-label to CalendarDay, which
needs to change when switching from selecting a start date to selecting
an end date, we can render a div that contains the phrase for the
currently focused date, and pass a reference to it to be used by
aria-labelledby.

The downside here is that since ids need to be unique per page and there
is no reliable way to auto-generate an id on the server that will be
consistent on the client, I had to add required id props in a number of
places. For folks using components that already require startDateId, we
can generate a new id based on that value, so the friction there should
be minimal.

Testing this using VoiceOver on Safari and the results seem to be just
what we want.

Profiling this in storybook (non-production React) on my Macbook pro
brings the time it takes to update DayPickerRangeController from ~110ms
after my previous commit to ~75ms. (Before both of these commits, we
were looking at ~150ms).

I think there might still be some opportunity in preventing unnecessary
re-renders of CalendarMonth, but most of the remaining opportunity looks
like it might be in optimizing how modifiers are built in places like
DayPickerRangeController#componentWillReceiveProps.


After:
![image](https://user-images.githubusercontent.com/195534/58595065-518adf80-8224-11e9-93e2-8b3a2b539431.png)
