### PR TITLE
Cache some moment instances when rebuilding modifiers

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -40,6 +40,7 @@ import {
 
 import DayPicker from './DayPicker';
 import getPreviousMonthMemoLast from '../utils/getPreviousMonthMemoLast';
+import getPooledMoment from '../utils/getPooledMoment';
 
 const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
@@ -394,7 +395,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     if (didFocusChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
-          const momentObj = moment(day);
+          const momentObj = getPooledMoment(day);
           let isBlocked = false;
 
           if (didFocusChange || recomputeOutsideRange) {

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -31,6 +31,7 @@ import {
 
 import DayPicker from './DayPicker';
 import getPreviousMonthMemoLast from '../utils/getPreviousMonthMemoLast';
+import getPooledMoment from '../utils/getPooledMoment';
 
 const propTypes = forbidExtraProps({
   date: momentPropTypes.momentObj,
@@ -268,7 +269,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     if (didFocusChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
-          const momentObj = moment(day);
+          const momentObj = getPooledMoment(day);
           if (this.isBlocked(momentObj)) {
             modifiers = this.addModifier(modifiers, momentObj, 'blocked');
           } else {

--- a/src/utils/getPooledMoment.js
+++ b/src/utils/getPooledMoment.js
@@ -1,0 +1,10 @@
+import moment from 'moment';
+
+const momentPool = new Map();
+export default function getPooledMoment(dayString) {
+  if (!momentPool.has(dayString)) {
+    momentPool.set(dayString, moment(dayString));
+  }
+
+  return momentPool.get(dayString);
+}

--- a/test/utils/getPooledMoment_spec.js
+++ b/test/utils/getPooledMoment_spec.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import moment from 'moment';
+
+import getPooledMoment from '../../src/utils/getPooledMoment';
+
+describe('getPooledMoment', () => {
+  it('returns a moment given a day string', () => {
+    const momentObj = getPooledMoment('2017-12-10');
+    expect(moment.isMoment(momentObj)).to.equal(true);
+    expect(momentObj.format('YYYY MM DD')).to.equal('2017 12 10');
+  });
+
+  it('returns the same moment given the same day string', () => {
+    const momentObj1 = getPooledMoment('2017-12-10');
+    const momentObj2 = getPooledMoment('2017-12-10');
+    expect(momentObj1).to.equal(momentObj2);
+  });
+
+  it('returns a different moment given a different day string', () => {
+    const momentObj1 = getPooledMoment('2017-12-10');
+    const momentObj2 = getPooledMoment('2017-12-11');
+    expect(momentObj1).not.to.equal(momentObj2);
+  });
+});


### PR DESCRIPTION
When modifiers need to be rebuilt, which happens pretty frequently, we
iterate over every day and create a new moment instance for these
operations. These moment instances are never mutated, so we can safely
store and reuse them to improve performance.

This optimization reduces the time spent in
DayPickerRangeController#componentWillReceiveProps when selecting dates
from ~16ms to ~6-10ms.

Before:
![image](https://user-images.githubusercontent.com/195534/58720194-5d8eb280-8386-11e9-995c-d220264d63b9.png)

After:
![image](https://user-images.githubusercontent.com/195534/58720216-6a130b00-8386-11e9-8cc9-2180f0a0d1b8.png)

And here it is with a production build with 4x CPU slowdown.

Before:
![image](https://user-images.githubusercontent.com/195534/58720881-3f29b680-8388-11e9-92c7-515a6f8e758b.png)


After:
![image](https://user-images.githubusercontent.com/195534/58720860-31743100-8388-11e9-89f9-a1ecb166599f.png)
