### PR TITLE
Fixing render conditional in DayPickerKeyboardShortcuts

### DIFF
--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -189,7 +189,7 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
             onClick: this.onShowKeyboardShortcutsButtonClick,
             ariaLabel: toggleButtonText,
           })}
-        {renderKeyboardShortcutsButton || (
+        {!renderKeyboardShortcutsButton && (
           <button
             ref={this.setShowKeyboardShortcutsButtonRef}
             {...css(


### PR DESCRIPTION
Fixing conditional so we don't render the function definition.