### PR TITLE
Issue 1937 | Pass invalid date string to date change handlers

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -24,6 +24,7 @@ const propTypes = {
   stateDateWrapper: PropTypes.func,
   initialStartDate: momentPropTypes.momentObj,
   initialEndDate: momentPropTypes.momentObj,
+  onInvalidInput: PropTypes.func,
 
   ...omit(DateRangePickerShape, [
     'startDate',
@@ -40,6 +41,7 @@ const defaultProps = {
   autoFocusEndDate: false,
   initialStartDate: null,
   initialEndDate: null,
+  onInvalidInput: () => null,
 
   // input related props
   startDateId: START_DATE,
@@ -85,7 +87,7 @@ const defaultProps = {
   minimumNights: 1,
   enableOutsideDays: false,
   isDayBlocked: () => false,
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isOutsideRange: (day) => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => false,
 
   // internationalization
@@ -93,7 +95,7 @@ const defaultProps = {
   monthFormat: 'MMMM YYYY',
   phrases: DateRangePickerPhrases,
 
-  stateDateWrapper: date => date,
+  stateDateWrapper: (date) => date,
 };
 
 class DateRangePickerWrapper extends React.Component {
@@ -117,12 +119,15 @@ class DateRangePickerWrapper extends React.Component {
     this.onFocusChange = this.onFocusChange.bind(this);
   }
 
-  onDatesChange({ startDate, endDate }) {
-    const { stateDateWrapper } = this.props;
+  onDatesChange({ startDate, endDate, invalidDateString }) {
+    const { onInvalidInput, stateDateWrapper } = this.props;
     this.setState({
       startDate: startDate && stateDateWrapper(startDate),
       endDate: endDate && stateDateWrapper(endDate),
     });
+    if (invalidDateString) {
+      onInvalidInput(invalidDateString);
+    }
   }
 
   onFocusChange(focusedInput) {
@@ -141,6 +146,7 @@ class DateRangePickerWrapper extends React.Component {
       'initialStartDate',
       'initialEndDate',
       'stateDateWrapper',
+      'onInvalidInput',
     ]);
 
     return (

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -15,6 +15,7 @@ const propTypes = {
   // example props for the demo
   autoFocus: PropTypes.bool,
   initialDate: momentPropTypes.momentObj,
+  onInvalidInput: PropTypes.func,
 
   ...omit(SingleDatePickerShape, [
     'date',
@@ -28,6 +29,7 @@ const defaultProps = {
   // example props for the demo
   autoFocus: false,
   initialDate: null,
+  onInvalidInput: () => null,
 
   // input related props
   id: 'date',
@@ -69,7 +71,7 @@ const defaultProps = {
   renderDayContents: null,
   enableOutsideDays: false,
   isDayBlocked: () => false,
-  isOutsideRange: day => !isInclusivelyAfterDay(day, moment()),
+  isOutsideRange: (day) => !isInclusivelyAfterDay(day, moment()),
   isDayHighlighted: () => {},
 
   // internationalization props
@@ -90,8 +92,12 @@ class SingleDatePickerWrapper extends React.Component {
     this.onFocusChange = this.onFocusChange.bind(this);
   }
 
-  onDateChange(date) {
+  onDateChange(date, invalidDateString) {
+    const { onInvalidInput } = this.props;
     this.setState({ date });
+    if (invalidDateString) {
+      onInvalidInput(invalidDateString);
+    }
   }
 
   onFocusChange({ focused }) {
@@ -106,6 +112,7 @@ class SingleDatePickerWrapper extends React.Component {
     const props = omit(this.props, [
       'autoFocus',
       'initialDate',
+      'onInvalidInput',
     ]);
 
     return (

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -187,6 +187,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
       onDatesChange({
         startDate,
         endDate: null,
+        invalidDateString: endDateString,
       });
     }
   }
@@ -238,6 +239,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
       onDatesChange({
         startDate: null,
         endDate,
+        invalidDateString: startDateString,
       });
     }
   }

--- a/src/components/SingleDatePickerInputController.jsx
+++ b/src/components/SingleDatePickerInputController.jsx
@@ -147,7 +147,7 @@ export default class SingleDatePickerInputController extends React.PureComponent
         onClose({ date: newDate });
       }
     } else {
-      onDateChange(null);
+      onDateChange(null, dateString);
     }
   }
 

--- a/stories/DateRangePicker_input.js
+++ b/stories/DateRangePicker_input.js
@@ -42,7 +42,9 @@ const TestCustomCloseIcon = () => (
       color: '#484848',
       padding: '3px',
     }}
-  >'X'</span>
+  >
+    'X'
+  </span>
 );
 
 storiesOf('DRP - Input Props', module)
@@ -64,7 +66,7 @@ storiesOf('DRP - Input Props', module)
       initialStartDate={moment().add(3, 'months')}
       initialEndDate={moment().add(3, 'months').add(10, 'days')}
       disabled="startDate"
-      isOutsideRange={day => !isInclusivelyAfterDay(day, moment().add(3, 'months'))}
+      isOutsideRange={(day) => !isInclusivelyAfterDay(day, moment().add(3, 'months'))}
     />
   )))
   .add('disabled end date', withInfo()(() => (
@@ -72,8 +74,8 @@ storiesOf('DRP - Input Props', module)
       initialStartDate={moment().add(3, 'months')}
       initialEndDate={moment().add(3, 'months').add(10, 'days')}
       disabled="endDate"
-      isOutsideRange={day => !isInclusivelyAfterDay(day, moment()) ||
-        !isInclusivelyBeforeDay(day, moment().add(3, 'months').add(10, 'days'))}
+      isOutsideRange={(day) => !isInclusivelyAfterDay(day, moment())
+        || !isInclusivelyBeforeDay(day, moment().add(3, 'months').add(10, 'days'))}
     />
   )))
   .add('readOnly', withInfo()(() => (
@@ -178,5 +180,12 @@ storiesOf('DRP - Input Props', module)
       initialEndDate={moment().add(10, 'days')}
       showClearDates
       regular
+    />
+  )))
+  .add('handle invalid input', withInfo()(() => (
+    <DateRangePickerWrapper
+      initialStartDate={moment().add(3, 'months')}
+      initialEndDate={moment().add(3, 'months').add(10, 'days')}
+      onInvalidInput={(input) => alert(`invalid date string: ${input}`)}
     />
   )));

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -106,4 +106,10 @@ storiesOf('SDP - Input Props', module)
       showClearDate
       regular
     />
+  )))
+  .add('handle invalid input', withInfo()(() => (
+    <SingleDatePickerWrapper
+      initialDate={moment().add(3, 'days')}
+      onInvalidInput={(input) => alert(`invalid date string: ${input}`)}
+    />
   )));

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -386,6 +386,16 @@ describe('DateRangePickerInputController', () => {
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.endDate).to.equal(null);
       });
+
+      it('calls props.onDatesChange with invalidDateString in arg object', () => {
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DateRangePickerInputController onDatesChange={onDatesChangeStub} />
+        ));
+        wrapper.instance().onEndDateChange(invalidDateString);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.invalidDateString).to.equal(invalidDateString);
+      });
     });
 
     describe('is outside range', () => {
@@ -737,6 +747,19 @@ describe('DateRangePickerInputController', () => {
         wrapper.instance().onStartDateChange(invalidDateString);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate).to.equal(null);
+      });
+
+      it('calls props.onDatesChange with invalidDateString in arg object', () => {
+        const onDatesChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <DateRangePickerInputController
+            onDatesChange={onDatesChangeStub}
+            startDate={today}
+          />
+        ));
+        wrapper.instance().onStartDateChange(invalidDateString);
+        const args = onDatesChangeStub.getCall(0).args[0];
+        expect(args.invalidDateString).to.equal(invalidDateString);
       });
 
       it('calls props.onDatesChange with endDate === props.endDate', () => {

--- a/test/components/SingleDatePickerInputController_spec.jsx
+++ b/test/components/SingleDatePickerInputController_spec.jsx
@@ -182,13 +182,22 @@ describe('SingleDatePickerInputController', () => {
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
-      it('calls props.onDateChange with null as arg', () => {
+      it('calls props.onDateChange with null as first arg', () => {
         const onDateChangeStub = sinon.stub();
         const wrapper = shallow((
           <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
         ));
         wrapper.instance().onChange(invalidDateString);
         expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
+      });
+
+      it('calls props.onDateChange with invalid string as second arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController id="date" onDateChange={onDateChangeStub} onFocusChange={() => {}} />
+        ));
+        wrapper.instance().onChange(invalidDateString);
+        expect(onDateChangeStub.getCall(0).args[1]).to.equal(invalidDateString);
       });
 
       it('does not call props.onFocusChange', () => {
@@ -219,7 +228,7 @@ describe('SingleDatePickerInputController', () => {
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
-      it('calls props.onDateChange with null as arg', () => {
+      it('calls props.onDateChange with null as first arg', () => {
         const onDateChangeStub = sinon.stub();
         const wrapper = shallow((
           <SingleDatePickerInputController
@@ -231,6 +240,20 @@ describe('SingleDatePickerInputController', () => {
         ));
         wrapper.instance().onChange(todayDateString);
         expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
+      });
+
+      it('calls props.onDateChange with date string as second arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+            isOutsideRange={isOutsideRangeStub}
+          />
+        ));
+        wrapper.instance().onChange(todayDateString);
+        expect(onDateChangeStub.getCall(0).args[1]).to.equal(todayDateString);
       });
 
       it('does not call props.onFocusChange', () => {
@@ -266,7 +289,7 @@ describe('SingleDatePickerInputController', () => {
         expect(onDateChangeStub.callCount).to.equal(1);
       });
 
-      it('calls props.onDateChange with null as arg', () => {
+      it('calls props.onDateChange with null as first arg', () => {
         const onDateChangeStub = sinon.stub();
         const wrapper = shallow((
           <SingleDatePickerInputController
@@ -278,6 +301,20 @@ describe('SingleDatePickerInputController', () => {
         ));
         wrapper.instance().onChange(todayDateString);
         expect(onDateChangeStub.getCall(0).args[0]).to.equal(null);
+      });
+
+      it('calls props.onDateChange with date string as second arg', () => {
+        const onDateChangeStub = sinon.stub();
+        const wrapper = shallow((
+          <SingleDatePickerInputController
+            id="date"
+            onDateChange={onDateChangeStub}
+            onFocusChange={() => {}}
+            isDayBlocked={isDayBlocked}
+          />
+        ));
+        wrapper.instance().onChange(todayDateString);
+        expect(onDateChangeStub.getCall(0).args[1]).to.equal(todayDateString);
       });
     });
   });


### PR DESCRIPTION
Add `invalidDateString` to args for date change handlers (`onDateChange` and `onDatesChange`) whenever the date string is invalid. Add `storybook` stories and unit tests to support changes.