### PR TITLE
Remove overflowY:scroll on CalendarMonthGrid

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -370,7 +370,6 @@ CalendarMonthGrid.defaultProps = defaultProps;
 export default withStyles(({
   reactDates: {
     color,
-    noScrollBarOnVerticalScrollable,
     spacing,
     zIndex,
   },

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -396,14 +396,6 @@ export default withStyles(({
 
   CalendarMonthGrid__vertical_scrollable: {
     margin: '0 auto',
-    overflowY: 'scroll',
-    ...(noScrollBarOnVerticalScrollable && {
-      '-webkitOverflowScrolling': 'touch',
-      '::-webkit-scrollbar': {
-        '-webkit-appearance': 'none',
-        display: 'none',
-      },
-    }),
   },
 
   CalendarMonthGrid_month__horizontal: {


### PR DESCRIPTION
Not sure if this makes sense, but for vertical scrollable, we rely on the DayPicker container to do vertical scrolling, https://github.com/airbnb/react-dates/blob/7c58d6d6aadf0061980f1adeb52465c2606d58ac/src/components/DayPicker.jsx#L1310

and CalendarMonthGrid works as the content inside it, it doesn't look like we need a overflowY:scroll here

https://github.com/airbnb/react-dates/blob/7c58d6d6aadf0061980f1adeb52465c2606d58ac/src/components/CalendarMonthGrid.jsx#L399

with this it seems cause double scroll bars in some browsers. for this case, it's `Chrome 78, Google Pixel 3, 9.0`

![QA-2377](https://user-images.githubusercontent.com/3829183/70567906-ac927d00-1b4b-11ea-9354-78eaeb39f0bd.png)



@caseklim @kevinthepan @noratarano @ljharb 