### PR TITLE
[Fix] use the injected `css` prop instead of the imported one

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -105,6 +105,7 @@ class CalendarDay extends React.PureComponent {
       modifiers,
       renderDayContents,
       tabIndex,
+      css,
       styles,
       phrases,
     } = this.props;

--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 
 import { CalendarDayPhrases } from '../defaultPhrases';
@@ -183,6 +183,7 @@ class CalendarMonth extends React.PureComponent {
       renderDayContents,
       renderMonthElement,
       renderMonthText,
+      css,
       styles,
       verticalBorderSpacing,
     } = this.props;

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import { addEventListener } from 'consolidated-events';
 
@@ -260,6 +260,7 @@ class CalendarMonthGrid extends React.PureComponent {
       focusedDate,
       isFocused,
       isRTL,
+      css,
       styles,
       phrases,
       dayAriaLabelFormat,

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import momentPropTypes from 'react-moment-proptypes';
 import { forbidExtraProps, nonNegativeInteger, or } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import moment from 'moment';
 import raf from 'raf';
 
@@ -279,6 +279,7 @@ class CustomizableCalendarDay extends React.PureComponent {
       modifiers,
       tabIndex,
       renderDayContents,
+      css,
       styles,
       phrases,
 

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import throttle from 'lodash/throttle';
 import isTouchDevice from 'is-touch-device';
 
@@ -194,6 +194,7 @@ class DateInput extends React.PureComponent {
       small,
       regular,
       block,
+      css,
       styles,
       theme: { reactDates },
     } = this.props;

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -450,6 +450,7 @@ class DateRangePicker extends React.PureComponent {
       dayAriaLabelFormat,
       isRTL,
       weekDayFormat,
+      css,
       styles,
       verticalHeight,
       noBorder,
@@ -616,6 +617,7 @@ class DateRangePicker extends React.PureComponent {
       verticalSpacing,
       small,
       regular,
+      css,
       styles,
     } = this.props;
 

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DateRangePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -180,6 +180,7 @@ function DateRangePickerInput({
   verticalSpacing,
   small,
   regular,
+  css,
   styles,
 }) {
   const calendarIcon = customInputIcon || (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, mutuallyExclusiveProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import moment from 'moment';
 import throttle from 'lodash/throttle';
@@ -983,6 +983,7 @@ class DayPicker extends React.PureComponent {
       horizontalMonthPadding,
       orientation,
       renderWeekHeaderElement,
+      css,
       styles,
     } = this.props;
 
@@ -1068,6 +1069,7 @@ class DayPicker extends React.PureComponent {
       daySize,
       isFocused,
       isRTL,
+      css,
       styles,
       theme,
       phrases,

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerKeyboardShortcutsPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -166,6 +166,7 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
       buttonLocation,
       showKeyboardShortcutsPanel,
       closeKeyboardShortcutsPanel,
+      css,
       styles,
       phrases,
       renderKeyboardShortcutsButton,

--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { DayPickerNavigationPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -84,6 +84,7 @@ class DayPickerNavigation extends React.PureComponent {
       renderNavNextButton,
       showNavPrevButton,
       showNavNextButton,
+      css,
       styles,
     } = this.props;
 

--- a/src/components/KeyboardShortcutRow.jsx
+++ b/src/components/KeyboardShortcutRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
@@ -20,6 +20,7 @@ function KeyboardShortcutRow({
   label,
   action,
   block,
+  css,
   styles,
 }) {
   return (

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 import { Portal } from 'react-portal';
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
@@ -437,6 +437,7 @@ class SingleDatePicker extends React.PureComponent {
       isDayBlocked,
       isDayHighlighted,
       weekDayFormat,
+      css,
       styles,
       verticalHeight,
       transitionDuration,
@@ -578,6 +579,7 @@ class SingleDatePicker extends React.PureComponent {
       verticalSpacing,
       reopenPickerOnClearDate,
       keepOpenOnDateSelect,
+      css,
       styles,
       isOutsideRange,
       isDayBlocked,

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { forbidExtraProps, nonNegativeInteger } from 'airbnb-prop-types';
-import { css, withStyles, withStylesPropTypes } from 'react-with-styles';
+import { withStyles, withStylesPropTypes } from 'react-with-styles';
 
 import { SingleDatePickerInputPhrases } from '../defaultPhrases';
 import getPhrasePropTypes from '../utils/getPhrasePropTypes';
@@ -131,6 +131,7 @@ function SingleDatePickerInput({
   small,
   regular,
   verticalSpacing,
+  css,
   styles,
 }) {
   const calendarIcon = customInputIcon || (

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -1090,6 +1090,7 @@ describe('DayPicker', () => {
           initialVisibleMonth() { return today; },
           theme: { reactDates: { spacing: {} } },
           styles: {},
+          css() {},
         };
 
         describe('date is not visible', () => {


### PR DESCRIPTION
import `css`  directly from `react-withstyles` is [deprecated](https://github.com/airbnb/react-with-styles/blob/68100eecd92ab5bbe3dff25cc454cbe137ef4f05/src/withStyles.jsx#L275).

If themes is [registered using React Context API](https://github.com/airbnb/react-with-styles#option-1-using-react-context-recommended), calling `css` function will crash (because theme is undefined).