### PR TITLE
[Security] Bump lodash to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "airbnb-prop-types": "^2.8.1",
     "consolidated-events": "^1.1.1",
     "is-touch-device": "^1.0.1",
-    "lodash": "^4.1.1",
+    "lodash": "^4.17.15",
     "object.assign": "^4.1.0",
     "object.values": "^1.0.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
With the carat dependency installing should bump `lodash` to latest but it seemed best to be explicit to address the following [Snyk Issue](https://www.npmjs.com/advisories/1065)