### PR TITLE
Call getStateForNewMonth when date/startDate/endDate is set to a date that is not visible

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -18,6 +18,7 @@ import isBeforeDay from '../utils/isBeforeDay';
 import getVisibleDays from '../utils/getVisibleDays';
 import isDayVisible from '../utils/isDayVisible';
 
+import getPooledMoment from '../utils/getPooledMoment';
 import getSelectedDateOffset from '../utils/getSelectedDateOffset';
 
 import toISODateString from '../utils/toISODateString';
@@ -41,7 +42,6 @@ import {
 } from '../constants';
 
 import DayPicker from './DayPicker';
-import getPooledMoment from '../utils/getPooledMoment';
 
 const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
@@ -284,6 +284,8 @@ export default class DayPickerRangeController extends React.PureComponent {
     } = this.props;
 
     const { hoverDate } = this.state;
+
+    let { currentMonth } = this.state;
     let { visibleDays } = this.state;
 
     let recomputeOutsideRange = false;
@@ -313,6 +315,18 @@ export default class DayPickerRangeController extends React.PureComponent {
     const didEndDateChange = endDate !== prevEndDate;
     const didFocusChange = focusedInput !== prevFocusedInput;
 
+    let isDateVisible = true;
+
+    if (didStartDateChange || didEndDateChange) {
+      if (didStartDateChange) {
+        isDateVisible = isDayVisible(startDate, currentMonth, numberOfMonths, enableOutsideDays);
+      }
+
+      if (didEndDateChange) {
+        isDateVisible = isDayVisible(endDate, currentMonth, numberOfMonths, enableOutsideDays);
+      }
+    }
+
     if (
       numberOfMonths !== prevNumberOfMonths
       || enableOutsideDays !== prevEnableOutsideDays
@@ -321,10 +335,10 @@ export default class DayPickerRangeController extends React.PureComponent {
         && !prevFocusedInput
         && didFocusChange
       )
+      || !isDateVisible
     ) {
       const newMonthState = this.getStateForNewMonth(nextProps);
-      const { currentMonth } = newMonthState;
-      ({ visibleDays } = newMonthState);
+      ({ currentMonth, visibleDays } = newMonthState);
       this.setState({
         currentMonth,
         visibleDays,

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -13,6 +13,7 @@ import isSameDay from '../utils/isSameDay';
 import isAfterDay from '../utils/isAfterDay';
 
 import getVisibleDays from '../utils/getVisibleDays';
+import isDayVisible from '../utils/isDayVisible';
 
 import toISODateString from '../utils/toISODateString';
 import { addModifier, deleteModifier } from '../utils/modifiers';
@@ -219,6 +220,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       focused: prevFocused,
       date: prevDate,
     } = this.props;
+    let { currentMonth } = this.state;
     let { visibleDays } = this.state;
 
     let recomputeOutsideRange = false;
@@ -244,6 +246,15 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       recomputeOutsideRange || recomputeDayBlocked || recomputeDayHighlighted
     );
 
+    const didDateChange = date !== prevDate;
+    const didFocusChange = focused !== prevFocused;
+
+    let isDateVisible = true;
+
+    if (didDateChange) {
+      isDateVisible = isDayVisible(date, currentMonth, numberOfMonths, enableOutsideDays);
+    }
+
     if (
       numberOfMonths !== prevNumberOfMonths
       || enableOutsideDays !== prevEnableOutsideDays
@@ -251,19 +262,15 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         initialVisibleMonth !== prevInitialVisibleMonth
         && !prevFocused
         && focused
-      )
+      ) || !isDateVisible
     ) {
       const newMonthState = this.getStateForNewMonth(nextProps);
-      const { currentMonth } = newMonthState;
-      ({ visibleDays } = newMonthState);
+      ({ currentMonth, visibleDays } = newMonthState);
       this.setState({
         currentMonth,
         visibleDays,
       });
     }
-
-    const didDateChange = date !== prevDate;
-    const didFocusChange = focused !== prevFocused;
 
     let modifiers = {};
 

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -297,33 +297,80 @@ describe('DayPickerRangeController', () => {
           });
           expect(wrapper.instance().state.visibleDays).to.equal(visibleDays);
         });
-        describe('startDate changed from one date to another', () => {
-          it('removes previous `after-hovered-start` range', () => {
-            const minimumNights = 5;
-            const startDate = moment().add(7, 'days');
-            const dayAfterStartDate = startDate.clone().add(1, 'day');
-            const firstAvailableDate = startDate.clone().add(minimumNights + 1, 'days');
-            const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
-            const nextStartDate = moment().add(4, 'days');
-            const wrapper = shallow((
-              <DayPickerRangeController
-                onDatesChange={sinon.stub()}
-                onFocusChange={sinon.stub()}
-                startDate={startDate}
-                focusedInput={START_DATE}
-                minimumNights={minimumNights}
-              />
-            ));
-            deleteModifierFromRangeSpy.resetHistory();
-            wrapper.instance().componentWillReceiveProps({
-              ...props,
-              startDate: nextStartDate,
-            });
-            const afterHoverStartCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'after-hovered-start');
-            expect(afterHoverStartCalls.length).to.equal(1);
-            expect(isSameDay(afterHoverStartCalls[0].args[1], dayAfterStartDate)).to.equal(true);
-            expect(isSameDay(afterHoverStartCalls[0].args[2], firstAvailableDate)).to.equal(true);
+      });
+
+      describe('startDate changed from one date to another', () => {
+        it('removes previous `after-hovered-start` range', () => {
+          const minimumNights = 5;
+          const startDate = moment().add(7, 'days');
+          const dayAfterStartDate = startDate.clone().add(1, 'day');
+          const firstAvailableDate = startDate.clone().add(minimumNights + 1, 'days');
+          const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
+          const nextStartDate = moment().add(4, 'days');
+          const wrapper = shallow((
+            <DayPickerRangeController
+              onDatesChange={sinon.stub()}
+              onFocusChange={sinon.stub()}
+              startDate={startDate}
+              focusedInput={START_DATE}
+              minimumNights={minimumNights}
+            />
+          ));
+          deleteModifierFromRangeSpy.resetHistory();
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            startDate: nextStartDate,
           });
+          const afterHoverStartCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'after-hovered-start');
+          expect(afterHoverStartCalls.length).to.equal(1);
+          expect(isSameDay(afterHoverStartCalls[0].args[1], dayAfterStartDate)).to.equal(true);
+          expect(isSameDay(afterHoverStartCalls[0].args[2], firstAvailableDate)).to.equal(true);
+        });
+
+        it('calls getStateForNewMonth with nextProps when date is not visible', () => {
+          const getStateForNewMonthSpy = sinon.spy(
+            DayPickerRangeController.prototype,
+            'getStateForNewMonth',
+          );
+          const startDate = moment();
+          const nextStartDate = startDate.clone().add(2, 'months');
+
+          const wrapper = shallow((
+            <DayPickerRangeController {...props} startDate={startDate} />
+          ));
+
+          getStateForNewMonthSpy.resetHistory();
+
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            startDate: nextStartDate,
+          });
+
+          expect(getStateForNewMonthSpy.callCount).to.equal(1);
+        });
+      });
+
+      describe('endDate changed from one date to another', () => {
+        it('calls getStateForNewMonth with nextProps when date is not visible', () => {
+          const getStateForNewMonthSpy = sinon.spy(
+            DayPickerRangeController.prototype,
+            'getStateForNewMonth',
+          );
+          const endDate = moment();
+          const nextEndDate = endDate.clone().add(2, 'months');
+
+          const wrapper = shallow((
+            <DayPickerRangeController {...props} endDate={endDate} />
+          ));
+
+          getStateForNewMonthSpy.resetHistory();
+
+          wrapper.instance().componentWillReceiveProps({
+            ...props,
+            endDate: nextEndDate,
+          });
+
+          expect(getStateForNewMonthSpy.callCount).to.equal(1);
         });
       });
     });

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -46,6 +46,30 @@ describe('DayPickerSingleDateController', () => {
       onFocusChange() {},
     };
 
+    describe('date changed from one date to another', () => {
+      it('calls getStateForNewMonth with nextProps when date is not visible', () => {
+        const getStateForNewMonthSpy = sinon.spy(
+          DayPickerSingleDateController.prototype,
+          'getStateForNewMonth',
+        );
+        const date = moment();
+        const nextDate = date.clone().add(2, 'months');
+
+        const wrapper = shallow((
+          <DayPickerSingleDateController {...props} date={date} />
+        ));
+
+        getStateForNewMonthSpy.resetHistory();
+
+        wrapper.instance().componentWillReceiveProps({
+          ...props,
+          date: nextDate,
+        });
+
+        expect(getStateForNewMonthSpy.callCount).to.equal(1);
+      });
+    });
+
     describe('modifiers', () => {
       describe('selected modifier', () => {
         describe('props.date did not change', () => {


### PR DESCRIPTION
If `date`, `startDate`, or `endDate` is set externally by a different date input, this will bring the month with the newly selected date into view.