### PR TITLE
Add guard for undefined objects in addModifier

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1023,7 +1023,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
-      const month = updatedDays[monthIso] || visibleDays[monthIso];
+      const month = updatedDays[monthIso] || visibleDays[monthIso] || {};
 
       if (!month[iso] || !month[iso].has(modifier)) {
         const modifiers = new Set(month[iso]);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -550,7 +550,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       }, updatedDaysAfterAddition);
     } else {
       const monthIso = toISOMonthString(day);
-      const month = updatedDays[monthIso] || visibleDays[monthIso];
+      const month = updatedDays[monthIso] || visibleDays[monthIso] || {};
 
       if (!month[iso] || !month[iso].has(modifier)) {
         const modifiers = new Set(month[iso]);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -3819,6 +3819,18 @@ describe('DayPickerRangeController', () => {
       expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
     });
 
+    it('is resilient when visibleDays is an empty object', () => {
+      const wrapper = shallow((
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      ));
+      wrapper.instance().setState({ visibleDays: {} });
+      const modifiers = wrapper.instance().addModifier({}, today);
+      expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
+    });
+
     it('return value no longer has modifier arg for day if was in first arg', () => {
       const modifierToDelete = 'foo';
       const monthISO = toISOMonthString(today);

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -1102,6 +1102,18 @@ describe('DayPickerSingleDateController', () => {
       expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
     });
 
+    it('is resilient when visibleDays is an empty object', () => {
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      ));
+      wrapper.instance().setState({ visibleDays: {} });
+      const modifiers = wrapper.instance().addModifier({}, today);
+      expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
+    });
+
     it('return value no longer has modifier arg for day if was in first arg', () => {
       const modifierToAdd = 'foo';
       const monthISO = toISOMonthString(today);


### PR DESCRIPTION
After updating to v20.2.1, we started seeing a handful of errors about
`undefined is not an object` coming from these addModifier calls. It
isn't entirely clear to me how this happens, but I think we can prevent
it from being a problem by adding some guards in these codepaths.