### PR TITLE
[Fix] `DateRangePickerInputController`: fix onClose method

### DIFF
--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -179,6 +179,8 @@ export default class DateRangePickerInputController extends React.PureComponent 
       minimumNights,
       keepOpenOnDateSelect,
       onDatesChange,
+      onClose,
+      onFocusChange,
     } = this.props;
 
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
@@ -188,7 +190,10 @@ export default class DateRangePickerInputController extends React.PureComponent 
       && !(startDate && isBeforeDay(endDate, startDate.clone().add(minimumNights, 'days')));
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });
-      if (!keepOpenOnDateSelect) this.onClearFocus();
+      if (!keepOpenOnDateSelect) {
+        onFocusChange(null);
+        onClose({ startDate, endDate });
+      }
     } else {
       onDatesChange({
         startDate,

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -221,6 +221,23 @@ describe('DateRangePickerInputController', () => {
           expect(isSameDay(onDatesChangeArgs.endDate, futureDate)).to.equal(true);
         });
 
+        it('calls props.onClose with props.startDate and provided end date', () => {
+          const onCloseStub = sinon.stub();
+          const wrapper = shallow((
+            <DateRangePickerInputController
+              onClose={onCloseStub}
+              startDate={startDate}
+            />
+          ));
+          wrapper.instance().onEndDateChange(validFutureDateString);
+          expect(onCloseStub).to.have.property('callCount', 1);
+
+          const [onCloseArgs] = onCloseStub.getCall(0).args;
+          const futureDate = moment(validFutureDateString);
+          expect(onCloseArgs).to.have.property('startDate', startDate);
+          expect(isSameDay(onCloseArgs.endDate, futureDate)).to.equal(true);
+        });
+
         describe('props.onFocusChange', () => {
           it('is called once', () => {
             const onFocusChangeStub = sinon.stub();


### PR DESCRIPTION
Fixes #1892 
I suppose following issue because of firing **onClearFocus** with start and end dates from props, that's not right it should use values inside **onEndDateChange** function