### PR TITLE
[Fix] `CalendarMonth`: recompute month title height when rerendering

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -106,7 +106,7 @@ class CalendarMonth extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.setMonthTitleHeightTimeout = setTimeout(this.setMonthTitleHeight, 0);
+    this.queueSetMonthTitleHeight();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -131,6 +131,14 @@ class CalendarMonth extends React.PureComponent {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { setMonthTitleHeight } = this.props;
+
+    if (prevProps.setMonthTitleHeight === null && setMonthTitleHeight !== null) {
+      this.queueSetMonthTitleHeight();
+    }
+  }
+
   componentWillUnmount() {
     if (this.setMonthTitleHeightTimeout) {
       clearTimeout(this.setMonthTitleHeightTimeout);
@@ -147,6 +155,10 @@ class CalendarMonth extends React.PureComponent {
 
   setCaptionRef(ref) {
     this.captionRef = ref;
+  }
+
+  queueSetMonthTitleHeight() {
+    this.setMonthTitleHeightTimeout = window.setTimeout(this.setMonthTitleHeight, 0);
   }
 
   render() {

--- a/test/_helpers/describeIfWindow.js
+++ b/test/_helpers/describeIfWindow.js
@@ -1,0 +1,1 @@
+export default typeof document === 'undefined' ? describe.skip : describe;

--- a/test/components/CalendarMonth_spec.jsx
+++ b/test/components/CalendarMonth_spec.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import sinon from 'sinon-sandbox';
 import moment from 'moment';
+import describeIfWindow from '../_helpers/describeIfWindow';
 
 import CalendarMonth from '../../src/components/CalendarMonth';
 
@@ -45,6 +46,43 @@ describe('CalendarMonth', () => {
       expect(typeof onYearSelect).to.equal('function');
       expect(typeof isVisible).to.equal('boolean');
       expect(wrapper.find('#month-element').exists()).to.equal(true);
+    });
+
+    describeIfWindow('setMonthTitleHeight', () => {
+      beforeEach(() => {
+        sinon.stub(window, 'setTimeout').callsFake((handler) => handler());
+      });
+
+      it('sets the title height after mount', () => {
+        const setMonthTitleHeightStub = sinon.stub();
+        mount(
+          <CalendarMonth
+            isVisible
+            setMonthTitleHeight={setMonthTitleHeightStub}
+          />,
+        );
+
+        expect(setMonthTitleHeightStub).to.have.property('callCount', 1);
+      });
+
+      describe('if the callbacks gets set again', () => {
+        it('updates the title height', () => {
+          const setMonthTitleHeightStub = sinon.stub();
+          const wrapper = mount(
+            <CalendarMonth
+              isVisible
+              setMonthTitleHeight={setMonthTitleHeightStub}
+            />,
+          );
+
+          expect(setMonthTitleHeightStub).to.have.property('callCount', 1);
+
+          wrapper.setProps({ setMonthTitleHeight: null });
+
+          wrapper.setProps({ setMonthTitleHeight: setMonthTitleHeightStub });
+          expect(setMonthTitleHeightStub).to.have.property('callCount', 2);
+        });
+      });
     });
   });
 });

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -16,7 +16,7 @@ import {
   START_DATE,
 } from '../../src/constants';
 
-const describeIfWindow = typeof document === 'undefined' ? describe.skip : describe;
+import describeIfWindow from '../_helpers/describeIfWindow';
 
 class DateRangePickerWrapper extends React.Component {
   constructor(props) {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -9,7 +9,7 @@ import DayPickerSingleDateController from '../../src/components/DayPickerSingleD
 import SingleDatePickerInputController from '../../src/components/SingleDatePickerInputController';
 import SingleDatePicker, { PureSingleDatePicker } from '../../src/components/SingleDatePicker';
 
-const describeIfWindow = typeof document === 'undefined' ? describe.skip : describe;
+import describeIfWindow from '../_helpers/describeIfWindow';
 
 describe('SingleDatePicker', () => {
   afterEach(() => {

--- a/test/utils/disableScroll_spec.js
+++ b/test/utils/disableScroll_spec.js
@@ -5,7 +5,7 @@ import disableScroll, {
   getScrollAncestorsOverflowY,
 } from '../../src/utils/disableScroll';
 
-const describeIfWindow = typeof document === 'undefined' ? describe.skip : describe;
+import describeIfWindow from '../_helpers/describeIfWindow';
 
 const createScrollContainer = (level = 1) => {
   const el = document.createElement('div');


### PR DESCRIPTION
**react-dates version**
e.g. react-dates@20.2.5

**Describe the bug**
When passing in a different function for `renderMonthTitle` on each render call, the `DayPicker` is hidden on subsequent rerenders.
**Source code (including props configuration)**

If you change the [`DateRangePickerWrapper`](https://github.com/airbnb/react-dates/blob/master/examples/DateRangePickerWrapper.jsx#L141-L148) to the following code, you can reproduce the issue in storybook.

```
<DateRangePicker
  startDate={this.state.startDate}
  startDateId="your_unique_start_date_id"
  endDate={this.state.endDate}
  endDateId="your_unique_end_date_id"
  onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })}
  focusedInput={this.state.focusedInput}
  onFocusChange={focusedInput => this.setState({ focusedInput })}
  renderMonthText={() => "test"}
/>
```

Select a start date and then select an end date that is before the start date (which forces a rerender and not the daypicker to destroyed and readded).

**Screenshots/Gifs**

![bug-react-dates](https://user-images.githubusercontent.com/651816/60529091-25b4bb00-9cf6-11e9-9cf6-93c73ecfa305.gif)

**Bug Description**

When the `renderMonthTitle` functions changes the calculated `monthTitleHeight` gets reset (See [code](https://github.com/airbnb/react-dates/blob/master/src/components/DayPicker.jsx#L308-L312)). However, the `CalendarMonth` currently only computes the height on mount. This changes the behavior of the component to recompute the height whenever it is passed the callback to set it.

