### PR TITLE
Clear renderCalendarInfo timeout before assigning a new timeout (#1323)

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -319,6 +319,8 @@ class DayPicker extends React.PureComponent {
     // breaks the CSS transition.
     // The setTimeout will wait until the transition ends.
     if (this.calendarInfo) {
+      clearTimeout(this.setCalendarInfoWidthTimeout);
+
       this.setCalendarInfoWidthTimeout = setTimeout(() => {
         const { calendarInfoWidth } = this.state;
         const calendarInfoPanelWidth = calculateDimension(this.calendarInfo, 'width', true, true);


### PR DESCRIPTION
Clears the setTimeout assigned to this.setCalendarInfoWidthTimeout before a new setTimeout is assigned/reassigned to prevent a possible memory leak.

Fixes issue #1323 