### PR TITLE
Combine labelled DayPicker container elements

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1036,9 +1036,6 @@ class DayPicker extends React.PureComponent {
 
     return (
       <div
-        role="application"
-        aria-roledescription={phrases.roleDescription}
-        aria-label={phrases.calendarLabel}
         {...css(
           styles.DayPicker,
           isHorizontal && styles.DayPicker__horizontal,
@@ -1077,8 +1074,10 @@ class DayPicker extends React.PureComponent {
               onClick={(e) => { e.stopPropagation(); }}
               onKeyDown={this.onKeyDown}
               onMouseUp={() => { this.setState({ withMouseInteractions: true }); }}
-              role="region"
               tabIndex={-1}
+              role="application"
+              aria-roledescription={phrases.roleDescription}
+              aria-label={phrases.calendarLabel}
             >
               {!verticalScrollable && this.renderNavigation()}
 


### PR DESCRIPTION
This is to fix [an issue](https://jira.airbnb.biz/browse/PRODUCT-94500) where TalkBack (screen reader for Android devices) reads out all of the content of the calendar when focused. Every single day gets read out.

What I think is happening is:
- There are two wrapping divs. The outer has accessibility labels, while the inner has tabindex. Something like:

   ```jsx
   <div aria-label={phrases.calendarLabel}>
     <!-- More elements -->
     <div tabindex="-1">
       <!-- All the calendar content -->
     </div>
   </div>
   ```
- TalkBack is focusing on the inner wrapping div (with the tab index). Since there's no label or title, it reads out the content. Which happens to be the dates.
- VoiceOver on iOS can't focus on wrapping divs that have children with content, however. And we don't see the issue there.
- VoiceOver on MacOS seems to read the aria-label, and skips the div with tab index and no label.

I investigated a couple potential solutions to this:

1. **_Add an aria-label to the inner wrapping div_**

   Decided not to do this, because it results in two wrapping containers that TalkBack on Android and VoiceOver on MacOS focus on, before getting to the calendar controls. ❌ 

2. **_Remove `tabIndex={-1}` from the inner wrapping div_**

   Decided not to do this, because there's some logic around focusing on it when the `isFocused` prop becomes true. Haven't found another div that makes sense to focus in that case that don't run into the same problem ❌ 

3. **_Move the accessibility labeling from the outer to the inner wrapping div_**

   This is what I've implemented here. Behavior appears to be unchanged on VoiceOver on iOS (doesn't focus on the wrapping divs at all), VoiceOver on MacOS (focuses first on the labelled wrapping div). On TalkBack it reads out the label, instead of all the calendar content. ✅ 

   Unfortunately there's a downside. When reading the label, TalkBack now reads out something like "Calendar. Double click to activate", even though there's nothing to activate. Double clicking at that level literally does nothing. ❌ 

@majapw @backwardok do you have any ideas on other ways of fixing this?