### PR TITLE
Add option to allow days violating min nights to be clicked

### DIFF
--- a/examples/DayPickerRangeControllerWrapper.jsx
+++ b/examples/DayPickerRangeControllerWrapper.jsx
@@ -29,6 +29,7 @@ const propTypes = forbidExtraProps({
   isOutsideRange: PropTypes.func,
   isDayBlocked: PropTypes.func,
   isDayHighlighted: PropTypes.func,
+  daysViolatingMinNightsCanBeClicked: PropTypes.bool,
 
   // DayPicker props
   enableOutsideDays: PropTypes.bool,
@@ -79,6 +80,7 @@ const defaultProps = {
   isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
   enableOutsideDays: false,
+  daysViolatingMinNightsCanBeClicked: false,
 
   // calendar presentation and interaction related props
   orientation: HORIZONTAL_ORIENTATION,
@@ -112,6 +114,7 @@ class DayPickerRangeControllerWrapper extends React.Component {
     super(props);
 
     this.state = {
+      errorMessage: null,
       focusedInput: props.autoFocusEndDate ? END_DATE : START_DATE,
       startDate: props.initialStartDate,
       endDate: props.initialEndDate,
@@ -122,7 +125,19 @@ class DayPickerRangeControllerWrapper extends React.Component {
   }
 
   onDatesChange({ startDate, endDate }) {
-    this.setState({ startDate, endDate });
+    const { daysViolatingMinNightsCanBeClicked, minimumNights } = this.props;
+    let doesNotMeetMinNights = false;
+    if (daysViolatingMinNightsCanBeClicked && startDate && endDate) {
+      const dayDiff = endDate.diff(startDate.clone().startOf('day').hour(12), 'days');
+      doesNotMeetMinNights = dayDiff < minimumNights && dayDiff >= 0;
+    }
+    this.setState({
+      startDate,
+      endDate: doesNotMeetMinNights ? null : endDate,
+      errorMessage: doesNotMeetMinNights
+        ? 'That day does not meet the minimum nights requirement'
+        : null,
+    });
   }
 
   onFocusChange(focusedInput) {
@@ -133,8 +148,13 @@ class DayPickerRangeControllerWrapper extends React.Component {
   }
 
   render() {
-    const { showInputs } = this.props;
-    const { focusedInput, startDate, endDate } = this.state;
+    const { renderCalendarInfo: renderCalendarInfoProp, showInputs } = this.props;
+    const {
+      errorMessage,
+      focusedInput,
+      startDate,
+      endDate,
+    } = this.state;
 
     const props = omit(this.props, [
       'autoFocus',
@@ -146,6 +166,7 @@ class DayPickerRangeControllerWrapper extends React.Component {
 
     const startDateString = startDate && startDate.format('YYYY-MM-DD');
     const endDateString = endDate && endDate.format('YYYY-MM-DD');
+    const renderCalendarInfo = errorMessage ? () => <div>{errorMessage}</div> : renderCalendarInfoProp;
 
     return (
       <div style={{ height: '100%' }}>
@@ -163,6 +184,7 @@ class DayPickerRangeControllerWrapper extends React.Component {
           focusedInput={focusedInput}
           startDate={startDate}
           endDate={endDate}
+          renderCalendarInfo={renderCalendarInfo}
         />
       </div>
     );

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -64,6 +64,7 @@ const propTypes = forbidExtraProps({
   isDayBlocked: PropTypes.func,
   isDayHighlighted: PropTypes.func,
   getMinNightsForHoverDate: PropTypes.func,
+  daysViolatingMinNightsCanBeClicked: PropTypes.bool,
 
   // DayPicker props
   renderMonthText: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),
@@ -139,6 +140,7 @@ const defaultProps = {
   isDayBlocked() {},
   isDayHighlighted() {},
   getMinNightsForHoverDate() {},
+  daysViolatingMinNightsCanBeClicked: false,
 
   // DayPicker props
   renderMonthText: null,
@@ -593,10 +595,11 @@ export default class DayPickerRangeController extends React.PureComponent {
       startDateOffset,
       endDateOffset,
       disabled,
+      daysViolatingMinNightsCanBeClicked,
     } = this.props;
 
     if (e) e.preventDefault();
-    if (this.isBlocked(day)) return;
+    if (this.isBlocked(day, !daysViolatingMinNightsCanBeClicked)) return;
 
     let { startDate, endDate } = this.props;
 
@@ -649,6 +652,12 @@ export default class DayPickerRangeController extends React.PureComponent {
           onFocusChange(null);
           onClose({ startDate, endDate });
         }
+      } else if (
+        daysViolatingMinNightsCanBeClicked
+        && this.doesNotMeetMinimumNights(day)
+      ) {
+        endDate = day;
+        onDatesChange({ startDate, endDate });
       } else if (disabled !== START_DATE) {
         startDate = day;
         endDate = null;
@@ -1230,9 +1239,11 @@ export default class DayPickerRangeController extends React.PureComponent {
     return isSameDay(day, startDate);
   }
 
-  isBlocked(day) {
+  isBlocked(day, blockDaysViolatingMinNights = true) {
     const { isDayBlocked, isOutsideRange } = this.props;
-    return isDayBlocked(day) || isOutsideRange(day) || this.doesNotMeetMinimumNights(day);
+    return isDayBlocked(day)
+      || isOutsideRange(day)
+      || (blockDaysViolatingMinNights && this.doesNotMeetMinimumNights(day));
   }
 
   isToday(day) {

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -773,4 +773,15 @@ storiesOf('DayPickerRangeController', module)
       onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
       renderKeyboardShortcutsPanel={renderKeyboardShortcutsPanel}
     />
+  )))
+  .add('with minimum nights set and daysViolatingMinNightsCanBeClicked set to true', withInfo()(() => (
+    <DayPickerRangeControllerWrapper
+      daysViolatingMinNightsCanBeClicked
+      minimumNights={3}
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      initialStartDate={moment().add(3, 'days')}
+      autoFocusEndDate
+    />
   )));

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1911,6 +1911,24 @@ describe('DayPickerRangeController', () => {
       });
     });
 
+    describe('daysViolatingMinNightsCanBeClicked is true', () => {
+      it('props.onDatesChange is called and props.onFocusChange is not called when the day does not meet min nights', () => {
+        const onFocusChangeStub = sinon.stub();
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow(<DayPickerRangeController
+          daysViolatingMinNightsCanBeClicked
+          focusedInput={END_DATE}
+          minimumNights={3}
+          onFocusChange={onFocusChangeStub}
+          onDatesChange={onDatesChangeStub}
+          startDate={today}
+        />);
+        wrapper.instance().onDayClick(today.clone().add(1, 'days'));
+        expect(onFocusChangeStub.callCount).to.equal(0);
+        expect(onDatesChangeStub.callCount).to.equal(1);
+      });
+    });
+
     describe('props.focusedInput === START_DATE', () => {
       describe('props.onFocusChange', () => {
         it('is called once', () => {
@@ -4870,6 +4888,18 @@ describe('DayPickerRangeController', () => {
           isOutsideRange={isOutsideRangeStub}
         />);
         expect(wrapper.instance().isBlocked(today)).to.equal(false);
+      });
+
+      it('returns false if arg does not meet minimum nights but blockDaysViolatingMinNights is false', () => {
+        isDayBlockedStub.returns(false);
+        isOutsideRangeStub.returns(false);
+        doesNotMeetMinimumNightsStub.returns(true);
+
+        const wrapper = shallow(<DayPickerRangeController
+          isDayBlocked={isDayBlockedStub}
+          isOutsideRange={isOutsideRangeStub}
+        />);
+        expect(wrapper.instance().isBlocked(today, false)).to.equal(false);
       });
     });
 


### PR DESCRIPTION
This PR adds a prop that allows days violating min nights to be selected as the end date. I would like to show an error message when a day blocked by min nights is pressed, but since currently `onDayClick` returns immediately if the day violates the min nights requirement, I don't have a way of knowing that the day has been clicked. This new logic makes it so that all the same modifiers are applied to days violating min nights, but in the `onDayClick` function it doesn't immediately return and it calls `onDatesChange`.
![cal-min-nights-clicking](https://user-images.githubusercontent.com/14023505/73316311-6373b680-41e7-11ea-9015-3df8cbee9a74.gif)

