### PR TITLE
1641: Adding ability to set the month padding attribute on datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ reopenPickerOnClearDates: PropTypes.bool,
 renderCalendarInfo: PropTypes.func,
 renderMonthElement: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'), PropTypes.func, // ({ month, onMonthSelect, onYearSelect, isVisible }) => PropTypes.node,
 hideKeyboardShortcutsPanel: PropTypes.bool,
+horizontalMonthPadding: PropTypes.number,
+monthPadding: PropTypes.number,
 
 // navigation related props
 navPrev: PropTypes.node,
@@ -260,6 +262,8 @@ renderMonthElement: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'r
 hideKeyboardShortcutsPanel: PropTypes.bool,
 daySize: nonNegativeInteger,
 isRTL: PropTypes.bool,
+horizontalMonthPadding: PropTypes.number,
+monthPadding: PropTypes.number,
 
 // navigation related props
 navPrev: PropTypes.node,

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -97,6 +97,7 @@ const defaultProps = {
   transitionDuration: undefined,
   verticalSpacing: DEFAULT_VERTICAL_SPACING,
   horizontalMonthPadding: undefined,
+  monthPadding: undefined,
 
   // navigation related props
   dayPickerNavigationInlineStyles: null,
@@ -451,6 +452,7 @@ class DateRangePicker extends React.PureComponent {
       transitionDuration,
       verticalSpacing,
       horizontalMonthPadding,
+      monthPadding,
       small,
       disabled,
       theme: { reactDates },
@@ -548,6 +550,7 @@ class DateRangePicker extends React.PureComponent {
           transitionDuration={transitionDuration}
           disabled={disabled}
           horizontalMonthPadding={horizontalMonthPadding}
+          monthPadding={monthPadding}
         />
 
         {withFullScreenPortal && (

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -47,7 +47,6 @@ import {
   NAV_POSITION_BOTTOM,
 } from '../constants';
 
-const MONTH_PADDING = 23;
 const PREV_TRANSITION = 'prev';
 const NEXT_TRANSITION = 'next';
 const MONTH_SELECTION_TRANSITION = 'month_selection';
@@ -77,6 +76,7 @@ const propTypes = forbidExtraProps({
   transitionDuration: nonNegativeInteger,
   verticalBorderSpacing: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
+  monthPadding: nonNegativeInteger,
   renderKeyboardShortcutsButton: PropTypes.func,
   renderKeyboardShortcutsPanel: PropTypes.func,
 
@@ -147,6 +147,7 @@ export const defaultProps = {
   transitionDuration: undefined,
   verticalBorderSpacing: undefined,
   horizontalMonthPadding: 13,
+  monthPadding: 23,
   renderKeyboardShortcutsButton: undefined,
   renderKeyboardShortcutsPanel: undefined,
 
@@ -381,7 +382,7 @@ class DayPicker extends React.PureComponent {
 
   componentDidUpdate(prevProps, prevState) {
     const {
-      orientation, daySize, isFocused, numberOfMonths,
+      orientation, daySize, isFocused, numberOfMonths, monthPadding,
     } = this.props;
     const {
       currentMonth,
@@ -397,7 +398,7 @@ class DayPicker extends React.PureComponent {
       const visibleCalendarWeeks = this.calendarMonthWeeks.slice(1, numberOfMonths + 1);
       const calendarMonthWeeksHeight = Math.max(0, ...visibleCalendarWeeks) * (daySize - 1);
       const newMonthHeight = monthTitleHeight + calendarMonthWeeksHeight + 1;
-      this.adjustDayPickerHeight(newMonthHeight);
+      this.adjustDayPickerHeight(newMonthHeight + monthPadding);
     }
 
     if (!prevProps.isFocused && isFocused && !focusedDate) {
@@ -544,7 +545,9 @@ class DayPicker extends React.PureComponent {
   }
 
   onPrevMonthTransition(nextFocusedDate) {
-    const { daySize, isRTL, numberOfMonths } = this.props;
+    const {
+      daySize, isRTL, numberOfMonths, monthPadding,
+    } = this.props;
     const { calendarMonthWidth, monthTitleHeight } = this.state;
 
     let translationValue;
@@ -560,7 +563,7 @@ class DayPicker extends React.PureComponent {
       const visibleCalendarWeeks = this.calendarMonthWeeks.slice(0, numberOfMonths);
       const calendarMonthWeeksHeight = Math.max(0, ...visibleCalendarWeeks) * (daySize - 1);
       const newMonthHeight = monthTitleHeight + calendarMonthWeeksHeight + 1;
-      this.adjustDayPickerHeight(newMonthHeight);
+      this.adjustDayPickerHeight(newMonthHeight + monthPadding);
     }
 
     this.setState({
@@ -607,7 +610,9 @@ class DayPicker extends React.PureComponent {
   }
 
   onNextMonthTransition(nextFocusedDate) {
-    const { isRTL, numberOfMonths, daySize } = this.props;
+    const {
+      isRTL, numberOfMonths, daySize, monthPadding,
+    } = this.props;
     const { calendarMonthWidth, monthTitleHeight } = this.state;
 
     let translationValue;
@@ -627,7 +632,7 @@ class DayPicker extends React.PureComponent {
       const visibleCalendarWeeks = this.calendarMonthWeeks.slice(2, numberOfMonths + 2);
       const calendarMonthWeeksHeight = Math.max(0, ...visibleCalendarWeeks) * (daySize - 1);
       const newMonthHeight = monthTitleHeight + calendarMonthWeeksHeight + 1;
-      this.adjustDayPickerHeight(newMonthHeight);
+      this.adjustDayPickerHeight(newMonthHeight + monthPadding);
     }
 
     this.setState({
@@ -858,8 +863,7 @@ class DayPicker extends React.PureComponent {
     });
   }
 
-  adjustDayPickerHeight(newMonthHeight) {
-    const monthHeight = newMonthHeight + MONTH_PADDING;
+  adjustDayPickerHeight(monthHeight) {
     if (monthHeight !== this.calendarMonthGridHeight) {
       this.transitionContainer.style.height = `${monthHeight}px`;
       if (!this.calendarMonthGridHeight) {
@@ -872,7 +876,7 @@ class DayPicker extends React.PureComponent {
   }
 
   calculateAndSetDayPickerHeight() {
-    const { daySize, numberOfMonths } = this.props;
+    const { daySize, numberOfMonths, monthPadding } = this.props;
     const { monthTitleHeight } = this.state;
 
     const visibleCalendarWeeks = this.calendarMonthWeeks.slice(1, numberOfMonths + 1);
@@ -880,7 +884,7 @@ class DayPicker extends React.PureComponent {
     const newMonthHeight = monthTitleHeight + calendarMonthWeeksHeight + 1;
 
     if (this.isHorizontal()) {
-      this.adjustDayPickerHeight(newMonthHeight);
+      this.adjustDayPickerHeight(newMonthHeight + monthPadding);
     }
   }
 

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -79,6 +79,7 @@ const propTypes = forbidExtraProps({
   noBorder: PropTypes.bool,
   verticalBorderSpacing: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
+  monthPadding: nonNegativeInteger,
 
   dayPickerNavigationInlineStyles: PropTypes.object,
   navPosition: NavPositionShape,
@@ -178,6 +179,7 @@ const defaultProps = {
   transitionDuration: undefined,
   verticalBorderSpacing: undefined,
   horizontalMonthPadding: 13,
+  monthPadding: 23,
 
   // accessibility
   onBlur() {},
@@ -1317,6 +1319,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       transitionDuration,
       verticalBorderSpacing,
       horizontalMonthPadding,
+      monthPadding,
     } = this.props;
 
     const {
@@ -1385,6 +1388,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         noBorder={noBorder}
         transitionDuration={transitionDuration}
         horizontalMonthPadding={horizontalMonthPadding}
+        monthPadding={monthPadding}
       />
     );
   }

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -63,6 +63,7 @@ const propTypes = forbidExtraProps({
   verticalBorderSpacing: nonNegativeInteger,
   transitionDuration: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
+  monthPadding: nonNegativeInteger,
 
   dayPickerNavigationInlineStyles: PropTypes.object,
   navPosition: NavPositionShape,
@@ -127,6 +128,7 @@ const defaultProps = {
   verticalBorderSpacing: undefined,
   transitionDuration: undefined,
   horizontalMonthPadding: 13,
+  monthPadding: 23,
 
   dayPickerNavigationInlineStyles: null,
   navPosition: NAV_POSITION_TOP,
@@ -643,6 +645,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       transitionDuration,
       verticalBorderSpacing,
       horizontalMonthPadding,
+      monthPadding,
     } = this.props;
 
     const { currentMonth, visibleDays } = this.state;
@@ -701,6 +704,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         transitionDuration={transitionDuration}
         verticalBorderSpacing={verticalBorderSpacing}
         horizontalMonthPadding={horizontalMonthPadding}
+        monthPadding={monthPadding}
       />
     );
   }

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -88,6 +88,7 @@ const defaultProps = {
   verticalHeight: null,
   transitionDuration: undefined,
   horizontalMonthPadding: 13,
+  monthPadding: 23,
 
   // navigation related props
   dayPickerNavigationInlineStyles: null,
@@ -435,6 +436,7 @@ class SingleDatePicker extends React.PureComponent {
       transitionDuration,
       verticalSpacing,
       horizontalMonthPadding,
+      monthPadding,
       small,
       theme: { reactDates },
     } = this.props;
@@ -517,6 +519,7 @@ class SingleDatePicker extends React.PureComponent {
           verticalHeight={verticalHeight}
           transitionDuration={transitionDuration}
           horizontalMonthPadding={horizontalMonthPadding}
+          monthPadding={monthPadding}
         />
 
         {withFullScreenPortal && (

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -77,6 +77,7 @@ export default {
   transitionDuration: nonNegativeInteger,
   verticalSpacing: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
+  monthPadding: nonNegativeInteger,
 
   // navigation related props
   dayPickerNavigationInlineStyles: PropTypes.object,

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -66,6 +66,7 @@ export default {
   verticalHeight: nonNegativeInteger,
   transitionDuration: nonNegativeInteger,
   horizontalMonthPadding: nonNegativeInteger,
+  monthPadding: nonNegativeInteger,
 
   // navigation related props
   dayPickerNavigationInlineStyles: PropTypes.object,


### PR DESCRIPTION
This PR was created to solve #1641

This enables react-dates users to modify the bottom padding of calendar popup - this is an unmodifiable constant now.