### PR TITLE
feature(DayPickerSingleDateController) Add support for noNavButtons (match DayPickerRangeController support)

### DIFF
--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -70,6 +70,7 @@ const propTypes = forbidExtraProps({
   navNext: PropTypes.node,
   renderNavPrevButton: PropTypes.func,
   renderNavNextButton: PropTypes.func,
+  noNavButtons: PropTypes.bool,
 
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
@@ -131,6 +132,7 @@ const defaultProps = {
   navNext: null,
   renderNavPrevButton: null,
   renderNavNextButton: null,
+  noNavButtons: false,
 
   onPrevMonthClick() {},
   onNextMonthClick() {},
@@ -589,6 +591,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       navNext,
       renderNavPrevButton,
       renderNavNextButton,
+      noNavButtons,
       onOutsideClick,
       onShiftTab,
       onTab,
@@ -646,6 +649,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         navNext={navNext}
         renderNavPrevButton={renderNavPrevButton}
         renderNavNextButton={renderNavNextButton}
+        noNavButtons={noNavButtons}
         renderMonthText={renderMonthText}
         renderWeekHeaderElement={renderWeekHeaderElement}
         renderCalendarDay={renderCalendarDay}

--- a/stories/DayPickerSingleDateController.js
+++ b/stories/DayPickerSingleDateController.js
@@ -363,4 +363,10 @@ storiesOf('DayPickerSingleDateController', module)
       onNextMonthClick={action('DayPickerSingleDateController::onNextMonthClick')}
       verticalBorderSpacing={16}
     />
+  )))
+  .add('with no nav buttons', withInfo()(() => (
+    <DayPickerSingleDateControllerWrapper
+      onOutsideClick={action('DayPickerSingleDateController::onOutsideClick')}
+      noNavButtons
+    />
   )));

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import DayPicker from '../../src/components/DayPicker';
 import DayPickerSingleDateController from '../../src/components/DayPickerSingleDateController';
+import DayPickerNavigation from '../../src/components/DayPickerNavigation';
 
 import toISODateString from '../../src/utils/toISODateString';
 import toISOMonthString from '../../src/utils/toISOMonthString';
@@ -1538,6 +1539,18 @@ describe('DayPickerSingleDateController', () => {
         ));
         const dayPicker = wrapper.find(DayPicker);
         expect(dayPicker.props().initialVisibleMonth().isSame(today, 'day')).to.equal(true);
+      });
+    });
+
+    describe('noNavButtons prop', () => {
+      it('renders navigation button', () => {
+        const wrapper = shallow(<DayPickerSingleDateController />).dive().dive();
+        expect(wrapper.find(DayPickerNavigation)).to.have.lengthOf(1);
+      });
+
+      it('does not render navigation button when noNavButtons prop applied', () => {
+        const wrapper = shallow(<DayPickerSingleDateController noNavButtons />).dive().dive();
+        expect(wrapper.find(DayPickerNavigation)).to.have.lengthOf(0);
       });
     });
   });


### PR DESCRIPTION
`<DayPicker />` supports a property `noNavButtons`. Both DayPickerRangeController and DayPickerSingleDateController use this component, but currently only DayPickerRangeController supports passing the prop down.

This PR simply adds support for this prop to DayPickerSingleDateController to provide consistent behavior.