### PR TITLE
Fix modifying date string in text input using backspaces to an empty string will cause text input to reset text input

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -101,15 +101,15 @@ class DateInput extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const props = this.props;
-    /** 
+    const { props } = this;
+    /**
      * Only set this.state.dateString to displayValue
      * When date picker is turned on or off (plus displayValue is not null)
     */
-    if(props.focused !== nextProps.focused && nextProps.displayValue) {
-        this.setState({
-            dateString: nextProps.displayValue
-        });
+    if (props.focused !== nextProps.focused && nextProps.displayValue) {
+      this.setState({
+        dateString: nextProps.displayValue,
+      });
     }
   }
 

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -86,7 +86,7 @@ class DateInput extends React.PureComponent {
     super(props);
 
     this.state = {
-      dateString: '',
+      dateString: this.props.displayValue || '',
       isTouchDevice: false,
     };
 
@@ -101,11 +101,15 @@ class DateInput extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { dateString } = this.state;
-    if (dateString && nextProps.displayValue) {
-      this.setState({
-        dateString: '',
-      });
+    const props = this.props;
+    /** 
+     * Only set this.state.dateString to displayValue
+     * When date picker is turned on or off (plus displayValue is not null)
+    */
+    if(props.focused !== nextProps.focused && nextProps.displayValue) {
+        this.setState({
+            dateString: nextProps.displayValue
+        });
     }
   }
 
@@ -175,7 +179,6 @@ class DateInput extends React.PureComponent {
       id,
       placeholder,
       ariaLabel,
-      displayValue,
       screenReaderMessage,
       focused,
       showCaret,
@@ -192,7 +195,7 @@ class DateInput extends React.PureComponent {
       theme: { reactDates },
     } = this.props;
 
-    const value = dateString || displayValue || '';
+    const value = dateString || '';
     const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     const withFang = showCaret && focused;


### PR DESCRIPTION
Fixed #1875 

Modifying date string in text input using backspaces to an empty string will cause text input to reset text input