### PR TITLE
Prevent vertical scrollable prev nav button from overlapping weekday headers

### DIFF
--- a/src/components/DayPickerNavigation.jsx
+++ b/src/components/DayPickerNavigation.jsx
@@ -154,6 +154,7 @@ class DayPickerNavigation extends React.PureComponent {
           ...(isVerticalScrollable ? [
             styles.DayPickerNavigation__verticalScrollable,
             isDefaultNav && styles.DayPickerNavigation__verticalScrollableDefault,
+            showNavPrevButton && styles.DayPickerNavigation__verticalScrollable_prevNav,
           ] : []),
           ...(isBottomNavPosition ? [
             styles.DayPickerNavigation__bottom,
@@ -303,6 +304,9 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
 
   DayPickerNavigation__vertical: {},
   DayPickerNavigation__verticalScrollable: {},
+  DayPickerNavigation__verticalScrollable_prevNav: {
+    zIndex: zIndex + 1, // zIndex + 2 causes the button to show on top of the day of week headers
+  },
 
   DayPickerNavigation__verticalDefault: {
     position: 'absolute',


### PR DESCRIPTION
As title
#### Before
![scroll-bug](https://user-images.githubusercontent.com/14023505/73317122-dbdb7700-41e9-11ea-8a95-f4f555423cbf.gif)

#### After
![scroll-fix](https://user-images.githubusercontent.com/14023505/73317133-e269ee80-41e9-11ea-834a-b7bc75dbe71f.gif)
