### PR TITLE
Fix ios keyboard accessibility

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -43,6 +43,7 @@ const propTypes = forbidExtraProps({
 
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
 
@@ -71,6 +72,7 @@ const defaultProps = {
 
   onChange() {},
   onFocus() {},
+  onBlur() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
 
@@ -180,6 +182,7 @@ class DateInput extends React.PureComponent {
       focused,
       showCaret,
       onFocus,
+      onBlur,
       disabled,
       required,
       readOnly,
@@ -229,6 +232,7 @@ class DateInput extends React.PureComponent {
           onChange={this.onChange}
           onKeyDown={this.onKeyDown}
           onFocus={onFocus}
+          onBlur={onBlur}
           placeholder={placeholder}
           autoComplete="off"
           disabled={disabled}

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -617,6 +617,7 @@ class DateRangePicker extends React.PureComponent {
         minimumNights={minimumNights}
         withFullScreenPortal={withFullScreenPortal}
         onDatesChange={onDatesChange}
+        onBlur={this.onDayPickerFocusOut}
         onFocusChange={this.onDateRangePickerInputFocus}
         onKeyDownArrowDown={this.onDayPickerFocus}
         onKeyDownQuestionMark={this.showKeyboardShortcutsPanel}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -46,6 +46,7 @@ const propTypes = forbidExtraProps({
   onStartDateShiftTab: PropTypes.func,
   onEndDateTab: PropTypes.func,
   onClearDates: PropTypes.func,
+  onBlur: PropTypes.func,
   onKeyDownArrowDown: PropTypes.func,
   onKeyDownQuestionMark: PropTypes.func,
 
@@ -96,6 +97,7 @@ const defaultProps = {
   onStartDateShiftTab() {},
   onEndDateTab() {},
   onClearDates() {},
+  onBlur() {},
   onKeyDownArrowDown() {},
   onKeyDownQuestionMark() {},
 
@@ -149,6 +151,7 @@ function DateRangePickerInput({
   onEndDateFocus,
   onEndDateTab,
   endDateAriaLabel,
+  onBlur,
   onKeyDownArrowDown,
   onKeyDownQuestionMark,
   onClearDates,
@@ -237,6 +240,7 @@ function DateRangePickerInput({
         showCaret={showCaret}
         openDirection={openDirection}
         onChange={onStartDateChange}
+        onBlur={onBlur}
         onFocus={onStartDateFocus}
         onKeyDownShiftTab={onStartDateShiftTab}
         onKeyDownArrowDown={onKeyDownArrowDown}
@@ -272,6 +276,7 @@ function DateRangePickerInput({
         showCaret={showCaret}
         openDirection={openDirection}
         onChange={onEndDateChange}
+        onBlur={onBlur}
         onFocus={onEndDateFocus}
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -64,6 +64,7 @@ const propTypes = forbidExtraProps({
   isOutsideRange: PropTypes.func,
   displayFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
+  onBlur: PropTypes.func,
   onFocusChange: PropTypes.func,
   onClose: PropTypes.func,
   onDatesChange: PropTypes.func,
@@ -120,6 +121,7 @@ const defaultProps = {
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   displayFormat: () => moment.localeData().longDateFormat('L'),
 
+  onBlur() {},
   onFocusChange() {},
   onClose() {},
   onDatesChange() {},
@@ -294,6 +296,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
       openDirection,
       isFocused,
       phrases,
+      onBlur,
       onKeyDownArrowDown,
       onKeyDownQuestionMark,
       isRTL,
@@ -339,6 +342,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
         showClearDates={showClearDates}
         onClearDates={this.clearDates}
         screenReaderMessage={screenReaderMessage}
+        onBlur={onBlur}
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}
         isRTL={isRTL}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -579,6 +579,7 @@ class SingleDatePicker extends React.PureComponent {
         onDateChange={onDateChange}
         displayFormat={displayFormat}
         onFocusChange={this.onInputFocus}
+        onBlur={this.onFocusOut}
         onKeyDownArrowDown={this.onDayPickerFocus}
         onKeyDownQuestionMark={this.showKeyboardShortcutsPanel}
         screenReaderMessage={screenReaderInputMessage}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -46,6 +46,7 @@ const propTypes = forbidExtraProps({
   onChange: PropTypes.func,
   onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
   onKeyDownArrowDown: PropTypes.func,
@@ -83,6 +84,7 @@ const defaultProps = {
   onChange() {},
   onClearDate() {},
   onFocus() {},
+  onBlur() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
   onKeyDownArrowDown() {},
@@ -111,6 +113,7 @@ function SingleDatePickerInput({
   onClearDate,
   onChange,
   onFocus,
+  onBlur,
   onKeyDownShiftTab,
   onKeyDownTab,
   onKeyDownArrowDown,
@@ -179,6 +182,7 @@ function SingleDatePickerInput({
         showCaret={showCaret}
         onChange={onChange}
         onFocus={onFocus}
+        onBlur={onBlur}
         onKeyDownShiftTab={onKeyDownShiftTab}
         onKeyDownTab={onKeyDownTab}
         onKeyDownArrowDown={onKeyDownArrowDown}

--- a/src/components/SingleDatePickerInputController.jsx
+++ b/src/components/SingleDatePickerInputController.jsx
@@ -32,6 +32,7 @@ const propTypes = forbidExtraProps({
 
   focused: PropTypes.bool,
   onFocusChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
 
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
@@ -214,6 +215,7 @@ export default class SingleDatePickerInputController extends React.PureComponent
       customInputIcon,
       date,
       phrases,
+      onBlur,
       onKeyDownArrowDown,
       onKeyDownQuestionMark,
       screenReaderMessage,
@@ -248,6 +250,7 @@ export default class SingleDatePickerInputController extends React.PureComponent
         displayValue={displayValue}
         onChange={this.onChange}
         onFocus={this.onFocus}
+        onBlur={onBlur}
         onKeyDownShiftTab={this.onClearFocus}
         onKeyDownArrowDown={onKeyDownArrowDown}
         onKeyDownQuestionMark={onKeyDownQuestionMark}


### PR DESCRIPTION
Why it was done?

I just notice some bugs with accessibility in IOs devices with opened keyboard.
It is especially noticeable with DatePickers without **readOnly** property:
![bug](https://media.giphy.com/media/XbzBb636SBtQjMkU2w/giphy.gif)
So after clicking on 'Done' keyboard buttons nothing happened, but picker should close on it.

Also there are some rare cases with DatePickers with **readOnly** property:
As example airbnb.com:
![bug2](https://media.giphy.com/media/iFyHVsYRECHKgXcixa/giphy.gif)
I can open picker, don't select any date, but then I just click navigation arrow button inside of keyboard - and also nothing happened, but it should be closed.