### PR TITLE
Fix deprecation warning of unformatted moment call

### DIFF
--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -56,7 +56,7 @@ describe('CalendarDay', () => {
 
     describe('aria-label', () => {
       const phrases = {};
-      const day = moment('10/10/2017');
+      const day = moment('10/10/2017', 'MM/DD/YYYY');
 
       beforeEach(() => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
@@ -166,7 +166,7 @@ describe('CalendarDay', () => {
     });
 
     describe('event handlers', () => {
-      const day = moment('10/10/2017');
+      const day = moment('10/10/2017', 'MM/DD/YYYY');
 
       let wrapper;
       beforeEach(() => {
@@ -204,7 +204,7 @@ describe('CalendarDay', () => {
   });
 
   describe('#onKeyDown', () => {
-    const day = moment('10/10/2017');
+    const day = moment('10/10/2017', 'MM/DD/YYYY');
 
     let onDayClick;
     let wrapper;

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -57,7 +57,7 @@ describe('CustomizableCalendarDay', () => {
 
     describe('aria-label', () => {
       const phrases = {};
-      const day = moment('10/10/2017');
+      const day = moment('10/10/2017', 'MM/DD/YYYY');
 
       beforeEach(() => {
         phrases.chooseAvailableDate = sinon.stub().returns('chooseAvailableDate text');
@@ -153,7 +153,7 @@ describe('CustomizableCalendarDay', () => {
     });
 
     describe('event handlers', () => {
-      const day = moment('10/10/2017');
+      const day = moment('10/10/2017', 'MM/DD/YYYY');
 
       let wrapper;
       beforeEach(() => {
@@ -208,7 +208,7 @@ describe('CustomizableCalendarDay', () => {
   });
 
   describe('#onKeyDown', () => {
-    const day = moment('10/10/2017');
+    const day = moment('10/10/2017', 'MM/DD/YYYY');
 
     let onDayClick;
     let wrapper;


### PR DESCRIPTION
### Summary

Removes this very distracting warning.

```console
$ npm run mocha

> react-dates@20.3.0 mocha /Users/nora_tarano/airlab-shared/repos/react-dates
> mocha ./test/_helpers

Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments: 
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: 10/10/2017, _f: undefined, _strict: undefined, _locale: [object Object]
Error: 
    at Function.createFromInputFallback (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:320:98)
    at configFromString (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2385:15)
    at configFromInput (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2611:13)
    at prepareConfig (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2594:13)
    at createFromConfig (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2561:44)
    at createLocalOrUTC (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2648:16)
    at createLocal (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:2652:16)
    at hooks (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/moment/moment.js:12:29)
    at Object.<anonymous> (/Users/nora_tarano/airlab-shared/repos/react-dates/test/utils/getCalendarDaySettings_spec.js:8:17)
    at Module._compile (module.js:635:30)
    at Module._compile (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/pirates/lib/index.js:99:24)
    at Module._extensions..js (module.js:646:10)
    at Object.newLoader [as .js] (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/pirates/lib/index.js:104:7)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at /Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/mocha/lib/mocha.js:231:27
    at Array.forEach (<anonymous>)
    at Mocha.loadFiles (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/mocha/lib/mocha.js:228:14)
    at Mocha.run (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/mocha/lib/mocha.js:514:10)
    at Object.<anonymous> (/Users/nora_tarano/airlab-shared/repos/react-dates/node_modules/mocha/bin/_mocha:480:18)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

### Reviewers

@ljharb @majapw @TaeKimJR @ahuth @indiesquidge 