### PR TITLE
Fix for getWeekHeaders(), prevents it from changing state.currentMonth

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -591,7 +591,7 @@ class DayPicker extends React.PureComponent {
 
     const weekHeaders = [];
     for (let i = 0; i < 7; i += 1) {
-      weekHeaders.push(currentMonth.day((i + firstDayOfWeek) % 7).format(weekDayFormat));
+      weekHeaders.push(currentMonth.clone().day((i + firstDayOfWeek) % 7).format(weekDayFormat));
     }
 
     return weekHeaders;


### PR DESCRIPTION
Fix for a bug that prevents `getWeekHeaders()` from changing `this.state.currentMonth`.

A bug that was introduced in v21.1.0, it resets `startDate` to the last day in the `startDate` week, because`getWeekHeaders()` changing `this.state.currentMonth`.

![dayPickerBug](https://user-images.githubusercontent.com/7444386/65332142-68cc4f00-dbbe-11e9-80be-bb8204fcbb98.gif)