### PR TITLE
Fix DateInput cannot fully show Chinese issue

### DIFF
--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -172,7 +172,7 @@ export default {
     },
 
     sizing: {
-      inputWidth: 130,
+      inputWidth: 140,
       inputWidth_small: 97,
       arrowWidth: 24,
     },


### PR DESCRIPTION
**Before:**
<img width="531" alt="Screen Shot 2019-08-11 at 7 13 55 PM" src="https://user-images.githubusercontent.com/1174439/62833178-1584e980-bc6d-11e9-930b-827bf98dfb44.png">

**After:**
<img width="527" alt="Screen Shot 2019-08-11 at 7 14 48 PM" src="https://user-images.githubusercontent.com/1174439/62833182-1ddd2480-bc6d-11e9-9487-d1fcb668bc83.png">
