### PR TITLE
Optimize deleteModifier/addModifier

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1008,14 +1008,15 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
+
         const modifiers = new Set(month[iso]);
         modifiers.add(modifier);
-        return Object.assign(acc, {
-          [monthIso]: {
-            ...month,
-            [iso]: modifiers,
-          },
-        });
+        acc[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+
+        return acc;
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
@@ -1023,12 +1024,9 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       const modifiers = new Set(month[iso]);
       modifiers.add(modifier);
-      updatedDaysAfterAddition = {
-        ...updatedDaysAfterAddition,
-        [monthIso]: {
-          ...month,
-          [iso]: modifiers,
-        },
+      updatedDaysAfterAddition[monthIso] = {
+        ...month,
+        [iso]: modifiers,
       };
     }
 
@@ -1074,12 +1072,11 @@ export default class DayPickerRangeController extends React.PureComponent {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.delete(modifier);
-        return Object.assign(acc, {
-          [monthIso]: {
-            ...month,
-            [iso]: modifiers,
-          },
-        });
+        acc[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+        return acc;
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
@@ -1087,12 +1084,9 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       const modifiers = new Set(month[iso]);
       modifiers.delete(modifier);
-      updatedDaysAfterDeletion = {
-        ...updatedDaysAfterDeletion,
-        [monthIso]: {
-          ...month,
-          [iso]: modifiers,
-        },
+      updatedDaysAfterDeletion[monthIso] = {
+        ...month,
+        [iso]: modifiers,
       };
     }
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1006,17 +1006,16 @@ export default class DayPickerRangeController extends React.PureComponent {
         Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
       ));
 
-      updatedDaysAfterAddition = monthsToUpdate.reduce((days, monthIso) => {
+      updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.add(modifier);
-        return {
-          ...days,
+        return Object.assign(acc, {
           [monthIso]: {
             ...month,
             [iso]: modifiers,
           },
-        };
+        });
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
@@ -1071,17 +1070,16 @@ export default class DayPickerRangeController extends React.PureComponent {
         Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
       ));
 
-      updatedDaysAfterDeletion = monthsToUpdate.reduce((days, monthIso) => {
+      updatedDaysAfterDeletion = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.delete(modifier);
-        return {
-          ...days,
+        return Object.assign(acc, {
           [monthIso]: {
             ...month,
             [iso]: modifiers,
           },
-        };
+        });
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1009,12 +1009,14 @@ export default class DayPickerRangeController extends React.PureComponent {
       updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-        const modifiers = new Set(month[iso]);
-        modifiers.add(modifier);
-        acc[monthIso] = {
-          ...month,
-          [iso]: modifiers,
-        };
+        if (!month[iso] || !month[iso].has(modifier)) {
+          const modifiers = new Set(month[iso]);
+          modifiers.add(modifier);
+          acc[monthIso] = {
+            ...month,
+            [iso]: modifiers,
+          };
+        }
 
         return acc;
       }, updatedDaysAfterAddition);
@@ -1022,12 +1024,14 @@ export default class DayPickerRangeController extends React.PureComponent {
       const monthIso = toISOMonthString(day);
       const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-      const modifiers = new Set(month[iso]);
-      modifiers.add(modifier);
-      updatedDaysAfterAddition[monthIso] = {
-        ...month,
-        [iso]: modifiers,
-      };
+      if (!month[iso] || !month[iso].has(modifier)) {
+        const modifiers = new Set(month[iso]);
+        modifiers.add(modifier);
+        updatedDaysAfterAddition[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+      }
     }
 
     return updatedDaysAfterAddition;
@@ -1070,24 +1074,30 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       updatedDaysAfterDeletion = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
-        const modifiers = new Set(month[iso]);
-        modifiers.delete(modifier);
-        acc[monthIso] = {
-          ...month,
-          [iso]: modifiers,
-        };
+
+        if (month[iso] && month[iso].has(modifier)) {
+          const modifiers = new Set(month[iso]);
+          modifiers.delete(modifier);
+          acc[monthIso] = {
+            ...month,
+            [iso]: modifiers,
+          };
+        }
+
         return acc;
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
       const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-      const modifiers = new Set(month[iso]);
-      modifiers.delete(modifier);
-      updatedDaysAfterDeletion[monthIso] = {
-        ...month,
-        [iso]: modifiers,
-      };
+      if (month[iso] && month[iso].has(modifier)) {
+        const modifiers = new Set(month[iso]);
+        modifiers.delete(modifier);
+        updatedDaysAfterDeletion[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+      }
     }
 
     return updatedDaysAfterDeletion;

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -535,14 +535,15 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
       updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
+
         const modifiers = new Set(month[iso]);
         modifiers.add(modifier);
-        return Object.assign(acc, {
-          [monthIso]: {
-            ...month,
-            [iso]: modifiers,
-          },
-        });
+        acc[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+
+        return acc;
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
@@ -550,12 +551,9 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
       const modifiers = new Set(month[iso]);
       modifiers.add(modifier);
-      updatedDaysAfterAddition = {
-        ...updatedDaysAfterAddition,
-        [monthIso]: {
-          ...month,
-          [iso]: modifiers,
-        },
+      updatedDaysAfterAddition[monthIso] = {
+        ...month,
+        [iso]: modifiers,
       };
     }
 
@@ -590,12 +588,11 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.delete(modifier);
-        return Object.assign(acc, {
-          [monthIso]: {
-            ...month,
-            [iso]: modifiers,
-          },
-        });
+        acc[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+        return acc;
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
@@ -603,12 +600,9 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
       const modifiers = new Set(month[iso]);
       modifiers.delete(modifier);
-      updatedDaysAfterDeletion = {
-        ...updatedDaysAfterDeletion,
-        [monthIso]: {
-          ...month,
-          [iso]: modifiers,
-        },
+      updatedDaysAfterDeletion[monthIso] = {
+        ...month,
+        [iso]: modifiers,
       };
     }
 

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -536,12 +536,14 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-        const modifiers = new Set(month[iso]);
-        modifiers.add(modifier);
-        acc[monthIso] = {
-          ...month,
-          [iso]: modifiers,
-        };
+        if (!month[iso] || !month[iso].has(modifier)) {
+          const modifiers = new Set(month[iso]);
+          modifiers.add(modifier);
+          acc[monthIso] = {
+            ...month,
+            [iso]: modifiers,
+          };
+        }
 
         return acc;
       }, updatedDaysAfterAddition);
@@ -549,12 +551,14 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       const monthIso = toISOMonthString(day);
       const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-      const modifiers = new Set(month[iso]);
-      modifiers.add(modifier);
-      updatedDaysAfterAddition[monthIso] = {
-        ...month,
-        [iso]: modifiers,
-      };
+      if (!month[iso] || !month[iso].has(modifier)) {
+        const modifiers = new Set(month[iso]);
+        modifiers.add(modifier);
+        updatedDaysAfterAddition[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+      }
     }
 
     return updatedDaysAfterAddition;
@@ -586,24 +590,30 @@ export default class DayPickerSingleDateController extends React.PureComponent {
 
       updatedDaysAfterDeletion = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
-        const modifiers = new Set(month[iso]);
-        modifiers.delete(modifier);
-        acc[monthIso] = {
-          ...month,
-          [iso]: modifiers,
-        };
+
+        if (month[iso] && month[iso].has(modifier)) {
+          const modifiers = new Set(month[iso]);
+          modifiers.delete(modifier);
+          acc[monthIso] = {
+            ...month,
+            [iso]: modifiers,
+          };
+        }
+
         return acc;
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
       const month = updatedDays[monthIso] || visibleDays[monthIso];
 
-      const modifiers = new Set(month[iso]);
-      modifiers.delete(modifier);
-      updatedDaysAfterDeletion[monthIso] = {
-        ...month,
-        [iso]: modifiers,
-      };
+      if (month[iso] && month[iso].has(modifier)) {
+        const modifiers = new Set(month[iso]);
+        modifiers.delete(modifier);
+        updatedDaysAfterDeletion[monthIso] = {
+          ...month,
+          [iso]: modifiers,
+        };
+      }
     }
 
     return updatedDaysAfterDeletion;

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -533,17 +533,16 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
       ));
 
-      updatedDaysAfterAddition = monthsToUpdate.reduce((days, monthIso) => {
+      updatedDaysAfterAddition = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.add(modifier);
-        return {
-          ...days,
+        return Object.assign(acc, {
           [monthIso]: {
             ...month,
             [iso]: modifiers,
           },
-        };
+        });
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
@@ -587,17 +586,16 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         Object.keys(visibleDays[monthKey]).indexOf(iso) > -1
       ));
 
-      updatedDaysAfterDeletion = monthsToUpdate.reduce((days, monthIso) => {
+      updatedDaysAfterDeletion = monthsToUpdate.reduce((acc, monthIso) => {
         const month = updatedDays[monthIso] || visibleDays[monthIso];
         const modifiers = new Set(month[iso]);
         modifiers.delete(modifier);
-        return {
-          ...days,
+        return Object.assign(acc, {
           [monthIso]: {
             ...month,
             [iso]: modifiers,
           },
-        };
+        });
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -891,9 +891,9 @@ describe('DayPickerRangeController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -974,9 +974,9 @@ describe('DayPickerRangeController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -1057,9 +1057,9 @@ describe('DayPickerRangeController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -3798,8 +3798,14 @@ describe('DayPickerRangeController', () => {
           onFocusChange={sinon.stub()}
         />
       ));
-      const modifiers = wrapper.instance().deleteModifier({}, today);
-      expect(Object.keys(modifiers)).to.contain(toISOMonthString(today));
+
+      const isoMonth = toISOMonthString(today);
+      const isoDate = toISODateString(today);
+      const modifiers = wrapper.instance()
+        .deleteModifier({ [isoMonth]: { [isoDate]: new Set(['foo']) } }, today, 'foo');
+
+      expect(Object.keys(modifiers)).to.contain(isoMonth);
+      expect(modifiers[isoMonth][isoDate].size).to.equal(0);
     });
 
     it('has day ISO as key one layer down', () => {

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -111,9 +111,9 @@ describe('DayPickerSingleDateController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -194,9 +194,9 @@ describe('DayPickerSingleDateController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -289,9 +289,9 @@ describe('DayPickerSingleDateController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -372,9 +372,9 @@ describe('DayPickerSingleDateController', () => {
             const startOfMonth = today.clone().startOf('month');
             visibleDays = {
               [toISOMonthString(startOfMonth)]: {
-                [toISODateString(startOfMonth)]: [],
-                [toISODateString(startOfMonth.clone().add(1, 'day'))]: [],
-                [toISODateString(startOfMonth.clone().add(2, 'days'))]: [],
+                [toISODateString(startOfMonth)]: new Set(),
+                [toISODateString(startOfMonth.clone().add(1, 'day'))]: new Set(),
+                [toISODateString(startOfMonth.clone().add(2, 'days'))]: new Set(),
               },
             };
           });
@@ -1087,7 +1087,7 @@ describe('DayPickerSingleDateController', () => {
           onFocusChange={sinon.stub()}
         />
       ));
-      const modifiers = wrapper.instance().addModifier({}, today);
+      const modifiers = wrapper.instance().addModifier({}, today, 'foo');
       expect(Object.keys(modifiers)).to.contain(toISOMonthString(today));
     });
 
@@ -1200,8 +1200,14 @@ describe('DayPickerSingleDateController', () => {
           onFocusChange={sinon.stub()}
         />
       ));
-      const modifiers = wrapper.instance().deleteModifier({}, today);
-      expect(Object.keys(modifiers)).to.contain(toISOMonthString(today));
+
+      const isoMonth = toISOMonthString(today);
+      const isoDate = toISODateString(today);
+      const modifiers = wrapper.instance()
+        .deleteModifier({ [isoMonth]: { [isoDate]: new Set(['foo']) } }, today, 'foo');
+
+      expect(Object.keys(modifiers)).to.contain(isoMonth);
+      expect(modifiers[isoMonth][isoDate].size).to.equal(0);
     });
 
     it('has day ISO as key one layer down', () => {


### PR DESCRIPTION
While profiling DayRangePickerController, I noticed that we spend a
significant amount of time generating modifiers whenever anything is
changed. A good amount of this cost comes from these reducers that
unnecessarily create new objects and spread into them on every
iteration. We can make this faster by mutating the accumulator while
inside the reducer.

In my profiling, this reduces the speed of deleteModifier from ~28ms to
~20ms, and I think it will reduce the memory usage, which should further
help reduce garbage collection times.

---

Mutate updatedDaysAfterDeletion in deleteModifier/addModifier

We create this object in this function and then return it at the end, so
it should be safe to just mutate it while we are in this function
instead of rebuilding it immediately again.

This reduces the amount of time spent in deleteModifier from ~20ms to
~16ms.

---

Avoid creating new Sets when deleting/adding modifiers

I noticed that we always create a new set and then delete from it even
if the modifier is not in the set, or create a new set and then add it
even it the modifier is already in the set. This optimization reduces
the cost of DayPickerRangeController#componentWillReceiveProps from
~16ms to ~12ms.

Before:
![image](https://user-images.githubusercontent.com/195534/58668351-75febe80-82ed-11e9-9f0d-091f25eae995.png)

After:
![image](https://user-images.githubusercontent.com/195534/58668379-8adb5200-82ed-11e9-810d-29f82d16fe14.png)

