### PR TITLE
Turn off react/deprecated lint rule and remove erroneous `.only`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,8 @@
     "no-restricted-imports": 0, // TODO: enable with full RTL support
 
     "react/jsx-props-no-spreading": 0, // TODO: re-evaluate
+
+    "react/no-deprecated": 1, // TODO: update to UNSAFE_componentWillReceiveProps
   },
 
   "overrides": [

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -4492,7 +4492,7 @@ describe('DayPickerRangeController', () => {
       });
     });
 
-    describe.only('renderKeyboardShortcutsPanel prop', () => {
+    describe('renderKeyboardShortcutsPanel prop', () => {
       it('passes down custom panel render function', () => {
         const testRenderKeyboardShortcutsPanel = () => {};
         const wrapper = shallow(


### PR DESCRIPTION
The lint rule was likely introduced by a downstream dependency. Currently turning off the rule to unblock development.

Also removing an erroneous `.only`.