### PR TITLE
Add a render function for keyboard shortcuts panel

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -74,7 +74,7 @@ const defaultProps = {
   renderDayContents: null,
   minimumNights: 1,
   isDayBlocked: () => false,
-  isOutsideRange: (day) => !isInclusivelyAfterDay(day, moment()),
+  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
   enableOutsideDays: false,
 
@@ -145,13 +145,12 @@ class DayPickerRangeControllerWrapper extends React.Component {
 
     return (
       <div style={{ height: '100%' }}>
-        {showInputs
-          && (
+        {showInputs && (
           <div style={{ marginBottom: 16 }}>
             <input type="text" name="start date" value={startDateString} readOnly />
             <input type="text" name="end date" value={endDateString} readOnly />
           </div>
-          )}
+        )}
 
         <DayPickerRangeController
           {...props}

--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -50,6 +50,7 @@ const propTypes = forbidExtraProps({
   renderCalendarDay: PropTypes.func,
   renderDayContents: PropTypes.func,
   renderKeyboardShortcutsButton: PropTypes.func,
+  renderKeyboardShortcutsPanel: PropTypes.func,
 
   // i18n
   monthFormat: PropTypes.string,
@@ -73,7 +74,7 @@ const defaultProps = {
   renderDayContents: null,
   minimumNights: 1,
   isDayBlocked: () => false,
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isOutsideRange: (day) => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
   enableOutsideDays: false,
 
@@ -90,6 +91,7 @@ const defaultProps = {
   renderMonthText: null,
   renderMonthElement: null,
   renderKeyboardShortcutsButton: undefined,
+  renderKeyboardShortcutsPanel: undefined,
 
   // navigation related props
   navPrev: null,
@@ -143,12 +145,13 @@ class DayPickerRangeControllerWrapper extends React.Component {
 
     return (
       <div style={{ height: '100%' }}>
-        {showInputs &&
+        {showInputs
+          && (
           <div style={{ marginBottom: 16 }}>
             <input type="text" name="start date" value={startDateString} readOnly />
             <input type="text" name="end date" value={endDateString} readOnly />
           </div>
-        }
+          )}
 
         <DayPickerRangeController
           {...props}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -72,6 +72,7 @@ const propTypes = forbidExtraProps({
   verticalBorderSpacing: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
   renderKeyboardShortcutsButton: PropTypes.func,
+  renderKeyboardShortcutsPanel: PropTypes.func,
 
   // navigation props
   disablePrev: PropTypes.bool,
@@ -134,6 +135,7 @@ export const defaultProps = {
   verticalBorderSpacing: undefined,
   horizontalMonthPadding: 13,
   renderKeyboardShortcutsButton: undefined,
+  renderKeyboardShortcutsPanel: undefined,
 
   // navigation props
   disablePrev: false,
@@ -949,6 +951,7 @@ class DayPicker extends React.PureComponent {
       renderCalendarInfo,
       renderMonthElement,
       renderKeyboardShortcutsButton,
+      renderKeyboardShortcutsPanel,
       calendarInfoPosition,
       hideKeyboardShortcutsPanel,
       onOutsideClick,
@@ -1141,6 +1144,7 @@ class DayPicker extends React.PureComponent {
                   closeKeyboardShortcutsPanel={this.closeKeyboardShortcutsPanel}
                   phrases={phrases}
                   renderKeyboardShortcutsButton={renderKeyboardShortcutsButton}
+                  renderKeyboardShortcutsPanel={renderKeyboardShortcutsPanel}
                 />
               )}
             </div>

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -219,8 +219,8 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
             </span>
           </button>
         )}
-        {showKeyboardShortcutsPanel
-          && (renderKeyboardShortcutsPanel ? (
+        {showKeyboardShortcutsPanel && (
+          renderKeyboardShortcutsPanel ? (
             renderKeyboardShortcutsPanel({
               closeButtonAriaLabel: phrases.hideKeyboardShortcutsPanel,
               keyboardShortcuts: this.keyboardShortcuts,
@@ -272,7 +272,8 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
                 ))}
               </ul>
             </div>
-          ))}
+          )
+        )}
       </div>
     );
   }

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -23,6 +23,7 @@ const propTypes = forbidExtraProps({
   closeKeyboardShortcutsPanel: PropTypes.func,
   phrases: PropTypes.shape(getPhrasePropTypes(DayPickerKeyboardShortcutsPhrases)),
   renderKeyboardShortcutsButton: PropTypes.func,
+  renderKeyboardShortcutsPanel: PropTypes.func,
 });
 
 const defaultProps = {
@@ -33,6 +34,7 @@ const defaultProps = {
   closeKeyboardShortcutsPanel() {},
   phrases: DayPickerKeyboardShortcutsPhrases,
   renderKeyboardShortcutsButton: undefined,
+  renderKeyboardShortcutsPanel: undefined,
 };
 
 function getKeyboardShortcuts(phrases) {
@@ -168,6 +170,7 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
       styles,
       phrases,
       renderKeyboardShortcutsButton,
+      renderKeyboardShortcutsPanel,
     } = this.props;
 
     const toggleButtonText = showKeyboardShortcutsPanel
@@ -216,51 +219,60 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
             </span>
           </button>
         )}
-        {showKeyboardShortcutsPanel && (
-          <div
-            {...css(styles.DayPickerKeyboardShortcuts_panel)}
-            role="dialog"
-            aria-labelledby="DayPickerKeyboardShortcuts_title"
-            aria-describedby="DayPickerKeyboardShortcuts_description"
-          >
+        {showKeyboardShortcutsPanel
+          && (renderKeyboardShortcutsPanel ? (
+            renderKeyboardShortcutsPanel({
+              closeButtonAriaLabel: phrases.hideKeyboardShortcutsPanel,
+              keyboardShortcuts: this.keyboardShortcuts,
+              onCloseButtonClick: closeKeyboardShortcutsPanel,
+              onKeyDown: this.onKeyDown,
+              title: phrases.keyboardShortcuts,
+            })
+          ) : (
             <div
-              {...css(styles.DayPickerKeyboardShortcuts_title)}
-              id="DayPickerKeyboardShortcuts_title"
+              {...css(styles.DayPickerKeyboardShortcuts_panel)}
+              role="dialog"
+              aria-labelledby="DayPickerKeyboardShortcuts_title"
+              aria-describedby="DayPickerKeyboardShortcuts_description"
             >
-              {phrases.keyboardShortcuts}
+              <div
+                {...css(styles.DayPickerKeyboardShortcuts_title)}
+                id="DayPickerKeyboardShortcuts_title"
+              >
+                {phrases.keyboardShortcuts}
+              </div>
+
+              <button
+                ref={this.setHideKeyboardShortcutsButtonRef}
+                {...css(
+                  styles.DayPickerKeyboardShortcuts_buttonReset,
+                  styles.DayPickerKeyboardShortcuts_close,
+                )}
+                type="button"
+                tabIndex="0"
+                aria-label={phrases.hideKeyboardShortcutsPanel}
+                onClick={closeKeyboardShortcutsPanel}
+                onKeyDown={this.onKeyDown}
+              >
+                <CloseButton {...css(styles.DayPickerKeyboardShortcuts_closeSvg)} />
+              </button>
+
+              <ul
+                {...css(styles.DayPickerKeyboardShortcuts_list)}
+                id="DayPickerKeyboardShortcuts_description"
+              >
+                {this.keyboardShortcuts.map(({ unicode, label, action }) => (
+                  <KeyboardShortcutRow
+                    key={label}
+                    unicode={unicode}
+                    label={label}
+                    action={action}
+                    block={block}
+                  />
+                ))}
+              </ul>
             </div>
-
-            <button
-              ref={this.setHideKeyboardShortcutsButtonRef}
-              {...css(
-                styles.DayPickerKeyboardShortcuts_buttonReset,
-                styles.DayPickerKeyboardShortcuts_close,
-              )}
-              type="button"
-              tabIndex="0"
-              aria-label={phrases.hideKeyboardShortcutsPanel}
-              onClick={closeKeyboardShortcutsPanel}
-              onKeyDown={this.onKeyDown}
-            >
-              <CloseButton {...css(styles.DayPickerKeyboardShortcuts_closeSvg)} />
-            </button>
-
-            <ul
-              {...css(styles.DayPickerKeyboardShortcuts_list)}
-              id="DayPickerKeyboardShortcuts_description"
-            >
-              {this.keyboardShortcuts.map(({ unicode, label, action }) => (
-                <KeyboardShortcutRow
-                  key={label}
-                  unicode={unicode}
-                  label={label}
-                  action={action}
-                  block={block}
-                />
-              ))}
-            </ul>
-          </div>
-        )}
+          ))}
       </div>
     );
   }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -88,6 +88,7 @@ const propTypes = forbidExtraProps({
   renderDayContents: PropTypes.func,
   renderCalendarInfo: PropTypes.func,
   renderKeyboardShortcutsButton: PropTypes.func,
+  renderKeyboardShortcutsPanel: PropTypes.func,
   calendarInfoPosition: CalendarInfoPositionShape,
   firstDayOfWeek: DayOfWeekShape,
   verticalHeight: nonNegativeInteger,
@@ -154,6 +155,7 @@ const defaultProps = {
   renderCalendarInfo: null,
   renderMonthElement: null,
   renderKeyboardShortcutsButton: undefined,
+  renderKeyboardShortcutsPanel: undefined,
   calendarInfoPosition: INFO_POSITION_BOTTOM,
   firstDayOfWeek: null,
   verticalHeight: null,
@@ -1142,6 +1144,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       enableOutsideDays,
       firstDayOfWeek,
       renderKeyboardShortcutsButton,
+      renderKeyboardShortcutsPanel,
       hideKeyboardShortcutsPanel,
       daySize,
       focusedInput,
@@ -1207,6 +1210,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         renderCalendarInfo={renderCalendarInfo}
         renderMonthElement={renderMonthElement}
         renderKeyboardShortcutsButton={renderKeyboardShortcutsButton}
+        renderKeyboardShortcutsPanel={renderKeyboardShortcutsPanel}
         calendarInfoPosition={calendarInfoPosition}
         firstDayOfWeek={firstDayOfWeek}
         hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -221,8 +221,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={(day) => day.subtract(3, 'days')}
-      endDateOffset={(day) => day.add(3, 'days')}
+      startDateOffset={day => day.subtract(3, 'days')}
+      endDateOffset={day => day.add(3, 'days')}
     />
   )))
   .add('with 45 days range selection', withInfo()(() => (
@@ -230,8 +230,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={(day) => day.subtract(22, 'days')}
-      endDateOffset={(day) => day.add(22, 'days')}
+      startDateOffset={day => day.subtract(22, 'days')}
+      endDateOffset={day => day.add(22, 'days')}
     />
   )))
   .add('with 4 days after today range selection', withInfo()(() => (
@@ -239,7 +239,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      endDateOffset={(day) => day.add(4, 'days')}
+      endDateOffset={day => day.add(4, 'days')}
     />
   )))
   .add('with current week range selection', withInfo()(() => (
@@ -247,8 +247,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={(day) => day.startOf('week')}
-      endDateOffset={(day) => day.endOf('week')}
+      startDateOffset={day => day.startOf('week')}
+      endDateOffset={day => day.endOf('week')}
     />
   )))
   .add('with custom inputs', withInfo()(() => (
@@ -437,7 +437,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isOutsideRange={(day) => !isInclusivelyAfterDay(day, moment())
+      isOutsideRange={day => !isInclusivelyAfterDay(day, moment())
         || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))}
     />
   )))
@@ -462,7 +462,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayBlocked={(day) => moment.weekdays(day.weekday()) === 'Friday'}
+      isDayBlocked={day => moment.weekdays(day.weekday()) === 'Friday'}
     />
   )))
   .add('with navigation blocked (minDate and maxDate)', withInfo()(() => (
@@ -479,7 +479,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      renderDayContents={(day) => day.format('ddd')}
+      renderDayContents={day => day.format('ddd')}
     />
   )))
   .add('with info panel', withInfo()(() => (

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -438,7 +438,8 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       isOutsideRange={day => !isInclusivelyAfterDay(day, moment())
-        || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))}
+        || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))
+      }
     />
   )))
   .add('with some blocked dates', withInfo()(() => (
@@ -446,7 +447,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayBlocked={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
+      isDayBlocked={day1 => datesList.some(day2 => isSameDay(day1, day2))}
     />
   )))
   .add('with some highlighted dates', withInfo()(() => (
@@ -454,7 +455,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayHighlighted={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
+      isDayHighlighted={day1 => datesList.some(day2 => isSameDay(day1, day2))}
     />
   )))
   .add('blocks fridays', withInfo()(() => (
@@ -541,7 +542,7 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       getMinNightsForHoverDate={() => 2}
-      isDayBlocked={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
+      isDayBlocked={day1 => datesList.some(day2 => isSameDay(day1, day2))}
     />
   )))
   .add('with custom keyboard shortcuts button', withInfo()(() => (

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -9,6 +9,9 @@ import InfoPanelDecorator, { monospace } from './InfoPanelDecorator';
 import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
+import CloseButton from '../src/components/CloseButton';
+import KeyboardShortcutRow from '../src/components/KeyboardShortcutRow';
+
 import { VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE } from '../src/constants';
 
 import DayPickerRangeControllerWrapper from '../examples/DayPickerRangeControllerWrapper';
@@ -41,7 +44,7 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Prev
   </div>
@@ -58,7 +61,7 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Next
   </div>
@@ -119,6 +122,80 @@ function renderKeyboardShortcutsButton(buttonProps) {
   );
 }
 
+function renderKeyboardShortcutsPanel(panelProps) {
+  const {
+    closeButtonAriaLabel,
+    keyboardShortcuts,
+    onCloseButtonClick,
+    onKeyDown,
+    title,
+  } = panelProps;
+
+  const PANEL_PADDING_PX = 50;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      width: '100%',
+      height: '100%',
+      top: 0,
+      left: 0,
+      zIndex: 2,
+    }}
+    >
+      <div style={{
+        backgroundColor: '#000000',
+        opacity: 0.5,
+        width: '100%',
+        height: '100%',
+      }}
+      />
+      <div style={{
+        backgroundColor: '#ffffff',
+        padding: PANEL_PADDING_PX,
+        width: '50%',
+        height: '50%',
+        position: 'absolute',
+        top: '25%',
+        left: '25%',
+      }}
+      >
+        <button
+          aria-label={closeButtonAriaLabel}
+          onClick={onCloseButtonClick}
+          onKeyDown={onKeyDown}
+          style={{
+            height: 25,
+            width: 25,
+            position: 'absolute',
+            top: PANEL_PADDING_PX,
+            right: PANEL_PADDING_PX,
+          }}
+          type="button"
+        >
+          <CloseButton />
+        </button>
+        <div style={{
+          fontSize: 16,
+          fontWeight: 'bold',
+          marginBottom: 16,
+        }}
+        >
+          {title}
+        </div>
+        {keyboardShortcuts.map(({ action: keyboardShortcutAction, label, unicode }) => (
+          <KeyboardShortcutRow
+            action={keyboardShortcutAction}
+            key={label}
+            label={label}
+            unicode={unicode}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 const datesList = [
   moment(),
   moment().add(1, 'days'),
@@ -144,8 +221,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={day => day.subtract(3, 'days')}
-      endDateOffset={day => day.add(3, 'days')}
+      startDateOffset={(day) => day.subtract(3, 'days')}
+      endDateOffset={(day) => day.add(3, 'days')}
     />
   )))
   .add('with 45 days range selection', withInfo()(() => (
@@ -153,8 +230,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={day => day.subtract(22, 'days')}
-      endDateOffset={day => day.add(22, 'days')}
+      startDateOffset={(day) => day.subtract(22, 'days')}
+      endDateOffset={(day) => day.add(22, 'days')}
     />
   )))
   .add('with 4 days after today range selection', withInfo()(() => (
@@ -162,7 +239,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      endDateOffset={day => day.add(4, 'days')}
+      endDateOffset={(day) => day.add(4, 'days')}
     />
   )))
   .add('with current week range selection', withInfo()(() => (
@@ -170,8 +247,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      startDateOffset={day => day.startOf('week')}
-      endDateOffset={day => day.endOf('week')}
+      startDateOffset={(day) => day.startOf('week')}
+      endDateOffset={(day) => day.endOf('week')}
     />
   )))
   .add('with custom inputs', withInfo()(() => (
@@ -360,9 +437,8 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isOutsideRange={day => !isInclusivelyAfterDay(day, moment())
-        || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))
-      }
+      isOutsideRange={(day) => !isInclusivelyAfterDay(day, moment())
+        || isInclusivelyAfterDay(day, moment().add(2, 'weeks'))}
     />
   )))
   .add('with some blocked dates', withInfo()(() => (
@@ -370,7 +446,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayBlocked={day1 => datesList.some(day2 => isSameDay(day1, day2))}
+      isDayBlocked={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
     />
   )))
   .add('with some highlighted dates', withInfo()(() => (
@@ -378,7 +454,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayHighlighted={day1 => datesList.some(day2 => isSameDay(day1, day2))}
+      isDayHighlighted={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
     />
   )))
   .add('blocks fridays', withInfo()(() => (
@@ -386,7 +462,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      isDayBlocked={day => moment.weekdays(day.weekday()) === 'Friday'}
+      isDayBlocked={(day) => moment.weekdays(day.weekday()) === 'Friday'}
     />
   )))
   .add('with navigation blocked (minDate and maxDate)', withInfo()(() => (
@@ -403,7 +479,7 @@ storiesOf('DayPickerRangeController', module)
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
-      renderDayContents={day => day.format('ddd')}
+      renderDayContents={(day) => day.format('ddd')}
     />
   )))
   .add('with info panel', withInfo()(() => (
@@ -465,7 +541,7 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       getMinNightsForHoverDate={() => 2}
-      isDayBlocked={day1 => datesList.some(day2 => isSameDay(day1, day2))}
+      isDayBlocked={(day1) => datesList.some((day2) => isSameDay(day1, day2))}
     />
   )))
   .add('with custom keyboard shortcuts button', withInfo()(() => (
@@ -474,5 +550,13 @@ storiesOf('DayPickerRangeController', module)
       onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       renderKeyboardShortcutsButton={renderKeyboardShortcutsButton}
+    />
+  )))
+  .add('with custom keyboard shortcuts panel', withInfo()(() => (
+    <DayPickerRangeControllerWrapper
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      renderKeyboardShortcutsPanel={renderKeyboardShortcutsPanel}
     />
   )));

--- a/test/components/DayPickerKeyboardShortcuts_spec.jsx
+++ b/test/components/DayPickerKeyboardShortcuts_spec.jsx
@@ -146,6 +146,17 @@ describe('DayPickerKeyboardShortcuts', () => {
           expect(wrapper.children().find(Button)).to.have.lengthOf(1);
         });
       });
+
+      describe('renderKeyboardShortcutsPanel', () => {
+        it('renders the provided keyboard shortcuts panel', () => {
+          const props = {
+            renderKeyboardShortcutsPanel: () => (<div>Keyboard shortcuts here!</div>),
+            showKeyboardShortcutsPanel: true,
+          };
+          const wrapper = shallow(<DayPickerKeyboardShortcuts {...props} />).dive();
+          expect(wrapper.children().contains('Keyboard shortcuts here!'));
+        });
+      });
     });
 
     describe('#DayPickerKeyboardShortcuts_panel', () => {

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -4491,5 +4491,21 @@ describe('DayPickerRangeController', () => {
           .eql(testRenderKeyboardShortcutsButton);
       });
     });
+
+    describe.only('renderKeyboardShortcutsPanel prop', () => {
+      it('passes down custom panel render function', () => {
+        const testRenderKeyboardShortcutsPanel = () => {};
+        const wrapper = shallow(
+          <DayPickerRangeController
+            renderKeyboardShortcutsPanel={testRenderKeyboardShortcutsPanel}
+          />,
+        );
+        const dayPicker = wrapper.find(DayPicker);
+        expect(dayPicker).to.have.lengthOf(1);
+        expect(dayPicker.prop('renderKeyboardShortcutsPanel'))
+          .to
+          .eql(testRenderKeyboardShortcutsPanel);
+      });
+    });
   });
 });

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -135,6 +135,18 @@ describe('DayPicker', () => {
           .to
           .eql(testRenderKeyboardShortcutsButton);
       });
+
+      it('component exists with custom panel render function if renderKeyboardShortcutsPanel is passed down', () => {
+        const testRenderKeyboardShortcutsPanel = () => {};
+        const wrapper = shallow(
+          <DayPicker renderKeyboardShortcutsPanel={testRenderKeyboardShortcutsPanel} />,
+        ).dive();
+        const dayPickerKeyboardShortcuts = wrapper.find(DayPickerKeyboardShortcuts);
+        expect(dayPickerKeyboardShortcuts).to.have.lengthOf(1);
+        expect(dayPickerKeyboardShortcuts.prop('renderKeyboardShortcutsPanel'))
+          .to
+          .eql(testRenderKeyboardShortcutsPanel);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Add a prop `renderKeyboardShortcutsPanel` that allows a custom panel for keyboard shortcuts to be rendered.

## Screenshots

### Default
![image](https://user-images.githubusercontent.com/2915936/65088959-1bf33900-d970-11e9-8038-63ce41d199a6.png)

### renderKeyboardShortcutsPanel
![image](https://user-images.githubusercontent.com/2915936/65088966-26adce00-d970-11e9-9fcd-b0fa499bce00.png)
