### PR TITLE
Avoid some moment object creation in modifier generation

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -39,6 +39,7 @@ import {
 } from '../constants';
 
 import DayPicker from './DayPicker';
+import getPreviousMonthMemoLast from '../utils/getPreviousMonthMemoLast';
 
 const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
@@ -990,7 +991,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     if (orientation === VERTICAL_SCROLLABLE) {
       numberOfMonths = Object.keys(visibleDays).length;
     } else {
-      currentMonth = currentMonth.clone().subtract(1, 'month');
+      currentMonth = getPreviousMonthMemoLast(currentMonth);
       numberOfMonths += 2;
     }
     if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
@@ -1055,7 +1056,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     if (orientation === VERTICAL_SCROLLABLE) {
       numberOfMonths = Object.keys(visibleDays).length;
     } else {
-      currentMonth = currentMonth.clone().subtract(1, 'month');
+      currentMonth = getPreviousMonthMemoLast(currentMonth);
       numberOfMonths += 2;
     }
     if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -30,6 +30,7 @@ import {
 } from '../constants';
 
 import DayPicker from './DayPicker';
+import getPreviousMonthMemoLast from '../utils/getPreviousMonthMemoLast';
 
 const propTypes = forbidExtraProps({
   date: momentPropTypes.momentObj,
@@ -517,7 +518,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     if (orientation === VERTICAL_SCROLLABLE) {
       numberOfMonths = Object.keys(visibleDays).length;
     } else {
-      currentMonth = currentMonth.clone().subtract(1, 'month');
+      currentMonth = getPreviousMonthMemoLast(currentMonth);
       numberOfMonths += 2;
     }
     if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {
@@ -571,7 +572,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     if (orientation === VERTICAL_SCROLLABLE) {
       numberOfMonths = Object.keys(visibleDays).length;
     } else {
-      currentMonth = currentMonth.clone().subtract(1, 'month');
+      currentMonth = getPreviousMonthMemoLast(currentMonth);
       numberOfMonths += 2;
     }
     if (!day || !isDayVisible(day, currentMonth, numberOfMonths, enableOutsideDays)) {

--- a/src/utils/getPreviousMonthMemoLast.js
+++ b/src/utils/getPreviousMonthMemoLast.js
@@ -1,0 +1,11 @@
+let getPreviousMonthMemoKey;
+let getPreviousMonthMemoValue;
+
+export default function getPreviousMonthMemoLast(month) {
+  if (month !== getPreviousMonthMemoKey) {
+    getPreviousMonthMemoKey = month;
+    getPreviousMonthMemoValue = month.clone().subtract(1, 'month');
+  }
+
+  return getPreviousMonthMemoValue;
+}


### PR DESCRIPTION
Creating these moment objects is expensive, and we do it a lot in
addModifier/deleteModifier, which get called a lot whenever these day
pickers update. For this particular one, we almost always want the same
value every time it is called, so we can memoize the previous value, a
la reselect.

This reduces the amount of time spent generating modifiers from ~46ms to
~32ms.

Before:
![image](https://user-images.githubusercontent.com/195534/58670813-3d62e300-82f5-11e9-91f8-8b6c0b0559f8.png)

After:
![image](https://user-images.githubusercontent.com/195534/58670824-48b60e80-82f5-11e9-9635-dd41b6ef8574.png)
