### PR TITLE
Added support for custom input components

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "object.values": "^1.0.4",
     "prop-types": "^15.6.1",
     "react-addons-shallow-compare": "^15.6.2",
+    "react-is": "^16.8.6",
     "react-moment-proptypes": "^1.6.0",
     "react-outside-click-handler": "^1.2.0",
     "react-portal": "^4.1.5",

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -7,6 +7,8 @@ import isTouchDevice from 'is-touch-device';
 
 import noflip from '../utils/noflip';
 import getInputHeight from '../utils/getInputHeight';
+import componentPropType from '../utils/componentPropType';
+import getRenderComponent from '../utils/getRenderComponent';
 import openDirectionShape from '../shapes/OpenDirectionShape';
 
 import {
@@ -25,6 +27,7 @@ const FANG_STROKE_BOTTOM = `M0,0 ${FANG_WIDTH_PX / 2},${FANG_HEIGHT_PX} ${FANG_W
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
+  component: componentPropType,
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   displayValue: PropTypes.string,
@@ -54,6 +57,7 @@ const propTypes = forbidExtraProps({
 });
 
 const defaultProps = {
+  component: 'input',
   placeholder: 'Select Date',
   displayValue: '',
   ariaLabel: undefined,
@@ -172,6 +176,7 @@ class DateInput extends React.PureComponent {
       isTouchDevice: isTouch,
     } = this.state;
     const {
+      component,
       id,
       placeholder,
       ariaLabel,
@@ -199,6 +204,8 @@ class DateInput extends React.PureComponent {
 
     const inputHeight = getInputHeight(reactDates, small);
 
+    const Input = getRenderComponent(component);
+
     return (
       <div
         {...css(
@@ -211,7 +218,7 @@ class DateInput extends React.PureComponent {
           withFang && openDirection === OPEN_UP && styles.DateInput__openUp,
         )}
       >
-        <input
+        <Input
           {...css(
             styles.DateInput_input,
             small && styles.DateInput_input__small,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -49,6 +49,7 @@ const defaultProps = {
   focusedInput: null,
 
   // input related props
+  component: 'input',
   startDatePlaceholderText: 'Start Date',
   endDatePlaceholderText: 'End Date',
   startDateAriaLabel: undefined,

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -5,6 +5,7 @@ import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 import noflip from '../utils/noflip';
 import openDirectionShape from '../shapes/OpenDirectionShape';
 
@@ -29,6 +30,7 @@ const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
 
   children: PropTypes.node,
+  component: componentPropType,
 
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
@@ -82,6 +84,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   children: null,
+  component: 'input',
   startDateId: START_DATE,
   endDateId: END_DATE,
   startDatePlaceholderText: 'Start Date',
@@ -132,6 +135,7 @@ const defaultProps = {
 
 function DateRangePickerInput({
   children,
+  component,
   startDate,
   startDateId,
   startDatePlaceholderText,
@@ -220,6 +224,7 @@ function DateRangePickerInput({
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
 
       <DateInput
+        component={component}
         id={startDateId}
         placeholder={startDatePlaceholderText}
         ariaLabel={startDateAriaLabel}
@@ -255,6 +260,7 @@ function DateRangePickerInput({
       {isStartDateFocused && children}
 
       <DateInput
+        component={component}
         id={endDateId}
         placeholder={endDatePlaceholderText}
         ariaLabel={endDateAriaLabel}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -8,6 +8,7 @@ import openDirectionShape from '../shapes/OpenDirectionShape';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 
 import DateRangePickerInput from './DateRangePickerInput';
 
@@ -29,6 +30,7 @@ import {
 
 const propTypes = forbidExtraProps({
   children: PropTypes.node,
+  component: componentPropType,
 
   startDate: momentPropTypes.momentObj,
   startDateId: PropTypes.string,
@@ -85,6 +87,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   children: null,
+  component: 'input',
 
   startDate: null,
   startDateId: START_DATE,
@@ -270,6 +273,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
   render() {
     const {
       children,
+      component,
       startDate,
       startDateId,
       startDatePlaceholderText,
@@ -309,6 +313,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
 
     return (
       <DateRangePickerInput
+        component={component}
         startDate={startDateString}
         startDateId={startDateId}
         startDatePlaceholderText={startDatePlaceholderText}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -46,6 +46,7 @@ const defaultProps = {
   focused: false,
 
   // input related props
+  component: 'input',
   id: 'date',
   placeholder: 'Date',
   ariaLabel: undefined,
@@ -520,6 +521,7 @@ class SingleDatePicker extends React.PureComponent {
 
   render() {
     const {
+      component,
       id,
       placeholder,
       ariaLabel,
@@ -560,6 +562,7 @@ class SingleDatePicker extends React.PureComponent {
 
     const input = (
       <SingleDatePickerInputController
+        component={component}
         id={id}
         placeholder={placeholder}
         ariaLabel={ariaLabel}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -5,6 +5,7 @@ import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 import noflip from '../utils/noflip';
 
 import DateInput from './DateInput';
@@ -18,6 +19,7 @@ import { ICON_BEFORE_POSITION, ICON_AFTER_POSITION, OPEN_DOWN } from '../constan
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
+  component: componentPropType,
   id: PropTypes.string.isRequired,
   children: PropTypes.node,
   placeholder: PropTypes.string,
@@ -57,6 +59,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   children: null,
+  component: 'input',
   placeholder: 'Select Date',
   ariaLabel: undefined,
   displayValue: '',
@@ -93,6 +96,7 @@ const defaultProps = {
 };
 
 function SingleDatePickerInput({
+  component,
   id,
   children,
   placeholder,
@@ -166,6 +170,7 @@ function SingleDatePickerInput({
       {inputIconPosition === ICON_BEFORE_POSITION && inputIcon}
 
       <DateInput
+        component={component}
         id={id}
         placeholder={placeholder}
         ariaLabel={ariaLabel}

--- a/src/components/SingleDatePickerInputController.jsx
+++ b/src/components/SingleDatePickerInputController.jsx
@@ -8,6 +8,7 @@ import openDirectionShape from '../shapes/OpenDirectionShape';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 
 import SingleDatePickerInput from './SingleDatePickerInput';
 
@@ -33,6 +34,7 @@ const propTypes = forbidExtraProps({
   focused: PropTypes.bool,
   onFocusChange: PropTypes.func.isRequired,
 
+  component: componentPropType,
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   ariaLabel: PropTypes.string,
@@ -78,6 +80,7 @@ const defaultProps = {
   date: null,
   focused: false,
 
+  component: 'input',
   placeholder: '',
   ariaLabel: undefined,
   screenReaderMessage: 'Date',
@@ -197,6 +200,7 @@ export default class SingleDatePickerInputController extends React.PureComponent
   render() {
     const {
       children,
+      component,
       id,
       placeholder,
       ariaLabel,
@@ -229,6 +233,7 @@ export default class SingleDatePickerInputController extends React.PureComponent
 
     return (
       <SingleDatePickerInput
+        component={component}
         id={id}
         placeholder={placeholder}
         ariaLabel={ariaLabel}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -4,6 +4,7 @@ import { mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
 
 import { DateRangePickerPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 
 import FocusedInputShape from './FocusedInputShape';
 import IconPositionShape from './IconPositionShape';
@@ -26,6 +27,7 @@ export default {
   onClose: PropTypes.func,
 
   // input related props
+  component: componentPropType,
   startDateId: PropTypes.string.isRequired,
   startDatePlaceholderText: PropTypes.string,
   startDateOffset: PropTypes.func,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -4,6 +4,7 @@ import { mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
 
 import { SingleDatePickerPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
+import componentPropType from '../utils/componentPropType';
 
 import IconPositionShape from './IconPositionShape';
 import OrientationShape from './OrientationShape';
@@ -21,6 +22,7 @@ export default {
   onFocusChange: PropTypes.func.isRequired,
 
   // input related props
+  component: componentPropType,
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
   ariaLabel: PropTypes.string,

--- a/src/utils/componentPropType.js
+++ b/src/utils/componentPropType.js
@@ -1,0 +1,31 @@
+/* eslint-disable consistent-return */
+import { isValidElementType } from 'react-is';
+
+const createComponentPropType = isRequired => (
+  props,
+  propName,
+  componentName,
+  location,
+  propFullName,
+) => {
+  const prop = `${location} \`${propFullName}\``;
+  const comp = `\`${componentName}\``;
+  const value = props[propName];
+
+  if (isRequired && value == null) {
+    throw new Error(
+      `The ${prop} is marked as required in ${comp}, but its value is \`${
+        value === null ? 'null' : 'undefined'
+      }\``,
+    );
+  } else if (value && !isValidElementType(value)) {
+    return new Error(
+      `Invalid prop ${prop} supplied to ${comp}: the prop is not a valid React component`,
+    );
+  }
+};
+
+const componentPropType = createComponentPropType(false);
+componentPropType.isRequired = createComponentPropType(true);
+
+export default componentPropType;

--- a/src/utils/getRenderComponent.jsx
+++ b/src/utils/getRenderComponent.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function getRenderComponent(Component) {
+  return typeof Component === 'string'
+    ? Component
+    : React.forwardRef((props, ref) => <Component {...props} innerRef={ref} />);
+}


### PR DESCRIPTION
Adds support for custom input components, not modifying the date-pickers at all.

Fixes #1549

Example usage:

```jsx
import { SingleDatePicker } from 'react-dates'
import TextField from '@material-ui/core/TextField'

<SingleDatePicker component={ TextField } />
```

> One gotcha is you haver to make sure you handle the passed `innerRef`. Attach it to an HTML element, for gods sake.