### PR TITLE
[Refactor] `CalendarMonthGrid`: Skip unnecessary setState

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -151,33 +151,35 @@ class CalendarMonthGrid extends React.PureComponent {
     const hasNumberOfMonthsChanged = prevNumberOfMonths !== numberOfMonths;
     let newMonths = months;
 
-    if (hasMonthChanged && !hasNumberOfMonthsChanged) {
-      if (isNextMonth(prevInitialMonth, initialMonth)) {
-        newMonths = months.slice(1);
-        newMonths.push(months[months.length - 1].clone().add(1, 'month'));
-      } else if (isPrevMonth(prevInitialMonth, initialMonth)) {
-        newMonths = months.slice(0, months.length - 1);
-        newMonths.unshift(months[0].clone().subtract(1, 'month'));
-      } else {
+    if (hasMonthChanged || hasNumberOfMonthsChanged) {
+      if (hasMonthChanged && !hasNumberOfMonthsChanged) {
+        if (isNextMonth(prevInitialMonth, initialMonth)) {
+          newMonths = months.slice(1);
+          newMonths.push(months[months.length - 1].clone().add(1, 'month'));
+        } else if (isPrevMonth(prevInitialMonth, initialMonth)) {
+          newMonths = months.slice(0, months.length - 1);
+          newMonths.unshift(months[0].clone().subtract(1, 'month'));
+        } else {
+          const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
+          newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
+        }
+      }
+
+      if (hasNumberOfMonthsChanged) {
         const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
         newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
       }
-    }
 
-    if (hasNumberOfMonthsChanged) {
-      const withoutTransitionMonths = orientation === VERTICAL_SCROLLABLE;
-      newMonths = getMonths(initialMonth, numberOfMonths, withoutTransitionMonths);
-    }
+      const momentLocale = moment.locale();
+      if (this.locale !== momentLocale) {
+        this.locale = momentLocale;
+        newMonths = newMonths.map((m) => m.locale(this.locale));
+      }
 
-    const momentLocale = moment.locale();
-    if (this.locale !== momentLocale) {
-      this.locale = momentLocale;
-      newMonths = newMonths.map((m) => m.locale(this.locale));
+      this.setState({
+        months: newMonths,
+      });
     }
-
-    this.setState({
-      months: newMonths,
-    });
   }
 
   componentDidUpdate() {

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -45,6 +45,21 @@ describe('CalendarMonthGrid', () => {
     expect(Object.keys(collisions).length).to.equal(months.length);
   });
 
+  it('does not setState if hasMonthChanged and hasNumberOfMonthsChanged are falsy', () => {
+    const setState = sinon.stub(CalendarMonthGrid.prototype, 'setState');
+    const initialMonth = moment();
+    const wrapper = shallow((
+      <CalendarMonthGrid numberOfMonths={12} initialMonth={initialMonth} />
+    )).dive();
+
+    wrapper.instance().componentWillReceiveProps({
+      initialMonth,
+      numberOfMonths: 12,
+    });
+
+    expect(setState.callCount).to.eq(0);
+  });
+
   it('works with the same number of months', () => {
     const initialMonth = moment();
     const wrapper = shallow((


### PR DESCRIPTION
I just notice that setState in **CalendarMonthGrid** component called if it is unnecessary (**hasMonthChanged** and **hasNumberOfMonthsChanged** are falsy values)
