### PR TITLE
Revert "Revert "[Tests] `DayPicker`: unit test for getWeekHeaders()""

### DIFF
--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -3,6 +3,7 @@ import moment from 'moment/min/moment-with-locales';
 import { expect } from 'chai';
 import sinon from 'sinon-sandbox';
 import { mount, shallow } from 'enzyme';
+import { cloneDeep } from 'lodash';
 
 import * as isDayVisible from '../../src/utils/isDayVisible';
 import isSameMonth from '../../src/utils/isSameMonth';
@@ -1010,6 +1011,23 @@ describe('DayPicker', () => {
       const wrapper = shallow(<DayPicker initialVisibleMonth={() => INITIAL_MONTH} />).dive();
       const instance = wrapper.instance();
       expect(instance.getWeekHeaders()).to.be.eql(INITIAL_MONTH.localeData().weekdaysMin());
+    });
+  });
+
+  describe('#getWeekHeaders', () => {
+    it('returns unmutated weekday headers for currentMonth in a future', () => {
+      sinon.stub(PureDayPicker.prototype, 'render').returns(null);
+
+      const getWeekHeadersSpy = sinon.spy(PureDayPicker.prototype, 'getWeekHeaders');
+      const INITIAL_MONTH = moment().add(2, 'Months').week(3).weekday(3);
+      const wrapper = shallow(<DayPicker initialVisibleMonth={() => INITIAL_MONTH} />).dive();
+      const instance = wrapper.instance();
+      const state = cloneDeep(wrapper.state());
+
+      expect(instance.getWeekHeaders()).to.be.eql(INITIAL_MONTH.localeData().weekdaysMin());
+      expect(instance.state).not.to.equal(state);
+      expect(instance.state).to.eql(state);
+      expect(getWeekHeadersSpy).to.have.property('callCount', 1);
     });
   });
 


### PR DESCRIPTION
This reverts commit defb7fd680cab4154d12e9416c9f28e4a47e9e5b.

@v47 @ljharb Unfortunately, due to an accidental `describe.only` that slipped into master, we weren't running the full test suite on https://github.com/airbnb/react-dates/pull/1798. It seems like the test actually fails on React 15. If you'd like to take another look, we can try to get it merged in.

Thanks!