### PR TITLE
Add VERTICAL_SCROLLABLE as an orientation for DateRangePicker #898

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -26,6 +26,7 @@ import {
   END_DATE,
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
+  VERTICAL_SCROLLABLE,
   ANCHOR_LEFT,
   ANCHOR_RIGHT,
   OPEN_DOWN,
@@ -483,7 +484,7 @@ class DateRangePicker extends React.PureComponent {
           anchorDirection === ANCHOR_LEFT && styles.DateRangePicker_picker__directionLeft,
           anchorDirection === ANCHOR_RIGHT && styles.DateRangePicker_picker__directionRight,
           orientation === HORIZONTAL_ORIENTATION && styles.DateRangePicker_picker__horizontal,
-          orientation === VERTICAL_ORIENTATION && styles.DateRangePicker_picker__vertical,
+          orientation === VERTICAL_ORIENTATION || orientation === VERTICAL_SCROLLABLE && styles.DateRangePicker_picker__vertical,
           !withAnyPortal && openDirection === OPEN_DOWN && {
             top: inputHeight + verticalSpacing,
           },

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -7,7 +7,7 @@ import getPhrasePropTypes from '../utils/getPhrasePropTypes';
 
 import FocusedInputShape from './FocusedInputShape';
 import IconPositionShape from './IconPositionShape';
-import OrientationShape from './OrientationShape';
+import ScrollableOrientationShape from './ScrollableOrientationShape';
 import DisabledShape from './DisabledShape';
 import anchorDirectionShape from './AnchorDirectionShape';
 import openDirectionShape from './OpenDirectionShape';
@@ -55,7 +55,7 @@ export default {
   renderMonthText: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),
   renderMonthElement: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),
   renderWeekHeaderElement: PropTypes.func,
-  orientation: OrientationShape,
+  orientation: ScrollableOrientationShape,
   anchorDirection: anchorDirectionShape,
   openDirection: openDirectionShape,
   horizontalMargin: PropTypes.number,


### PR DESCRIPTION
Previously functional but leaves a prop type warning in the console