### PR TITLE
Add tests for minDate and maxDate props in DateRangePicker

### DIFF
--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -741,4 +741,34 @@ describe('DateRangePicker', () => {
       });
     });
   });
+
+  describe('minDate and maxDate props', () => {
+    describe('minDate is passed in', () => {
+      it('Should pass minDate to DayPickerRangeController', () => {
+        const minDate = moment('2018-10-19');
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            minDate={minDate}
+          />
+        )).dive();
+        expect(wrapper.find(DayPickerRangeController).props().minDate).to.equal(minDate);
+      });
+    });
+
+    describe('maxDate is passed in', () => {
+      it('Should pass maxDate to DayPickerRangeController', () => {
+        const maxDate = moment('2018-12-19');
+        const wrapper = shallow((
+          <DateRangePicker
+            {...requiredProps}
+            focusedInput={START_DATE}
+            maxDate={maxDate}
+          />
+        )).dive();
+        expect(wrapper.find(DayPickerRangeController).props().maxDate).to.equal(maxDate);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Missing tests for minDate and maxDate props in DateRangePicker.

From #1793