### PR TITLE
Revert "[Tests] `DayPicker`: unit test for getWeekHeaders()"

### DIFF
--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -3,7 +3,6 @@ import moment from 'moment/min/moment-with-locales';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
 import { mount, shallow } from 'enzyme';
-import { cloneDeep } from 'lodash';
 
 import * as isDayVisible from '../../src/utils/isDayVisible';
 
@@ -869,23 +868,6 @@ describe('DayPicker', () => {
       const wrapper = shallow(<DayPicker initialVisibleMonth={() => INITIAL_MONTH} />).dive();
       const instance = wrapper.instance();
       expect(instance.getWeekHeaders()).to.be.eql(INITIAL_MONTH.localeData().weekdaysMin());
-    });
-  });
-
-  describe('#getWeekHeaders', () => {
-    it('returns unmutated weekday headers for currentMonth in a future', () => {
-      sinon.stub(PureDayPicker.prototype, 'render');
-
-      const getWeekHeadersSpy = sinon.spy(PureDayPicker.prototype, 'getWeekHeaders');
-      const INITIAL_MONTH = moment().add(2, 'Months').week(3).weekday(3);
-      const wrapper = shallow(<DayPicker initialVisibleMonth={() => INITIAL_MONTH} />).dive();
-      const instance = wrapper.instance();
-      const state = cloneDeep(wrapper.state());
-
-      expect(instance.getWeekHeaders()).to.be.eql(INITIAL_MONTH.localeData().weekdaysMin());
-      expect(instance.state).not.to.equal(state);
-      expect(instance.state).to.eql(state);
-      expect(getWeekHeadersSpy).to.have.property('callCount', 1);
     });
   });
 


### PR DESCRIPTION
This reverts commit 5584f822fdcc3fa266deff62756ac887b4c0d2af.

Unfortunately, due to a `.only` that snuck into a test, https://github.com/airbnb/react-dates/pull/1798 did not actually run the full test suite and passed erroneously. I'm gonna revert for now, merge in https://github.com/airbnb/react-dates/pull/1835, and rebase @caseklim's change.

