### PR TITLE
Fix IOS focus input with portals

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -216,7 +216,7 @@ class DateInput extends React.PureComponent {
             styles.DateInput_input,
             small && styles.DateInput_input__small,
             regular && styles.DateInput_input__regular,
-            readOnly && styles.DateInput_input__readOnly,
+            (readOnly || isTouch) && styles.DateInput_input__readOnly,
             focused && styles.DateInput_input__focused,
             disabled && styles.DateInput_input__disabled,
           )}


### PR DESCRIPTION
Why was it done?

For **DatePicker** rendered in **Portal**, that haven't got **readOnly** prop, there is bug with input cursor:

![bug](https://media.giphy.com/media/gjOYqIFKxreX2nIYAq/giphy.gif)

So I suppose we need extra check for adding readOnly style to input