### PR TITLE
[A11y] Keep keyboard focus on navigation buttons after click

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -55,10 +55,10 @@ class CalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
-      if (isFocused || tabIndex !== prevProps.tabIndex) {
+      if (isFocused) {
         raf(() => {
           if (this.buttonRef) {
             this.buttonRef.focus();

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -225,10 +225,10 @@ class CustomizableCalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
-      if (isFocused || tabIndex !== prevProps.tabIndex) {
+      if (isFocused) {
         raf(() => {
           if (this.buttonRef) {
             this.buttonRef.focus();

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -240,7 +240,7 @@ describe('CalendarDay', () => {
   });
 
   describe('#componentDidUpdate', () => {
-    it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
       const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();
       const focus = sinon.spy();
       wrapper.instance().buttonRef = { focus };
@@ -250,6 +250,21 @@ describe('CalendarDay', () => {
       return new Promise((resolve) => {
         raf(() => {
           expect(focus.callCount).to.eq(1);
+          resolve();
+        });
+      });
+    });
+
+    it('does not focus buttonRef when isFocused is false and tabIndex has become 0', () => {
+      const wrapper = shallow(<CalendarDay tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidUpdate({ tabIndex: -1 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        raf(() => {
+          expect(focus.callCount).to.eq(0);
           resolve();
         });
       });

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -191,7 +191,7 @@ describe('CustomizableCalendarDay', () => {
   });
 
   describe('#componentDidUpdate', () => {
-    it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
       const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();
       const focus = sinon.spy();
       wrapper.instance().buttonRef = { focus };
@@ -201,6 +201,21 @@ describe('CustomizableCalendarDay', () => {
       return new Promise((resolve) => {
         raf(() => {
           expect(focus.callCount).to.eq(1);
+          resolve();
+        });
+      });
+    });
+
+    it('does not focus buttonRef when isFocused is false and tabIndex has become 0', () => {
+      const wrapper = shallow(<CustomizableCalendarDay tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidUpdate({ tabIndex: -1 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        raf(() => {
+          expect(focus.callCount).to.eq(0);
           resolve();
         });
       });


### PR DESCRIPTION
This PR makes it so that when a keyboard only user selects one of the navigation buttons the focus stays on the button rather than shifting to the first available date on the calendar. This makes it much easier for a keyboard user to see the availability of a month more than 1 month in the future. Here is the [jira ticket](https://jira.airbnb.biz/browse/PRODUCT-83356) filed for this bug.

#### Before
![calendar-nav-tabbing-bug](https://user-images.githubusercontent.com/14023505/62746565-38ad6000-ba05-11e9-9b68-7330a8710fcf.gif)

#### After
![calendar-nav-tabbing-fix](https://user-images.githubusercontent.com/14023505/62746573-406d0480-ba05-11e9-851d-fa42949de9bd.gif)
