### PR TITLE
[a11y] Add `aria-roledescription`

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1027,6 +1027,7 @@ class DayPicker extends React.PureComponent {
     return (
       <div
         role="application"
+        aria-roledescription={phrases.roleDescription}
         aria-label={phrases.calendarLabel}
         {...css(
           styles.DayPicker,

--- a/src/defaultPhrases.js
+++ b/src/defaultPhrases.js
@@ -1,4 +1,5 @@
 const calendarLabel = 'Calendar';
+const roleDescription = 'datepicker';
 const closeDatePicker = 'Close';
 const focusStartDate = 'Interact with the calendar and add the check-in date for your trip.';
 const clearDate = 'Clear Date';
@@ -35,6 +36,7 @@ const dateIsSelectedAsEndDate = ({ date }) => `Selected as end date. ${date}`;
 
 export default {
   calendarLabel,
+  roleDescription,
   closeDatePicker,
   focusStartDate,
   clearDate,
@@ -71,6 +73,7 @@ export default {
 
 export const DateRangePickerPhrases = {
   calendarLabel,
+  roleDescription,
   closeDatePicker,
   clearDates,
   focusStartDate,
@@ -112,6 +115,7 @@ export const DateRangePickerInputPhrases = {
 
 export const SingleDatePickerPhrases = {
   calendarLabel,
+  roleDescription,
   closeDatePicker,
   clearDate,
   jumpToPrevMonth,
@@ -148,6 +152,7 @@ export const SingleDatePickerInputPhrases = {
 
 export const DayPickerPhrases = {
   calendarLabel,
+  roleDescription,
   jumpToPrevMonth,
   jumpToNextMonth,
   keyboardShortcuts,


### PR DESCRIPTION
As per the [recommendation of the W3C](https://www.w3.org/TR/wai-aria-1.1/#application), adding an `aria-roledescription` to describe the role of the datepicker application. Since this is supposed to be a human-readable and localized description of the element it's passed in through the existing phrases prop, and a default value was included.