### PR TITLE
Revert "Merge pull request #1758 from airbnb/nora--remove-direct-imports-of-css"

### DIFF
--- a/examples/PresetDateRangePicker.jsx
+++ b/examples/PresetDateRangePicker.jsx
@@ -4,7 +4,7 @@ import momentPropTypes from 'react-moment-proptypes';
 import moment from 'moment';
 import omit from 'lodash/omit';
 
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes, css } from 'react-with-styles';
 
 import DateRangePicker from '../src/components/DateRangePicker';
 
@@ -123,7 +123,7 @@ class DateRangePickerWrapper extends React.Component {
   }
 
   renderDatePresets() {
-    const { presets, styles, css } = this.props;
+    const { presets, styles } = this.props;
     const { startDate, endDate } = this.state;
 
     return (

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -107,7 +107,6 @@ class CalendarDay extends React.PureComponent {
       tabIndex,
       styles,
       phrases,
-      css,
     } = this.props;
 
     if (!day) return <td />;

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
 import { CalendarDayPhrases } from '../defaultPhrases';
@@ -152,7 +152,6 @@ class CalendarMonth extends React.PureComponent {
 
   render() {
     const {
-      css,
       dayAriaLabelFormat,
       daySize,
       focusedDate,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import { addEventListener } from 'consolidated-events';
 
@@ -265,7 +265,6 @@ class CalendarMonthGrid extends React.PureComponent {
       transitionDuration,
       verticalBorderSpacing,
       setMonthTitleHeight,
-      css,
     } = this.props;
 
     const { months } = this.state;

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger, or } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -272,7 +272,6 @@ class CustomizableCalendarDay extends React.PureComponent {
 
   render() {
     const {
-      css,
       day,
       ariaLabelFormat,
       daySize,

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import throttle from 'lodash/throttle';
 import isTouchDevice from 'is-touch-device';
 
@@ -190,7 +190,6 @@ class DateInput extends React.PureComponent {
       block,
       styles,
       theme: { reactDates },
-      css,
     } = this.props;
 
     const value = dateString || displayValue || '';

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -398,7 +398,6 @@ class DateRangePicker extends React.PureComponent {
   renderDayPicker() {
     const {
       anchorDirection,
-      css,
       openDirection,
       isDayBlocked,
       isDayHighlighted,
@@ -559,7 +558,6 @@ class DateRangePicker extends React.PureComponent {
 
   render() {
     const {
-      css,
       startDate,
       startDateId,
       startDatePlaceholderText,

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -132,7 +132,6 @@ const defaultProps = {
 
 function DateRangePickerInput({
   children,
-  css,
   startDate,
   startDateId,
   startDatePlaceholderText,

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import moment from 'moment';
 import throttle from 'lodash/throttle';
@@ -884,7 +884,6 @@ class DayPicker extends React.PureComponent {
       orientation,
       renderWeekHeaderElement,
       styles,
-      css,
     } = this.props;
 
     const { calendarMonthWidth } = this.state;
@@ -946,7 +945,6 @@ class DayPicker extends React.PureComponent {
     } = this.state;
 
     const {
-      css,
       enableOutsideDays,
       numberOfMonths,
       orientation,

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -164,7 +164,6 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
     const {
       block,
       buttonLocation,
-      css,
       showKeyboardShortcutsPanel,
       closeKeyboardShortcutsPanel,
       styles,

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerNavigationPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -59,7 +59,6 @@ const defaultProps = {
 };
 
 function DayPickerNavigation({
-  css,
   inlineStyles,
   disablePrev,
   disableNext,

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -16,7 +16,6 @@ const defaultProps = {
 };
 
 function KeyboardShortcutRow({
-  css,
   unicode,
   label,
   action,

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -388,7 +388,6 @@ class SingleDatePicker extends React.PureComponent {
   renderDayPicker() {
     const {
       anchorDirection,
-      css,
       openDirection,
       onDateChange,
       date,
@@ -530,7 +529,6 @@ class SingleDatePicker extends React.PureComponent {
 
   render() {
     const {
-      css,
       id,
       placeholder,
       ariaLabel,

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { withStyles, withStylesPropTypes } from 'react-with-styles';
+import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -95,7 +95,6 @@ const defaultProps = {
 function SingleDatePickerInput({
   id,
   children,
-  css,
   placeholder,
   ariaLabel,
   displayValue,


### PR DESCRIPTION
## Summary

Reverts https://github.com/airbnb/react-dates/pull/1758, which "fixed" the imports of `css` to use the injected prop rather than directly importing from `react-with-styles`. Unfortunately, this broke inline styles for RTL, which were not expected to be auto-transformed by the aphrodite interface. 

In other words, react-dates is RTL-compatible, but does not implement RTL through the react-with-styles interface, so https://github.com/airbnb/react-dates/pull/1758 broke RTL for react-dates completely when used with the aphrodite interface.

## Followup

In a followup, we'll have to update this library to rely on the css prop, but it will take more work than that PR anticipated.

## Reviewers

@TaeKimJR @ljharb @joeuy @lencioni @majapw @caseklim