### PR TITLE
Use @babel/plugin-transform-runtime for helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,58 +1,108 @@
 {
   "env": {
     "test": {
-      "presets": [["airbnb", { looseClasses: true }]],
+      "presets": [["airbnb", { "looseClasses": true }]],
       "plugins": [
         ["inline-react-svg", {
-          "svgo": false
+          "svgo": false,
         }],
         ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
         "./scripts/pure-component-fallback.js",
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false,
+            "useESModules": false,
+          },
+        ],
         "istanbul",
       ]
     },
 
     "development": {
-      "presets": [["airbnb", { looseClasses: true }]],
+      "presets": [["airbnb", { "looseClasses": true }]],
       "plugins": [
         ["inline-react-svg", {
-          "svgo": false
+          "svgo": false,
         }],
         ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
         "./scripts/pure-component-fallback.js",
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false,
+            "useESModules": false,
+          },
+        ],
       ],
     },
 
     "production": {
-      "presets": [["airbnb", { looseClasses: true, removePropTypes: true }]],
+      "presets": [["airbnb", { "looseClasses": true, "removePropTypes": true }]],
       "plugins": [
         ["inline-react-svg", {
-          "svgo": false
+          "svgo": false,
         }],
         ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
         "./scripts/pure-component-fallback.js",
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false,
+            "useESModules": false,
+          },
+        ],
       ],
     },
 
     "cjs": {
-      "presets": [["airbnb", { looseClasses: true, removePropTypes: true }]],
+      "presets": [["airbnb", { "looseClasses": true, "removePropTypes": true }]],
       "plugins": [
         ["inline-react-svg", {
           "svgo": false
         }],
         ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
         "./scripts/pure-component-fallback.js",
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false,
+            "useESModules": false,
+          },
+        ],
       ],
     },
 
     "esm": {
-      "presets": [["airbnb", { looseClasses: true, modules: false, removePropTypes: true }]],
+      "presets": [["airbnb", { "looseClasses": true, "modules": false, "removePropTypes": true }]],
       "plugins": [
         ["inline-react-svg", {
-          "svgo": false
+          "svgo": false,
         }],
         ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
         "./scripts/pure-component-fallback.js",
+        [
+          "@babel/plugin-transform-runtime",
+          {
+            "absoluteRuntime": false,
+            "corejs": false,
+            "helpers": true,
+            "regenerator": false,
+            "useESModules": true,
+          },
+        ],
       ],
     },
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/register": "^7.4.4",
     "@storybook/addon-actions": "^5.1.1",
     "@storybook/addon-info": "^5.1.1",
@@ -110,6 +111,7 @@
     "why-did-you-update": "^1.0.6"
   },
   "dependencies": {
+    "@babel/runtime": "^7.4.5",
     "airbnb-prop-types": "^2.10.0",
     "consolidated-events": "^1.1.1 || ^2.0.0",
     "enzyme-shallow-equal": "^1.0.0",


### PR DESCRIPTION
Currently when this project is built, a bunch of babel helpers end up
being inlined into each module as needed. With Babel 7, we can use
@babel/plugin-transform-runtime to add imports for @babel/runtime
modules instead of inlining and duplicating these helper functions. This
should reduce bundle size impact of this project a fair amount.

Here's an example diff of one of the components:

```diff
0a1,4
> import _extends from "@babel/runtime/helpers/esm/extends";
> import _assertThisInitialized from "@babel/runtime/helpers/esm/assertThisInitialized";
> import _inheritsLoose from "@babel/runtime/helpers/esm/inheritsLoose";
> import _objectSpread from "@babel/runtime/helpers/esm/objectSpread";
2,12d5
<
< function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
<
< function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
<
< function _inheritsLoose(subClass, superClass) { subClass.prototype = Object.create(superClass.prototype); subClass.prototype.constructor = subClass; subClass.__proto__ = superClass; }
<
< function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
<
< function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
<
```

This change reduces the size of the esm build directory from 380,051 bytes to 361,346 bytes
