### PR TITLE
Add Input Font-Weight to Default Theme

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -305,7 +305,7 @@ export default withStyles(({
   },
 
   DateInput_input: {
-    fontWeight: 200,
+    fontWeight: font.input.weight,
     fontSize: font.input.size,
     lineHeight: font.input.lineHeight,
     color: color.text,

--- a/src/theme/DefaultTheme.js
+++ b/src/theme/DefaultTheme.js
@@ -184,6 +184,7 @@ export default {
       captionSize: 18,
       input: {
         size: 19,
+        weight: 200,
         lineHeight: '24px',
         size_small: 15,
         lineHeight_small: '18px',


### PR DESCRIPTION
Adds input font-weight to the DefaultTheme config.

Fixes #536