### PR TITLE
Update flakey test for no-selected-start-before-selected-end

### DIFF
--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1622,10 +1622,11 @@ describe('DayPickerRangeController', () => {
               />,
             );
             const newStartDate = today;
-            const visibleDays = wrapper.instance().state.visibleDays;
-            const numberOfVisibleDays = Object.values(visibleDays).reduce((total, visibleDayArray) => {
-              return total + Object.keys(visibleDayArray).length;
-            }, 0);
+            const { visibleDays } = wrapper.instance().state;
+            const numberOfVisibleDays = Object.values(visibleDays).reduce(
+              (total, visibleDayArray) => total + Object.keys(visibleDayArray).length,
+              0,
+            );
             wrapper.instance().componentWillReceiveProps({
               ...props,
               endDate,

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1613,7 +1613,7 @@ describe('DayPickerRangeController', () => {
         describe('start date has changed, previous start date is falsey, start and end date is truthy', () => {
           it('calls deleteModifier with `no-selected-start-before-selected-end` if day is before selected end date', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
-            const endDate = moment('1993-10-27');
+            const endDate = today.clone().add(10, 'days');
             const wrapper = shallow(
               <DayPickerRangeController
                 {...props}
@@ -1621,15 +1621,18 @@ describe('DayPickerRangeController', () => {
                 endDate={endDate}
               />,
             );
-            const newStartDate = endDate.clone().subtract(10, 'days');
-            const numberVisibleDays = 91;
+            const newStartDate = today;
+            const visibleDays = wrapper.instance().state.visibleDays;
+            const numberOfVisibleDays = Object.values(visibleDays).reduce((total, visibleDayArray) => {
+              return total + Object.keys(visibleDayArray).length;
+            }, 0);
             wrapper.instance().componentWillReceiveProps({
               ...props,
               endDate,
               startDate: newStartDate,
             });
             const noSelectedStartBeforeSelectedEndCalls = getCallsByModifier(deleteModifierSpy, 'no-selected-start-before-selected-end');
-            expect(noSelectedStartBeforeSelectedEndCalls.length).to.equal(numberVisibleDays);
+            expect(noSelectedStartBeforeSelectedEndCalls.length).to.equal(numberOfVisibleDays);
           });
         });
       });


### PR DESCRIPTION
**What's this fix?**
Fixes the breaking test in master from merged in PR #1608 

**What happened?**
The broken test was validating that a change in end date would call `deleteModifier` for `no-selected-start-before-selected-end` on all visible days. Turns out the test was flakey because the visible days object calculated by DayPickerRangeController is determined by the `initialVisibleMonthThunk`.
```
const initialVisibleMonthThunk = initialVisibleMonth || (
   startDate ? () => startDate : () => this.today
);
``` 
[DayPickerRangeController.jsx Line 1065](https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerRangeController.jsx#L1065). 

The default `initialVisibleMonthThunk` does not take into account a passed in end date and by defaulting to today, the test cannot rely on a hardcoded number of times that `deleteModifier `will run. This isn't a major issue since DayPickerRangeController is most likely consumed by using the DateRangePicker kitchen sink that determines `initialVisibleMonthThunk` like so
``` 
const initialVisibleMonthThunk = initialVisibleMonth || (
    () => (startDate || endDate || moment())
);
```
[DayPickerRangeController.jsx Line 460](https://github.com/airbnb/react-dates/blob/master/src/components/DateRangePicker.jsx#L460). 

Happy to update the default of DayPickerRangeController to match the default on the DateRangePicker for both consistency and expected behavior, but wanted to prioritize fixing the flakey test for now.

Let me know if this works @majapw @ljharb! 😁
