### PR TITLE
Add functionality to see previous months for vertical scrollable calendar

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -679,6 +679,29 @@ class DayPicker extends React.PureComponent {
     this.transitionContainer = ref;
   }
 
+  getNextScrollableMonths(e) {
+    const { onGetNextScrollableMonths } = this.props;
+    if (e) e.preventDefault();
+
+    if (onGetNextScrollableMonths) onGetNextScrollableMonths(e);
+
+    this.setState(({ scrollableMonthMultiple }) => ({
+      scrollableMonthMultiple: scrollableMonthMultiple + 1,
+    }));
+  }
+
+  getPrevScrollableMonths(e) {
+    const { numberOfMonths, onGetPrevScrollableMonths } = this.props;
+    if (e) e.preventDefault();
+
+    if (onGetPrevScrollableMonths) onGetPrevScrollableMonths(e);
+
+    this.setState(({ currentMonth, scrollableMonthMultiple }) => ({
+      currentMonth: currentMonth.clone().subtract(numberOfMonths, 'month'),
+      scrollableMonthMultiple: scrollableMonthMultiple + 1,
+    }));
+  }
+
   maybeTransitionNextMonth(newFocusedDate) {
     const { numberOfMonths } = this.props;
     const { currentMonth, focusedDate } = this.state;
@@ -707,29 +730,6 @@ class DayPicker extends React.PureComponent {
     }
 
     return false;
-  }
-
-  getNextScrollableMonths(e) {
-    const { onGetNextScrollableMonths } = this.props;
-    if (e) e.preventDefault();
-
-    if (onGetNextScrollableMonths) onGetNextScrollableMonths(e);
-
-    this.setState(({ scrollableMonthMultiple }) => ({
-      scrollableMonthMultiple: scrollableMonthMultiple + 1,
-    }));
-  }
-
-  getPrevScrollableMonths(e) {
-    const { numberOfMonths, onGetPrevScrollableMonths } = this.props;
-    if (e) e.preventDefault();
-
-    if (onGetPrevScrollableMonths) onGetPrevScrollableMonths(e);
-
-    this.setState(({ currentMonth, scrollableMonthMultiple }) => ({
-      currentMonth: currentMonth.clone().subtract(numberOfMonths, 'month'),
-      scrollableMonthMultiple: scrollableMonthMultiple + 1,
-    }));
   }
 
   isHorizontal() {
@@ -879,15 +879,13 @@ class DayPicker extends React.PureComponent {
       return null;
     }
 
-    const onPrevMonthClick =
-      orientation === VERTICAL_SCROLLABLE
-        ? this.getPrevScrollableMonths
-        : this.onPrevMonthClick;
+    const onPrevMonthClick = orientation === VERTICAL_SCROLLABLE
+      ? this.getPrevScrollableMonths
+      : this.onPrevMonthClick;
 
-    const onNextMonthClick =
-      orientation === VERTICAL_SCROLLABLE
-        ? this.getNextScrollableMonths
-        : this.onNextMonthClick;
+    const onNextMonthClick = orientation === VERTICAL_SCROLLABLE
+      ? this.getNextScrollableMonths
+      : this.onNextMonthClick;
 
     return (
       <DayPickerNavigation

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -859,7 +859,7 @@ class DayPicker extends React.PureComponent {
     });
   }
 
-  renderNavigation(navDirection = null) {
+  renderNavigation(navDirection) {
     const {
       dayPickerNavigationInlineStyles,
       disablePrev,

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -228,7 +228,7 @@ function DayPickerNavigation({
                 onNextMonthClick(e)
               };
             },
-            onMouseUp: disableNext ? undefined : e => {
+            onMouseUp: disableNext ? undefined : (e) => {
               e.currentTarget.blur();
             },
           })

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -133,9 +133,7 @@ function DayPickerNavigation({
     );
   }
 
-  const isDefaultNav = isVerticalScrollable
-    ? isDefaultNavNext
-    : (isDefaultNavNext || isDefaultNavPrev);
+  const isDefaultNav = isDefaultNavNext || isDefaultNavPrev;
 
   return (
     <div
@@ -157,8 +155,8 @@ function DayPickerNavigation({
         hasInlineStyles && inlineStyles,
       )}
     >
-      {showNavPrevButton &&
-        (renderNavPrevButton ? (
+      {showNavPrevButton
+        && (renderNavPrevButton ? (
           renderNavPrevButton({
             ariaLabel: phrases.jumpToPrevMonth,
             disabled: disablePrev,
@@ -195,7 +193,8 @@ function DayPickerNavigation({
                 ...(isDefaultNavPrev ? [
                   styles.DayPickerNavigation_button__verticalDefault,
                   styles.DayPickerNavigation_prevButton__verticalDefault,
-                  isVerticalScrollable && styles.DayPickerNavigation_prevButton__verticalScrollableDefault,
+                  isVerticalScrollable
+                    && styles.DayPickerNavigation_prevButton__verticalScrollableDefault,
                 ] : []),
               ] : []),
             )}
@@ -216,8 +215,8 @@ function DayPickerNavigation({
           </div>
         ))}
 
-      {showNavNextButton &&
-        (renderNavNextButton ? (
+      {showNavNextButton
+        && (renderNavNextButton ? (
           renderNavNextButton({
             ariaLabel: phrases.jumpToNextMonth,
             disabled: disableNext,
@@ -225,8 +224,8 @@ function DayPickerNavigation({
             onKeyUp: disableNext ? undefined : (e) => {
               const { key } = e;
               if (key === 'Enter' || key === ' ') {
-                onNextMonthClick(e)
-              };
+                onNextMonthClick(e);
+              }
             },
             onMouseUp: disableNext ? undefined : (e) => {
               e.currentTarget.blur();
@@ -234,7 +233,7 @@ function DayPickerNavigation({
           })
         ) : (
           <div // eslint-disable-line jsx-a11y/interactive-supports-focus
-            role='button'
+            role="button"
             {...navNextTabIndex}
             {...css(
               styles.DayPickerNavigation_button,
@@ -254,15 +253,15 @@ function DayPickerNavigation({
                 ...(isDefaultNavNext ? [
                   styles.DayPickerNavigation_button__verticalDefault,
                   styles.DayPickerNavigation_nextButton__verticalDefault,
-                  isVerticalScrollable &&
-                    styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
+                  isVerticalScrollable
+                    && styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
                 ] : []),
               ] : []),
             )}
             aria-disabled={disableNext ? true : undefined}
             aria-label={phrases.jumpToNextMonth}
             onClick={disableNext ? undefined : onNextMonthClick}
-            onKeyUp={ disableNext ? undefined : (e) => {
+            onKeyUp={disableNext ? undefined : (e) => {
               const { key } = e;
               if (key === 'Enter' || key === ' ') {
                 onNextMonthClick(e);

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -40,6 +40,8 @@ const propTypes = forbidExtraProps({
 
   renderNavPrevButton: PropTypes.func,
   renderNavNextButton: PropTypes.func,
+  showNavPrevButton: PropTypes.bool,
+  showNavNextButton: PropTypes.bool,
 });
 
 const defaultProps = {
@@ -60,6 +62,8 @@ const defaultProps = {
 
   renderNavPrevButton: null,
   renderNavNextButton: null,
+  showNavPrevButton: true,
+  showNavNextButton: true,
 };
 
 function DayPickerNavigation({
@@ -76,6 +80,8 @@ function DayPickerNavigation({
   phrases,
   renderNavPrevButton,
   renderNavNextButton,
+  showNavPrevButton,
+  showNavNextButton,
   styles,
 }) {
   const isHorizontal = orientation === HORIZONTAL_ORIENTATION;
@@ -151,19 +157,21 @@ function DayPickerNavigation({
         hasInlineStyles && inlineStyles,
       )}
     >
-      {!isVerticalScrollable && (
-        renderNavPrevButton ? renderNavPrevButton({
-          ariaLabel: phrases.jumpToPrevMonth,
-          disabled: disablePrev,
-          onClick: disablePrev ? undefined : onPrevMonthClick,
-          onKeyUp: disablePrev ? undefined : (e) => {
-            const { key } = e;
-            if (key === 'Enter' || key === ' ') onPrevMonthClick(e);
-          },
-          onMouseUp: disablePrev ? undefined : (e) => {
-            e.currentTarget.blur();
-          },
-        }) : (
+      {showNavPrevButton &&
+        (renderNavPrevButton ? (
+          renderNavPrevButton({
+            ariaLabel: phrases.jumpToPrevMonth,
+            disabled: disablePrev,
+            onClick: disablePrev ? undefined : onPrevMonthClick,
+            onKeyUp: disablePrev ? undefined : (e) => {
+              const { key } = e;
+              if (key === 'Enter' || key === ' ') onPrevMonthClick(e);
+            },
+            onMouseUp: disablePrev ? undefined : (e) => {
+              e.currentTarget.blur();
+            },
+          })
+        ) : (
           <div // eslint-disable-line jsx-a11y/interactive-supports-focus
             role="button"
             {...navPrevTabIndex}
@@ -185,6 +193,7 @@ function DayPickerNavigation({
                 ...(isDefaultNavPrev ? [
                   styles.DayPickerNavigation_button__verticalDefault,
                   styles.DayPickerNavigation_prevButton__verticalDefault,
+                  isVerticalScrollable && styles.DayPickerNavigation_prevButton__verticalScrollableDefault,
                 ] : []),
               ] : []),
             )}
@@ -201,62 +210,63 @@ function DayPickerNavigation({
           >
             {navPrevIcon}
           </div>
-        )
-      )}
+        ))}
 
-      {renderNavNextButton ? renderNavNextButton({
-        ariaLabel: phrases.jumpToNextMonth,
-        disabled: disableNext,
-        onClick: disableNext ? undefined : onNextMonthClick,
-        onKeyUp: disableNext ? undefined : (e) => {
-          const { key } = e;
-          if (key === 'Enter' || key === ' ') onNextMonthClick(e);
-        },
-        onMouseUp: disableNext ? undefined : (e) => {
-          e.currentTarget.blur();
-        },
-      }) : (
-        <div // eslint-disable-line jsx-a11y/interactive-supports-focus
-          role="button"
-          {...navNextTabIndex}
-          {...css(
-            styles.DayPickerNavigation_button,
-            isDefaultNavNext && styles.DayPickerNavigation_button__default,
-            disableNext && styles.DayPickerNavigation_button__disabled,
-            ...(isHorizontal ? [
-              styles.DayPickerNavigation_button__horizontal,
-              ...(isDefaultNavNext ? [
-                styles.DayPickerNavigation_button__horizontalDefault,
-                isBottomNavPosition && styles.DayPickerNavigation_bottomButton__horizontalDefault,
-                isRTL && styles.DayPickerNavigation_leftButton__horizontalDefault,
-                !isRTL && styles.DayPickerNavigation_rightButton__horizontalDefault,
+      {showNavNextButton &&
+        (renderNavNextButton ? (
+          renderNavNextButton({
+            ariaLabel: phrases.jumpToNextMonth,
+            disabled: disableNext,
+            onClick: disableNext ? undefined : onNextMonthClick,
+            onKeyUp: disableNext ? undefined : (e) => {
+              const { key } = e;
+              if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+            },
+            onMouseUp: disableNext ? undefined : e => {
+              e.currentTarget.blur();
+            },
+          })
+        ) : (
+          <div // eslint-disable-line jsx-a11y/interactive-supports-focus
+            role='button'
+            {...navNextTabIndex}
+            {...css(
+              styles.DayPickerNavigation_button,
+              isDefaultNavNext && styles.DayPickerNavigation_button__default,
+              disableNext && styles.DayPickerNavigation_button__disabled,
+              ...(isHorizontal ? [
+                styles.DayPickerNavigation_button__horizontal,
+                ...(isDefaultNavNext ? [
+                  styles.DayPickerNavigation_button__horizontalDefault,
+                  isBottomNavPosition && styles.DayPickerNavigation_bottomButton__horizontalDefault,
+                  isRTL && styles.DayPickerNavigation_leftButton__horizontalDefault,
+                  !isRTL && styles.DayPickerNavigation_rightButton__horizontalDefault,
+                ] : []),
               ] : []),
-            ] : []),
-            ...(isVertical ? [
-              styles.DayPickerNavigation_button__vertical,
-              styles.DayPickerNavigation_nextButton__vertical,
-              ...(isDefaultNavNext ? [
-                styles.DayPickerNavigation_button__verticalDefault,
-                styles.DayPickerNavigation_nextButton__verticalDefault,
-                isVerticalScrollable
-                && styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
+              ...(isVertical ? [
+                styles.DayPickerNavigation_button__vertical,
+                ...(isDefaultNavNext ? [
+                  styles.DayPickerNavigation_button__verticalDefault,
+                  styles.DayPickerNavigation_nextButton__verticalDefault,
+                  isVerticalScrollable &&
+                    styles.DayPickerNavigation_nextButton__verticalScrollableDefault,
+                ] : []),
               ] : []),
-            ] : []),
-          )}
-          aria-disabled={disableNext ? true : undefined}
-          aria-label={phrases.jumpToNextMonth}
-          onClick={disableNext ? undefined : onNextMonthClick}
-          onKeyUp={disableNext ? undefined : (e) => {
-            const { key } = e;
-            if (key === 'Enter' || key === ' ') onNextMonthClick(e);
-          }}
-          onMouseUp={disableNext ? undefined : (e) => {
-            e.currentTarget.blur();
-          }}
-        >
-          {navNextIcon}
-        </div>
-      )}
+            )}
+            aria-disabled={disableNext ? true : undefined}
+            aria-label={phrases.jumpToNextMonth}
+            onClick={disableNext ? undefined : onNextMonthClick}
+            onKeyUp={ disableNext ? undefined : (e) => {
+              const { key } = e;
+              if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+            }}
+            onMouseUp={disableNext ? undefined : (e) => {
+              e.currentTarget.blur();
+            }}
+          >
+            {navNextIcon}
+          </div>
+        ))}
     </div>
   );
 }
@@ -341,8 +351,7 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     },
   },
 
-  DayPickerNavigation_button__horizontal: {
-  },
+  DayPickerNavigation_button__horizontal: {},
 
   DayPickerNavigation_button__horizontalDefault: {
     position: 'absolute',
@@ -368,8 +377,7 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     right: noflip(22),
   },
 
-  DayPickerNavigation_button__vertical: {
-  },
+  DayPickerNavigation_button__vertical: {},
 
   DayPickerNavigation_button__verticalDefault: {
     padding: 5,
@@ -382,14 +390,17 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     width: '50%',
   },
 
-  DayPickerNavigation_prevButton__verticalDefault: {
-  },
+  DayPickerNavigation_prevButton__verticalDefault: {},
 
   DayPickerNavigation_nextButton__verticalDefault: {
     borderLeft: noflip(0),
   },
 
   DayPickerNavigation_nextButton__verticalScrollableDefault: {
+    width: '100%',
+  },
+
+  DayPickerNavigation_prevButton__verticalScrollableDefault: {
     width: '100%',
   },
 

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -165,7 +165,9 @@ function DayPickerNavigation({
             onClick: disablePrev ? undefined : onPrevMonthClick,
             onKeyUp: disablePrev ? undefined : (e) => {
               const { key } = e;
-              if (key === 'Enter' || key === ' ') onPrevMonthClick(e);
+              if (key === 'Enter' || key === ' ') {
+                onPrevMonthClick(e);
+              }
             },
             onMouseUp: disablePrev ? undefined : (e) => {
               e.currentTarget.blur();
@@ -202,7 +204,9 @@ function DayPickerNavigation({
             onClick={disablePrev ? undefined : onPrevMonthClick}
             onKeyUp={disablePrev ? undefined : (e) => {
               const { key } = e;
-              if (key === 'Enter' || key === ' ') onPrevMonthClick(e);
+              if (key === 'Enter' || key === ' ') {
+                onPrevMonthClick(e);
+              }
             }}
             onMouseUp={disablePrev ? undefined : (e) => {
               e.currentTarget.blur();
@@ -220,7 +224,9 @@ function DayPickerNavigation({
             onClick: disableNext ? undefined : onNextMonthClick,
             onKeyUp: disableNext ? undefined : (e) => {
               const { key } = e;
-              if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+              if (key === 'Enter' || key === ' ') {
+                onNextMonthClick(e)
+              };
             },
             onMouseUp: disableNext ? undefined : e => {
               e.currentTarget.blur();
@@ -258,7 +264,9 @@ function DayPickerNavigation({
             onClick={disableNext ? undefined : onNextMonthClick}
             onKeyUp={ disableNext ? undefined : (e) => {
               const { key } = e;
-              if (key === 'Enter' || key === ' ') onNextMonthClick(e);
+              if (key === 'Enter' || key === ' ') {
+                onNextMonthClick(e);
+              }
             }}
             onMouseUp={disableNext ? undefined : (e) => {
               e.currentTarget.blur();

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -259,7 +259,8 @@ export default class DayPickerRangeController extends React.PureComponent {
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
-    this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
+    this.onGetNextScrollableMonths = this.onGetNextScrollableMonths.bind(this);
+    this.onGetPrevScrollableMonths = this.onGetPrevScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
@@ -989,7 +990,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     });
   }
 
-  onMultiplyScrollableMonths() {
+  onGetNextScrollableMonths() {
     const { numberOfMonths, enableOutsideDays } = this.props;
     const { currentMonth, visibleDays } = this.state;
 
@@ -998,6 +999,22 @@ export default class DayPickerRangeController extends React.PureComponent {
     const newVisibleDays = getVisibleDays(nextMonth, numberOfMonths, enableOutsideDays, true);
 
     this.setState({
+      visibleDays: {
+        ...visibleDays,
+        ...this.getModifiers(newVisibleDays),
+      },
+    });
+  }
+
+  onGetPrevScrollableMonths() {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const firstPreviousMonth = currentMonth.clone().subtract(numberOfMonths, 'month');
+    const newVisibleDays = getVisibleDays(firstPreviousMonth, numberOfMonths, enableOutsideDays, true);
+
+    this.setState({
+      currentMonth: firstPreviousMonth.clone(),
       visibleDays: {
         ...visibleDays,
         ...this.getModifiers(newVisibleDays),
@@ -1317,7 +1334,8 @@ export default class DayPickerRangeController extends React.PureComponent {
         onTab={onTab}
         onShiftTab={onShiftTab}
         onYearChange={this.onYearChange}
-        onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
+        onGetNextScrollableMonths={this.onGetNextScrollableMonths}
+        onGetPrevScrollableMonths={this.onGetPrevScrollableMonths}
         monthFormat={monthFormat}
         renderMonthText={renderMonthText}
         renderWeekHeaderElement={renderWeekHeaderElement}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -1011,7 +1011,9 @@ export default class DayPickerRangeController extends React.PureComponent {
     const { currentMonth, visibleDays } = this.state;
 
     const firstPreviousMonth = currentMonth.clone().subtract(numberOfMonths, 'month');
-    const newVisibleDays = getVisibleDays(firstPreviousMonth, numberOfMonths, enableOutsideDays, true);
+    const newVisibleDays = getVisibleDays(
+      firstPreviousMonth, numberOfMonths, enableOutsideDays, true,
+    );
 
     this.setState({
       currentMonth: firstPreviousMonth.clone(),

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -194,7 +194,8 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     this.onNextMonthClick = this.onNextMonthClick.bind(this);
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
-    this.onMultiplyScrollableMonths = this.onMultiplyScrollableMonths.bind(this);
+    this.onGetNextScrollableMonths = this.onGetNextScrollableMonths.bind(this);
+    this.onGetPrevScrollableMonths = this.onGetPrevScrollableMonths.bind(this);
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
@@ -461,7 +462,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     });
   }
 
-  onMultiplyScrollableMonths() {
+  onGetNextScrollableMonths() {
     const { numberOfMonths, enableOutsideDays } = this.props;
     const { currentMonth, visibleDays } = this.state;
 
@@ -470,6 +471,24 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     const newVisibleDays = getVisibleDays(nextMonth, numberOfMonths, enableOutsideDays, true);
 
     this.setState({
+      visibleDays: {
+        ...visibleDays,
+        ...this.getModifiers(newVisibleDays),
+      },
+    });
+  }
+
+  onGetPrevScrollableMonths() {
+    const { numberOfMonths, enableOutsideDays } = this.props;
+    const { currentMonth, visibleDays } = this.state;
+
+    const firstPreviousMonth = currentMonth.clone().subtract(numberOfMonths, 'month');
+    const newVisibleDays = getVisibleDays(
+      firstPreviousMonth, numberOfMonths, enableOutsideDays, true,
+    );
+
+    this.setState({
+      currentMonth: firstPreviousMonth.clone(),
       visibleDays: {
         ...visibleDays,
         ...this.getModifiers(newVisibleDays),
@@ -632,7 +651,8 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         onNextMonthClick={this.onNextMonthClick}
         onMonthChange={this.onMonthChange}
         onYearChange={this.onYearChange}
-        onMultiplyScrollableMonths={this.onMultiplyScrollableMonths}
+        onGetNextScrollableMonths={this.onGetNextScrollableMonths}
+        onGetPrevScrollableMonths={this.onGetPrevScrollableMonths}
         monthFormat={monthFormat}
         withPortal={withPortal}
         hidden={!focused}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -442,6 +442,23 @@ storiesOf('DayPickerRangeController', module)
             </span>
           </div>
         )}
+        navPrev={(
+          <div style={{ position: 'relative' }}>
+            <span
+              style={{
+                position: 'absolute',
+                top: 20,
+                left: 50,
+                fontSize: 24,
+                border: '1px solid gray',
+                width: 200,
+                padding: 10,
+              }}
+            >
+              Show More Months
+            </span>
+          </div>
+        )}
       />
     </div>
   )))

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -10,7 +10,7 @@ import isSameDay from '../src/utils/isSameDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 import CustomizableCalendarDay, { defaultStyles, selectedStyles } from '../src/components/CustomizableCalendarDay';
 
-import { NAV_POSITION_BOTTOM, VERTICAL_ORIENTATION } from '../src/constants';
+import { NAV_POSITION_BOTTOM, VERTICAL_ORIENTATION, VERTICAL_SCROLLABLE } from '../src/constants';
 
 import DayPickerSingleDateControllerWrapper from '../examples/DayPickerSingleDateControllerWrapper';
 
@@ -218,6 +218,15 @@ storiesOf('DayPickerSingleDateController', module)
       onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
       onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
       orientation={VERTICAL_ORIENTATION}
+    />
+  )))
+  .add('verticalScrollable', withInfo()(() => (
+    <DayPickerSingleDateControllerWrapper
+      numberOfMonths={3}
+      onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerSingleDateController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
+      orientation={VERTICAL_SCROLLABLE}
     />
   )))
   .add('with custom month navigation icons', withInfo()(() => (

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -4,7 +4,6 @@ import sinon from 'sinon-sandbox';
 import { shallow } from 'enzyme';
 
 import DayPickerNavigation from '../../src/components/DayPickerNavigation';
-import { VERTICAL_SCROLLABLE } from '../../src/constants';
 import RightArrow from '../../src/components/RightArrow';
 import LeftArrow from '../../src/components/LeftArrow';
 
@@ -15,8 +14,13 @@ describe('DayPickerNavigation', () => {
       expect(wrapper.find('[role="button"]')).to.have.lengthOf(2);
     });
 
-    it('renders one button when vertically scrollable', () => {
-      const wrapper = shallow(<DayPickerNavigation orientation={VERTICAL_SCROLLABLE} />).dive();
+    it('renders one button when showNavNextButton is false', () => {
+      const wrapper = shallow(<DayPickerNavigation showNavNextButton={false} />).dive();
+      expect(wrapper.find('[role="button"]')).to.have.lengthOf(1);
+    });
+
+    it('renders one button when showNavNextButton is false', () => {
+      const wrapper = shallow(<DayPickerNavigation showNavPrevButton={false} />).dive();
       expect(wrapper.find('[role="button"]')).to.have.lengthOf(1);
     });
 

--- a/test/components/DayPickerNavigation_spec.jsx
+++ b/test/components/DayPickerNavigation_spec.jsx
@@ -134,6 +134,8 @@ describe('DayPickerNavigation', () => {
       expect(onPrevMonthStub).to.have.property('callCount', 1);
       prevMonthButton.simulate('keyup', { key: ' ' });
       expect(onPrevMonthStub).to.have.property('callCount', 2);
+      prevMonthButton.simulate('keyup', { key: 'k' });
+      expect(onPrevMonthStub).to.have.property('callCount', 2);
     });
 
     it('props.onNextMonthClick is triggered by next month button key up', () => {
@@ -144,6 +146,8 @@ describe('DayPickerNavigation', () => {
       nextMonthButton.simulate('keyup', { key: 'Enter' });
       expect(onNextMonthStub).to.have.property('callCount', 1);
       nextMonthButton.simulate('keyup', { key: ' ' });
+      expect(onNextMonthStub).to.have.property('callCount', 2);
+      nextMonthButton.simulate('keyup', { key: 'k' });
       expect(onNextMonthStub).to.have.property('callCount', 2);
     });
 
@@ -191,6 +195,36 @@ describe('DayPickerNavigation', () => {
       />).dive().find('button').at(0);
       nextMonthButton.simulate('click');
       expect(onNextMonthStub).to.have.property('callCount', 0);
+    });
+
+    it('props.onPrevMonthClick is triggered by custom prev month button key up', () => {
+      const onPrevMonthStub = sinon.stub();
+      const renderNavPrevButtonStub = sinon.stub().onCall(0).callsFake(({ onKeyUp }) => <button onKeyUp={onKeyUp} type="button">Prev</button>);
+      const prevMonthButton = shallow(<DayPickerNavigation
+        onPrevMonthClick={onPrevMonthStub}
+        renderNavPrevButton={renderNavPrevButtonStub}
+      />).dive().find('button').at(0);
+      prevMonthButton.simulate('keyup', { key: 'Enter' });
+      expect(onPrevMonthStub).to.have.property('callCount', 1);
+      prevMonthButton.simulate('keyup', { key: ' ' });
+      expect(onPrevMonthStub).to.have.property('callCount', 2);
+      prevMonthButton.simulate('keyup', { key: 'k' });
+      expect(onPrevMonthStub).to.have.property('callCount', 2);
+    });
+
+    it('props.onNextMonthClick is triggered by custom next month button key up', () => {
+      const onNextMonthStub = sinon.stub();
+      const renderNavNextButtonStub = sinon.stub().onCall(0).callsFake(({ onKeyUp }) => <button onKeyUp={onKeyUp} type="button">Next</button>);
+      const nextMonthButton = shallow(<DayPickerNavigation
+        onNextMonthClick={onNextMonthStub}
+        renderNavNextButton={renderNavNextButtonStub}
+      />).dive().find('button').at(0);
+      nextMonthButton.simulate('keyup', { key: 'Enter' });
+      expect(onNextMonthStub).to.have.property('callCount', 1);
+      nextMonthButton.simulate('keyup', { key: ' ' });
+      expect(onNextMonthStub).to.have.property('callCount', 2);
+      nextMonthButton.simulate('keyup', { key: 'k' });
+      expect(onNextMonthStub).to.have.property('callCount', 2);
     });
   });
 });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -4142,7 +4142,7 @@ describe('DayPickerRangeController', () => {
     });
   });
 
-  it('return value now has modifier arg for day after multiplying number of months', () => {
+  it('return value now has modifier arg for day after getting next scrollable months', () => {
     const modifierToAdd = 'foo';
     const futureDateAfterMultiply = today.clone().add(4, 'months');
     const monthISO = toISOMonthString(futureDateAfterMultiply);
@@ -4160,8 +4160,31 @@ describe('DayPickerRangeController', () => {
     )).instance();
     let modifiers = wrapper.addModifier(updatedDays, futureDateAfterMultiply, modifierToAdd);
     expect(Array.from(modifiers[monthISO][todayISO])).to.not.contain(modifierToAdd);
-    wrapper.onMultiplyScrollableMonths();
+    wrapper.onGetNextScrollableMonths();
     modifiers = wrapper.addModifier(updatedDays, futureDateAfterMultiply, modifierToAdd);
+    expect(Array.from(modifiers[monthISO][todayISO])).to.contain(modifierToAdd);
+  });
+
+  it('return value now has modifier arg for day after getting previous scrollable months', () => {
+    const modifierToAdd = 'foo';
+    const pastDateAfterMultiply = today.clone().subtract(4, 'months');
+    const monthISO = toISOMonthString(pastDateAfterMultiply);
+    const todayISO = toISODateString(pastDateAfterMultiply);
+    const updatedDays = {
+      [monthISO]: { [todayISO]: new Set(['bar', 'baz']) },
+    };
+    const wrapper = shallow((
+      <DayPickerRangeController
+        onDatesChange={sinon.stub()}
+        onFocusChange={sinon.stub()}
+        orientation={VERTICAL_SCROLLABLE}
+        numberOfMonths={3}
+      />
+    )).instance();
+    let modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
+    expect(Array.from(modifiers[monthISO][todayISO])).to.not.contain(modifierToAdd);
+    wrapper.onGetPreviousScrollableMonths();
+    modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
     expect(Array.from(modifiers[monthISO][todayISO])).to.contain(modifierToAdd);
   });
 

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -4167,11 +4167,11 @@ describe('DayPickerRangeController', () => {
 
   it('return value now has modifier arg for day after getting previous scrollable months', () => {
     const modifierToAdd = 'foo';
-    const pastDateAfterMultiply = today.clone().subtract(4, 'months');
+    const pastDateAfterMultiply = today.clone().subtract(3, 'months');
     const monthISO = toISOMonthString(pastDateAfterMultiply);
-    const todayISO = toISODateString(pastDateAfterMultiply);
+    const dayISO = toISODateString(pastDateAfterMultiply);
     const updatedDays = {
-      [monthISO]: { [todayISO]: new Set(['bar', 'baz']) },
+      [monthISO]: { [dayISO]: new Set(['bar', 'baz']) },
     };
     const wrapper = shallow((
       <DayPickerRangeController
@@ -4182,10 +4182,10 @@ describe('DayPickerRangeController', () => {
       />
     )).instance();
     let modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
-    expect(Array.from(modifiers[monthISO][todayISO])).to.not.contain(modifierToAdd);
-    wrapper.onGetPreviousScrollableMonths();
+    expect(Array.from(modifiers[monthISO][dayISO])).to.not.contain(modifierToAdd);
+    wrapper.onGetPrevScrollableMonths();
     modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
-    expect(Array.from(modifiers[monthISO][todayISO])).to.contain(modifierToAdd);
+    expect(Array.from(modifiers[monthISO][dayISO])).to.contain(modifierToAdd);
   });
 
   describe('#addModifierToRange', () => {

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -1178,7 +1178,7 @@ describe('DayPickerSingleDateController', () => {
       expect(Array.from(modifiers[nextMonthISO][nextMonthDayISO])).to.contain(modifierToAdd);
     });
 
-    it('return value now has modifier arg for day after multiplying number of months', () => {
+    it('return value now has modifier arg for day after getting next scrollable months', () => {
       const modifierToAdd = 'foo';
       const numberOfMonths = 2;
       const nextMonth = today.clone().add(numberOfMonths, 'month');
@@ -1197,9 +1197,33 @@ describe('DayPickerSingleDateController', () => {
       )).instance();
       let modifiers = wrapper.addModifier(updatedDays, nextMonth, modifierToAdd);
       expect(Array.from(modifiers[nextMonthISO][nextMonthDayISO])).to.not.contain(modifierToAdd);
-      wrapper.onMultiplyScrollableMonths();
+      wrapper.onGetNextScrollableMonths();
       modifiers = wrapper.addModifier(updatedDays, nextMonth, modifierToAdd);
       expect(Array.from(modifiers[nextMonthISO][nextMonthDayISO])).to.contain(modifierToAdd);
+    });
+
+    it('return value now has modifier arg for day after getting previous scrollable months', () => {
+      const modifierToAdd = 'foo';
+      const numberOfMonths = 2;
+      const pastDateAfterMultiply = today.clone().subtract(numberOfMonths, 'months');
+      const monthISO = toISOMonthString(pastDateAfterMultiply);
+      const dayISO = toISODateString(pastDateAfterMultiply);
+      const updatedDays = {
+        [monthISO]: { [dayISO]: new Set(['bar', 'baz']) },
+      };
+      const wrapper = shallow((
+        <DayPickerSingleDateController
+          onDatesChange={sinon.stub()}
+          onFocusChange={sinon.stub()}
+          numberOfMonths={numberOfMonths}
+          orientation={VERTICAL_SCROLLABLE}
+        />
+      )).instance();
+      let modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
+      expect(Array.from(modifiers[monthISO][dayISO])).to.not.contain(modifierToAdd);
+      wrapper.onGetPrevScrollableMonths();
+      modifiers = wrapper.addModifier(updatedDays, pastDateAfterMultiply, modifierToAdd);
+      expect(Array.from(modifiers[monthISO][dayISO])).to.contain(modifierToAdd);
     });
   });
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -208,13 +208,30 @@ describe('DayPicker', () => {
   });
 
   describe('props.orientation === VERTICAL_SCROLLABLE', () => {
-    it('uses multiplyScrollableMonths instead of onNextMonthClick', () => {
+    it('renders two DayPickerNavigations', () => {
       const wrapper = shallow(
         <DayPicker orientation={VERTICAL_SCROLLABLE} />,
         { disableLifecycleMethods: false },
       ).dive();
-      const nav = wrapper.find(DayPickerNavigation);
-      expect(nav.prop('onNextMonthClick')).to.equal(wrapper.instance().multiplyScrollableMonths);
+      expect(wrapper.find(DayPickerNavigation)).to.have.length(2);
+    });
+
+    it('uses getNextScrollableMonths instead of onNextMonthClick', () => {
+      const wrapper = shallow(
+        <DayPicker orientation={VERTICAL_SCROLLABLE} />,
+        { disableLifecycleMethods: false },
+      ).dive();
+      const nav = wrapper.find(DayPickerNavigation)[1];
+      expect(nav.prop('onNextMonthClick')).to.equal(wrapper.instance().getNextScrollableMonths);
+    });
+
+    it('uses getPrevScrollableMonths instead of onNextMonthClick', () => {
+      const wrapper = shallow(
+        <DayPicker orientation={VERTICAL_SCROLLABLE} />,
+        { disableLifecycleMethods: false },
+      ).dive();
+      const nav = wrapper.find(DayPickerNavigation)[0];
+      expect(nav.prop('onPrevMonthClick')).to.equal(wrapper.instance().getPrevScrollableMonths);
     });
   });
 
@@ -795,17 +812,32 @@ describe('DayPicker', () => {
     });
   });
 
-  describe('#multiplyScrollableMonths', () => {
+  describe('#getNextScrollableMonths', () => {
     it('increments scrollableMonthMultiple', () => {
       const wrapper = shallow(<DayPicker />).dive();
-      wrapper.instance().multiplyScrollableMonths(event);
+      wrapper.instance().getNextScrollableMonths(event);
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
     });
 
     it('increments scrollableMonthMultiple without an event', () => {
       const wrapper = shallow(<DayPicker />).dive();
-      wrapper.instance().multiplyScrollableMonths();
+      wrapper.instance().getNextScrollableMonths();
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
+    });
+  });
+
+  describe('#getPrevScrollableMonths', () => {
+    it('increments scrollableMonthMultiple', () => {
+      const wrapper = shallow(<DayPicker />).dive();
+      wrapper.instance().getPrevScrollableMonths(event);
+      expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
+    });
+
+    it('increments scrollableMonthMultiple without an event', () => {
+      const wrapper = shallow(<DayPicker />).dive();
+      wrapper.instance().getPrevScrollableMonths();
+      expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
+      expect(wrapper.state().currentMonth).to.equal(moment().subtract(1, 'month'));
     });
   });
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -224,7 +224,6 @@ describe('DayPicker', () => {
       ).dive();
       expect(wrapper.find(DayPickerNavigation)).to.have.length(2);
       const nav = wrapper.find(DayPickerNavigation).get(1);
-      console.log(nav);
       expect(nav.props.onNextMonthClick).to.equal(wrapper.instance().getNextScrollableMonths);
     });
 
@@ -235,7 +234,6 @@ describe('DayPicker', () => {
       ).dive();
       expect(wrapper.find(DayPickerNavigation)).to.have.length(2);
       const nav = wrapper.find(DayPickerNavigation).get(0);
-      console.log(nav);
       expect(nav.props.onPrevMonthClick).to.equal(wrapper.instance().getPrevScrollableMonths);
     });
   });

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -5,6 +5,7 @@ import sinon from 'sinon-sandbox';
 import { mount, shallow } from 'enzyme';
 
 import * as isDayVisible from '../../src/utils/isDayVisible';
+import isSameMonth from '../../src/utils/isSameMonth';
 
 import DayPicker, { PureDayPicker } from '../../src/components/DayPicker';
 import CalendarMonthGrid from '../../src/components/CalendarMonthGrid';
@@ -221,8 +222,10 @@ describe('DayPicker', () => {
         <DayPicker orientation={VERTICAL_SCROLLABLE} />,
         { disableLifecycleMethods: false },
       ).dive();
-      const nav = wrapper.find(DayPickerNavigation)[1];
-      expect(nav.prop('onNextMonthClick')).to.equal(wrapper.instance().getNextScrollableMonths);
+      expect(wrapper.find(DayPickerNavigation)).to.have.length(2);
+      const nav = wrapper.find(DayPickerNavigation).get(1);
+      console.log(nav);
+      expect(nav.props.onNextMonthClick).to.equal(wrapper.instance().getNextScrollableMonths);
     });
 
     it('uses getPrevScrollableMonths instead of onNextMonthClick', () => {
@@ -230,8 +233,10 @@ describe('DayPicker', () => {
         <DayPicker orientation={VERTICAL_SCROLLABLE} />,
         { disableLifecycleMethods: false },
       ).dive();
-      const nav = wrapper.find(DayPickerNavigation)[0];
-      expect(nav.prop('onPrevMonthClick')).to.equal(wrapper.instance().getPrevScrollableMonths);
+      expect(wrapper.find(DayPickerNavigation)).to.have.length(2);
+      const nav = wrapper.find(DayPickerNavigation).get(0);
+      console.log(nav);
+      expect(nav.props.onPrevMonthClick).to.equal(wrapper.instance().getPrevScrollableMonths);
     });
   });
 
@@ -818,26 +823,14 @@ describe('DayPicker', () => {
       wrapper.instance().getNextScrollableMonths(event);
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
     });
-
-    it('increments scrollableMonthMultiple without an event', () => {
-      const wrapper = shallow(<DayPicker />).dive();
-      wrapper.instance().getNextScrollableMonths();
-      expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
-    });
   });
 
   describe('#getPrevScrollableMonths', () => {
-    it('increments scrollableMonthMultiple', () => {
-      const wrapper = shallow(<DayPicker />).dive();
-      wrapper.instance().getPrevScrollableMonths(event);
-      expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
-    });
-
-    it('increments scrollableMonthMultiple without an event', () => {
+    it('increments scrollableMonthMultiple and updates currentMonth', () => {
       const wrapper = shallow(<DayPicker />).dive();
       wrapper.instance().getPrevScrollableMonths();
       expect(wrapper.state().scrollableMonthMultiple).to.equal(2);
-      expect(wrapper.state().currentMonth).to.equal(moment().subtract(1, 'month'));
+      expect(isSameMonth(wrapper.state().currentMonth, moment().subtract(2, 'month'))).to.equal(true);
     });
   });
 


### PR DESCRIPTION
This PR adds the ability to view months before the current month when the calendar is vertically scrollable. There's a small issue where when you click to view more dates above the calendar shifts down and you see the farthest date in the past rather than staying on the month you were just viewing. I will try to fix this in a followup PR.

#### Before
![react-dates-scroll-before](https://user-images.githubusercontent.com/14023505/72180824-d7672f80-339c-11ea-8604-eed4b1648aeb.gif)

#### After
![react-dates-scroll-after](https://user-images.githubusercontent.com/14023505/72180832-dafab680-339c-11ea-8111-7057f19128ef.gif)
