### PR TITLE
Optimize toISODateString and toISOMonthString

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,6 @@
 export const DISPLAY_FORMAT = 'L';
 export const ISO_FORMAT = 'YYYY-MM-DD';
-export const ISO_MONTH_FORMAT = 'YYYY-MM';
+export const ISO_MONTH_FORMAT = 'YYYY-MM'; // TODO delete this line of dead code on next breaking change
 
 export const START_DATE = 'startDate';
 export const END_DATE = 'endDate';

--- a/src/utils/toISODateString.js
+++ b/src/utils/toISODateString.js
@@ -2,11 +2,13 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { ISO_FORMAT } from '../constants';
-
 export default function toISODateString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
   if (!dateObj) return null;
 
-  return dateObj.format(ISO_FORMAT);
+  // Template strings compiled in strict mode uses concat, which is slow. Since
+  // this code is in a hot path and we want it to be as fast as possible, we
+  // want to use old-fashioned +.
+  // eslint-disable-next-line prefer-template
+  return dateObj.year() + '-' + String(dateObj.month() + 1).padStart(2, '0') + '-' + String(dateObj.date()).padStart(2, '0');
 }

--- a/src/utils/toISOMonthString.js
+++ b/src/utils/toISOMonthString.js
@@ -2,11 +2,13 @@ import moment from 'moment';
 
 import toMomentObject from './toMomentObject';
 
-import { ISO_MONTH_FORMAT } from '../constants';
-
 export default function toISOMonthString(date, currentFormat) {
   const dateObj = moment.isMoment(date) ? date : toMomentObject(date, currentFormat);
   if (!dateObj) return null;
 
-  return dateObj.format(ISO_MONTH_FORMAT);
+  // Template strings compiled in strict mode uses concat, which is slow. Since
+  // this code is in a hot path and we want it to be as fast as possible, we
+  // want to use old-fashioned +.
+  // eslint-disable-next-line prefer-template
+  return dateObj.year() + '-' + String(dateObj.month() + 1).padStart(2, '0');
 }

--- a/test/utils/toISODateString_spec.js
+++ b/test/utils/toISODateString_spec.js
@@ -15,6 +15,12 @@ describe('toISODateString', () => {
     expect(dateString).to.equal('1991-07-13');
   });
 
+  it('matches moment format behavior', () => {
+    const testDate = moment('1991-07-13');
+    const dateString = toISODateString(testDate);
+    expect(dateString).to.equal(testDate.format(ISO_FORMAT));
+  });
+
   it('converts iso date string to ISO date string', () => {
     const testDate = moment('1991-07-13');
     const dateString = toISODateString(testDate.format(ISO_FORMAT));


### PR DESCRIPTION
These functions get called repeatedly when computing modifiers, which
happens any time components like DayPickerRangeController receives
props.

By manually building this string instead of relying on moment's format
function, we can get better performance. In my profiling, this cuts the
time spent in DayPickerRangeController#componentWillReceiveProps from
~50ms to ~40ms.

Before:
![image](https://user-images.githubusercontent.com/195534/58646915-46cf5980-82bb-11e9-96e9-3e6a63b8824b.png)

After:
![image](https://user-images.githubusercontent.com/195534/58646931-4fc02b00-82bb-11e9-9c47-3fd2fed7cdd9.png)
