### PR TITLE
fix(Daypicker): add blur handler to capture all blur events

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -240,6 +240,7 @@ class DayPicker extends React.PureComponent {
     this.setCalendarMonthGridHeightTimeout = null;
 
     this.onKeyDown = this.onKeyDown.bind(this);
+    this.onBlur = this.onBlur.bind(this);
     this.throttledKeyDown = throttle(this.onFinalKeyDown, 200, { trailing: false });
     this.onPrevMonthClick = this.onPrevMonthClick.bind(this);
     this.onPrevMonthTransition = this.onPrevMonthTransition.bind(this);
@@ -428,6 +429,12 @@ class DayPicker extends React.PureComponent {
     if (!MODIFIER_KEY_NAMES.has(e.key)) {
       this.throttledKeyDown(e);
     }
+  }
+
+  onBlur(e) {
+    const { onBlur } = this.props;
+
+    onBlur(e);
   }
 
   onFinalKeyDown(e) {
@@ -1179,6 +1186,7 @@ class DayPicker extends React.PureComponent {
               role="application"
               aria-roledescription={phrases.roleDescription}
               aria-label={phrases.calendarLabel}
+              onBlur={this.onBlur}
             >
               {!verticalScrollable && navPosition === NAV_POSITION_TOP && this.renderNavigation()}
 

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -31,6 +31,14 @@ describe('DayPicker', () => {
     sinon.restore();
   });
 
+  it('should pass onBlur to <DayPicker />', () => {
+    const onBlurStub = sinon.stub();
+    const wrapper = shallow(<DayPicker onBlur={onBlurStub} />);
+    expect(wrapper.prop('onBlur')).to.equal(onBlurStub);
+    wrapper.prop('onBlur')();
+    expect(onBlurStub.callCount).to.equal(1);
+  });
+
   describe('#render', () => {
     describe('renderWeekHeader', () => {
       it('there are 7 elements on each .DayPicker__week-header class', () => {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #1571 
- [x] bug
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Ordinarily, the focus and blur events in the DOM dot not bubble. React will bubble these events through its event model. So we can listen for blur events at the root of a component and react to these events fired on its child nodes.