### PR TITLE
Fix the focus going to the DayPicker instead of the Keyboard Shortcuts Panel...

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -322,21 +322,21 @@ class DayPicker extends React.PureComponent {
       if (isFocused) {
         const focusedDate = this.getFocusedDay(currentMonth);
 
-        let { onKeyboardShortcutsPanelClose } = this.state;
-        if (nextProps.showKeyboardShortcuts) {
-          // the ? shortcut came from the input and we should return input there once it is close
-          onKeyboardShortcutsPanelClose = onBlur;
-        }
-
         this.setState({
-          showKeyboardShortcuts,
-          onKeyboardShortcutsPanelClose,
           focusedDate,
           withMouseInteractions: false,
         });
       } else {
         this.setState({ focusedDate: null });
       }
+    }
+
+    if (showKeyboardShortcuts) {
+      // the ? shortcut came from the input and we should return input there once it is closed
+      this.setState({
+        showKeyboardShortcuts: true,
+        onKeyboardShortcutsPanelClose: onBlur,
+      });
     }
 
     if (renderMonthText !== prevRenderMonthText) {

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -361,7 +361,7 @@ class SingleDatePicker extends React.PureComponent {
   showKeyboardShortcutsPanel() {
     this.setState({
       isInputFocused: false,
-      isDayPickerFocused: true,
+      isDayPickerFocused: false,
       showKeyboardShortcuts: true,
     });
   }

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -36,6 +36,13 @@ storiesOf('SDP - Input Props', module)
       readOnly
     />
   )))
+  .add('readOnly with keepFocusOnInput', withInfo()(() => (
+    <SingleDatePickerWrapper
+      initialDate={moment().add(3, 'days')}
+      readOnly
+      keepFocusOnInput
+    />
+  )))
   .add('with clear dates button', withInfo()(() => (
     <SingleDatePickerWrapper
       initialDate={moment().add(3, 'days')}

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -31,6 +31,32 @@ describe('DayPicker', () => {
     sinon.restore();
   });
 
+  describe('#componentWillReceiveProps', () => {
+    describe('when nextProps.showKeyboardShortcuts is true', () => {
+      it('should set state.showKeyboardShortcuts to true', () => {
+        const wrapper = shallow(<DayPicker />).dive();
+        wrapper.setState({
+          showKeyboardShortcuts: false,
+        });
+        wrapper.instance().componentWillReceiveProps(
+          { showKeyboardShortcuts: true },
+          { currentMonth: moment() },
+        );
+        expect(wrapper.state().showKeyboardShortcuts).to.equal(true);
+      });
+
+      it('should set state.onKeyboardShortcutsPanelClose', () => {
+        const wrapper = shallow(<DayPicker />).dive();
+        const onBlur = sinon.spy();
+        wrapper.instance().componentWillReceiveProps(
+          { showKeyboardShortcuts: true, onBlur },
+          { currentMonth: moment() },
+        );
+        expect(wrapper.state().onKeyboardShortcutsPanelClose).to.equal(onBlur);
+      });
+    });
+  });
+
   describe('#render', () => {
     describe('renderWeekHeader', () => {
       it('there are 7 elements on each .DayPicker__week-header class', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -598,7 +598,7 @@ describe('SingleDatePicker', () => {
       expect(wrapper.state().isInputFocused).to.equal(false);
     });
 
-    it('sets state.isDayPickerFocused to true', () => {
+    it('sets state.isDayPickerFocused to false', () => {
       const wrapper = shallow((
         <SingleDatePicker
           onDateChange={sinon.stub()}
@@ -609,7 +609,7 @@ describe('SingleDatePicker', () => {
         isDayPickerFocused: false,
       });
       wrapper.instance().showKeyboardShortcutsPanel();
-      expect(wrapper.state().isDayPickerFocused).to.equal(true);
+      expect(wrapper.state().isDayPickerFocused).to.equal(false);
     });
 
     it('sets state.showKeyboardShortcuts to true', () => {


### PR DESCRIPTION
…when opened while focus is on the input.

Previously we were setting focus on the DayPicker and requiring that it have focus before we could show the Keyboard Shortcuts Panel so the CalendarDay would end up getting the focus instead of the close button inside the Keyboard Shortcuts Panel.  Now only the Panel should be getting the focus.

This should fix Issue #1949 