### PR TITLE
Remove all direct imports of css in favor of injected prop

### DIFF
--- a/examples/PresetDateRangePicker.jsx
+++ b/examples/PresetDateRangePicker.jsx
@@ -4,7 +4,7 @@ import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import omit from 'lodash/omit';
 
-import { withStyles, withStylesPropTypes, css } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import DateRangePicker from '../src/components/DateRangePicker';
 
@@ -123,7 +123,7 @@ class DateRangePickerWrapper extends React.Component {
   }
 
   renderDatePresets() {
-    const { presets, styles } = this.props;
+    const { presets, styles, css } = this.props;
     const { startDate, endDate } = this.state;
 
     return (

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -107,6 +107,7 @@ class CalendarDay extends React.PureComponent {
       tabIndex,
       styles,
       phrases,
+      css,
     } = this.props;
 
     if (!day) return <td />;

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
 import { CalendarDayPhrases } from '../defaultPhrases';
@@ -152,6 +152,7 @@ class CalendarMonth extends React.PureComponent {
 
   render() {
     const {
+      css,
       dayAriaLabelFormat,
       daySize,
       focusedDate,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import { addEventListener } from 'consolidated-events';
 
@@ -265,6 +265,7 @@ class CalendarMonthGrid extends React.PureComponent {
       transitionDuration,
       verticalBorderSpacing,
       setMonthTitleHeight,
+      css,
     } = this.props;
 
     const { months } = this.state;

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger, or } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -272,6 +272,7 @@ class CustomizableCalendarDay extends React.PureComponent {
 
   render() {
     const {
+      css,
       day,
       ariaLabelFormat,
       daySize,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import throttle from 'lodash/throttle';
 import isTouchDevice from 'is-touch-device';
 
@@ -190,6 +190,7 @@ class DateInput extends React.PureComponent {
       block,
       styles,
       theme: { reactDates },
+      css,
     } = this.props;
 
     const value = dateString || displayValue || '';

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -392,6 +392,7 @@ class DateRangePicker extends React.PureComponent {
   renderDayPicker() {
     const {
       anchorDirection,
+      css,
       openDirection,
       isDayBlocked,
       isDayHighlighted,
@@ -542,6 +543,7 @@ class DateRangePicker extends React.PureComponent {
 
   render() {
     const {
+      css,
       startDate,
       startDateId,
       startDatePlaceholderText,

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -132,6 +132,7 @@ const defaultProps = {
 
 function DateRangePickerInput({
   children,
+  css,
   startDate,
   startDateId,
   startDatePlaceholderText,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import moment from 'moment';
 import throttle from 'lodash/throttle';
@@ -856,6 +856,7 @@ class DayPicker extends React.PureComponent {
       orientation,
       weekDayFormat,
       styles,
+      css,
     } = this.props;
     const { calendarMonthWidth } = this.state;
     const verticalScrollable = orientation === VERTICAL_SCROLLABLE;
@@ -918,6 +919,7 @@ class DayPicker extends React.PureComponent {
     } = this.state;
 
     const {
+      css,
       enableOutsideDays,
       numberOfMonths,
       orientation,

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -162,6 +162,7 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
     const {
       block,
       buttonLocation,
+      css,
       showKeyboardShortcutsPanel,
       closeKeyboardShortcutsPanel,
       styles,

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerNavigationPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -51,6 +51,7 @@ const defaultProps = {
 };
 
 function DayPickerNavigation({
+  css,
   disablePrev,
   disableNext,
   navPrev,

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -16,6 +16,7 @@ const defaultProps = {
 };
 
 function KeyboardShortcutRow({
+  css,
   unicode,
   label,
   action,

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -384,6 +384,7 @@ class SingleDatePicker extends React.PureComponent {
   renderDayPicker() {
     const {
       anchorDirection,
+      css,
       openDirection,
       onDateChange,
       date,
@@ -519,6 +520,7 @@ class SingleDatePicker extends React.PureComponent {
 
   render() {
     const {
+      css,
       id,
       placeholder,
       ariaLabel,

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -95,6 +95,7 @@ const defaultProps = {
 function SingleDatePickerInput({
   id,
   children,
+  css,
   placeholder,
   ariaLabel,
   displayValue,


### PR DESCRIPTION
## Summary

Remove all direct imports of css in favor of the css injected prop. This is the preferred usage and is a pre-req to using contextual react-with-styles.

## Reviewers

@majapw @TaeKimJR @ahuth 