### PR TITLE
Defer day focusing until next animation frame

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -58,7 +58,11 @@ class CalendarDay extends React.PureComponent {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
       if (isFocused || tabIndex !== prevProps.tabIndex) {
-        this.buttonRef.focus();
+        requestAnimationFrame(() => {
+          if (this.buttonRef) {
+            this.buttonRef.focus();
+          }
+        });
       }
     }
   }

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -228,7 +228,11 @@ class CustomizableCalendarDay extends React.PureComponent {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
       if (isFocused || tabIndex !== prevProps.tabIndex) {
-        this.buttonRef.focus();
+        requestAnimationFrame(() => {
+          if (this.buttonRef) {
+            this.buttonRef.focus();
+          }
+        });
       }
     }
   }

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -238,6 +238,24 @@ describe('CalendarDay', () => {
     });
   });
 
+  describe('#componentDidUpdate', () => {
+    it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
+      const clock = sinon.useFakeTimers();
+      const originalRAF = global.requestAnimationFrame;
+      global.requestAnimationFrame = global.setTimeout;
+
+      const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidUpdate({ isFocused: true, tabIndex: -1 });
+      expect(focus.callCount).to.eq(0);
+      clock.tick(16);
+      expect(focus.callCount).to.eq(1);
+      clock.restore();
+      global.requestAnimationFrame = originalRAF;
+    });
+  });
+
   describe('#onDayClick', () => {
     let onDayClickSpy;
     beforeEach(() => {

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -189,6 +189,24 @@ describe('CustomizableCalendarDay', () => {
     });
   });
 
+  describe('#componentDidUpdate', () => {
+    it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
+      const clock = sinon.useFakeTimers();
+      const originalRAF = global.requestAnimationFrame;
+      global.requestAnimationFrame = global.setTimeout;
+
+      const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidUpdate({ isFocused: true, tabIndex: -1 });
+      expect(focus.callCount).to.eq(0);
+      clock.tick(16);
+      expect(focus.callCount).to.eq(1);
+      clock.restore();
+      global.requestAnimationFrame = originalRAF;
+    });
+  });
+
   describe('#onKeyDown', () => {
     const day = moment('10/10/2017');
 


### PR DESCRIPTION
At Airbnb we noticed a bug affecting only mobile devices or desktop with
mobile device emulation enabled. In months that span 5 weeks that are
followed by months that span 6 weeks (e.g. May 2019), the scroll
position of the calendar days was scrolled down some, causing the
numbers to awkwardly overlap with the days of the week and look broken.
This only happened when first opening the date picker, and once you go
to a different month it would fix itself.

After some sleuthing, I determined that this was caused by these
.focus() calls happening at a weird time, causing a parent container (I
think maybe the DayPicker transition container with overflow hidden) to
have a > 0 scrollTop.

It seems that we can prevent this from happening by deferring the focus
until the next animation frame. I think this could also help us avoid
some layout thrashing, which could give us a little performance boost
here.

I was entirely unable to reproduce this in react-dates storybook, but
testing this fix out in the Airbnb codebase seems to fix the issue.

Before fix:
![image](https://user-images.githubusercontent.com/195534/60138338-d4895200-975e-11e9-9282-ac81595baf8b.png)


After fix:
![image](https://user-images.githubusercontent.com/195534/60138316-c0455500-975e-11e9-9c81-8b2656d6c27c.png)
