### PR TITLE
Add guard for undefined objects in deleteModifier

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1089,7 +1089,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
-      const month = updatedDays[monthIso] || visibleDays[monthIso];
+      const month = updatedDays[monthIso] || visibleDays[monthIso] || {};
 
       if (month[iso] && month[iso].has(modifier)) {
         const modifiers = new Set(month[iso]);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -605,7 +605,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       }, updatedDaysAfterDeletion);
     } else {
       const monthIso = toISOMonthString(day);
-      const month = updatedDays[monthIso] || visibleDays[monthIso];
+      const month = updatedDays[monthIso] || visibleDays[monthIso] || {};
 
       if (month[iso] && month[iso].has(modifier)) {
         const modifiers = new Set(month[iso]);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -3615,6 +3615,18 @@ describe('DayPickerRangeController', () => {
       expect(Object.keys(modifiers)).to.contain(toISOMonthString(today));
     });
 
+    it('is resilient when visibleDays is an empty object', () => {
+      const wrapper = shallow((
+        <DayPickerRangeController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      ));
+      wrapper.instance().setState({ visibleDays: {} });
+      const modifiers = wrapper.instance().addModifier({}, today);
+      expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
+    });
+
     it('has day ISO as key one layer down', () => {
       const wrapper = shallow((
         <DayPickerRangeController
@@ -3827,8 +3839,7 @@ describe('DayPickerRangeController', () => {
         />
       ));
       wrapper.instance().setState({ visibleDays: {} });
-      const modifiers = wrapper.instance().addModifier({}, today);
-      expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
+      expect(() => { wrapper.instance().deleteModifier({}, today); }).to.not.throw();
     });
 
     it('return value no longer has modifier arg for day if was in first arg', () => {

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -1233,6 +1233,17 @@ describe('DayPickerSingleDateController', () => {
       expect(Object.keys(modifiers[toISOMonthString(today)])).to.contain(toISODateString(today));
     });
 
+    it('is resilient when visibleDays is an empty object', () => {
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDateChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+        />
+      ));
+      wrapper.instance().setState({ visibleDays: {} });
+      expect(() => { wrapper.instance().deleteModifier({}, today); }).to.not.throw();
+    });
+
     it('return value no longer has modifier arg for day if was in first arg', () => {
       const modifierToDelete = 'foo';
       const monthISO = toISOMonthString(today);


### PR DESCRIPTION
I fixed this for addModifier in d6304cb, but failed to address
deleteModifier.