### PR TITLE
Fix focus after nav button press

### DIFF
--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -18,9 +18,7 @@ const propTypes = {
 
   ...omit(SingleDatePickerShape, [
     'date',
-    'onDateChange',
     'focused',
-    'onFocusChange',
   ]),
 };
 
@@ -28,6 +26,9 @@ const defaultProps = {
   // example props for the demo
   autoFocus: false,
   initialDate: null,
+
+  onDateChange: () => {},
+  onFocusChange: () => {},
 
   // input related props
   id: 'date',
@@ -91,11 +92,17 @@ class SingleDatePickerWrapper extends React.Component {
   }
 
   onDateChange(date) {
+    const { onDateChange } = this.props;
     this.setState({ date });
+
+    onDateChange(date);
   }
 
   onFocusChange({ focused }) {
+    const { onFocusChange } = this.props;
     this.setState({ focused });
+
+    onFocusChange({ focused });
   }
 
   render() {

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -69,7 +69,7 @@ class CalendarDay extends React.PureComponent {
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
-      if (isFocused || tabIndex !== prevProps.tabIndex) {
+      if (isFocused && tabIndex !== prevProps.tabIndex) {
         raf(() => {
           if (this.buttonRef) {
             this.buttonRef.focus();

--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -55,6 +55,17 @@ class CalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
+  componentDidMount() {
+    const { isFocused, tabIndex } = this.props;
+    if (isFocused && tabIndex === 0) {
+      setTimeout(() => {
+        if (this.buttonRef) {
+          this.buttonRef.focus();
+        }
+      }, 0);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -239,7 +239,7 @@ class CustomizableCalendarDay extends React.PureComponent {
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {
-      if (isFocused || tabIndex !== prevProps.tabIndex) {
+      if (isFocused && tabIndex !== prevProps.tabIndex) {
         raf(() => {
           if (this.buttonRef) {
             this.buttonRef.focus();

--- a/src/components/CustomizableCalendarDay.jsx
+++ b/src/components/CustomizableCalendarDay.jsx
@@ -225,6 +225,17 @@ class CustomizableCalendarDay extends React.PureComponent {
     this.setButtonRef = this.setButtonRef.bind(this);
   }
 
+  componentDidMount() {
+    const { isFocused, tabIndex } = this.props;
+    if (isFocused && tabIndex === 0) {
+      setTimeout(() => {
+        if (this.buttonRef) {
+          this.buttonRef.focus();
+        }
+      }, 0);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     const { isFocused, tabIndex } = this.props;
     if (tabIndex === 0) {

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -538,6 +538,7 @@ class DateRangePicker extends React.PureComponent {
           calendarInfoPosition={calendarInfoPosition}
           isFocused={isDayPickerFocused}
           showKeyboardShortcuts={showKeyboardShortcuts}
+          onFocus={this.onDayPickerFocus}
           onBlur={this.onDayPickerBlur}
           phrases={phrases}
           dayAriaLabelFormat={dayAriaLabelFormat}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -115,6 +115,7 @@ const propTypes = forbidExtraProps({
   // accessibility props
   isFocused: PropTypes.bool,
   getFirstFocusableDay: PropTypes.func,
+  onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   showKeyboardShortcuts: PropTypes.bool,
   onTab: PropTypes.func,
@@ -185,6 +186,7 @@ export const defaultProps = {
   // accessibility props
   isFocused: false,
   getFirstFocusableDay: null,
+  onFocus() {},
   onBlur() {},
   showKeyboardShortcuts: false,
   onTab() {},
@@ -224,6 +226,7 @@ class DayPicker extends React.PureComponent {
       calendarMonthWidth: getCalendarMonthWidth(props.daySize, horizontalMonthPadding),
       focusedDate: (!props.hidden || props.isFocused) ? focusedDate : null,
       nextFocusedDate: null,
+      preventFocusDate: false,
       showKeyboardShortcuts: props.showKeyboardShortcuts,
       onKeyboardShortcutsPanelClose() {},
       isTouchDevice: isTouchDevice(),
@@ -456,11 +459,13 @@ class DayPicker extends React.PureComponent {
     switch (e.key) {
       case 'ArrowUp':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.subtract(1, 'week');
         didTransitionMonth = this.maybeTransitionPrevMonth(newFocusedDate);
         break;
       case 'ArrowLeft':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         if (isRTL) {
           newFocusedDate.add(1, 'day');
         } else {
@@ -470,22 +475,26 @@ class DayPicker extends React.PureComponent {
         break;
       case 'Home':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.startOf('week');
         didTransitionMonth = this.maybeTransitionPrevMonth(newFocusedDate);
         break;
       case 'PageUp':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.subtract(1, 'month');
         didTransitionMonth = this.maybeTransitionPrevMonth(newFocusedDate);
         break;
 
       case 'ArrowDown':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.add(1, 'week');
         didTransitionMonth = this.maybeTransitionNextMonth(newFocusedDate);
         break;
       case 'ArrowRight':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         if (isRTL) {
           newFocusedDate.subtract(1, 'day');
         } else {
@@ -495,11 +504,13 @@ class DayPicker extends React.PureComponent {
         break;
       case 'End':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.endOf('week');
         didTransitionMonth = this.maybeTransitionNextMonth(newFocusedDate);
         break;
       case 'PageDown':
         e.preventDefault();
+        this.setState({ preventFocusDate: false });
         newFocusedDate.add(1, 'month');
         didTransitionMonth = this.maybeTransitionNextMonth(newFocusedDate);
         break;
@@ -540,6 +551,7 @@ class DayPicker extends React.PureComponent {
 
   onPrevMonthClick(e) {
     if (e) e.preventDefault();
+    this.setState({ preventFocusDate: true });
     this.onPrevMonthTransition();
   }
 
@@ -582,6 +594,7 @@ class DayPicker extends React.PureComponent {
       translationValue: 0.00001,
       focusedDate: null,
       nextFocusedDate: currentMonth,
+      preventFocusDate: true,
       currentMonth,
     });
   }
@@ -597,12 +610,14 @@ class DayPicker extends React.PureComponent {
       translationValue: 0.0001,
       focusedDate: null,
       nextFocusedDate: currentMonth,
+      preventFocusDate: true,
       currentMonth,
     });
   }
 
   onNextMonthClick(e) {
     if (e) e.preventDefault();
+    this.setState({ preventFocusDate: true });
     this.onNextMonthTransition();
   }
 
@@ -888,6 +903,7 @@ class DayPicker extends React.PureComponent {
     this.setState({
       showKeyboardShortcuts: true,
       onKeyboardShortcutsPanelClose: onCloseCallBack,
+      preventFocusDate: true,
     });
   }
 
@@ -901,6 +917,7 @@ class DayPicker extends React.PureComponent {
     this.setState({
       onKeyboardShortcutsPanelClose: null,
       showKeyboardShortcuts: false,
+      preventFocusDate: false,
     });
   }
 
@@ -1019,6 +1036,7 @@ class DayPicker extends React.PureComponent {
       translationValue,
       scrollableMonthMultiple,
       focusedDate,
+      preventFocusDate,
       showKeyboardShortcuts,
       isTouchDevice: isTouch,
       hasSetHeight,
@@ -1060,6 +1078,7 @@ class DayPicker extends React.PureComponent {
       verticalBorderSpacing,
       horizontalMonthPadding,
       navPosition,
+      onFocus,
     } = this.props;
 
     const { reactDates: { spacing: { dayPickerHorizontalPadding } } } = theme;
@@ -1084,7 +1103,7 @@ class DayPicker extends React.PureComponent {
 
     const isCalendarMonthGridAnimating = monthTransition !== null;
 
-    const shouldFocusDate = !isCalendarMonthGridAnimating && isFocused;
+    const shouldFocusDate = !preventFocusDate && !isCalendarMonthGridAnimating && isFocused;
 
     let keyboardShortcutButtonLocation = BOTTOM_RIGHT;
     if (this.isVertical()) {
@@ -1175,6 +1194,7 @@ class DayPicker extends React.PureComponent {
               onClick={(e) => { e.stopPropagation(); }}
               onKeyDown={this.onKeyDown}
               onMouseUp={() => { this.setState({ withMouseInteractions: true }); }}
+              onFocus={onFocus}
               tabIndex={-1}
               role="application"
               aria-roledescription={phrases.roleDescription}

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -105,6 +105,7 @@ const propTypes = forbidExtraProps({
   transitionDuration: nonNegativeInteger,
 
   // accessibility
+  onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   isFocused: PropTypes.bool,
   showKeyboardShortcuts: PropTypes.bool,
@@ -182,6 +183,7 @@ const defaultProps = {
   horizontalMonthPadding: 13,
 
   // accessibility
+  onFocus() {},
   onBlur() {},
   isFocused: false,
   showKeyboardShortcuts: false,
@@ -1315,6 +1317,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       renderCalendarInfo,
       renderMonthElement,
       calendarInfoPosition,
+      onFocus,
       onBlur,
       onShiftTab,
       onTab,
@@ -1385,6 +1388,7 @@ export default class DayPickerRangeController extends React.PureComponent {
         hideKeyboardShortcutsPanel={hideKeyboardShortcutsPanel}
         isFocused={isFocused}
         getFirstFocusableDay={this.getFirstFocusableDay}
+        onFocus={onFocus}
         onBlur={onBlur}
         showKeyboardShortcuts={showKeyboardShortcuts}
         phrases={phrases}

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -86,6 +86,7 @@ const propTypes = forbidExtraProps({
   calendarInfoPosition: CalendarInfoPositionShape,
 
   // accessibility
+  onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   isFocused: PropTypes.bool,
   showKeyboardShortcuts: PropTypes.bool,
@@ -154,6 +155,7 @@ const defaultProps = {
   calendarInfoPosition: INFO_POSITION_BOTTOM,
 
   // accessibility
+  onFocus() {},
   onBlur() {},
   isFocused: false,
   showKeyboardShortcuts: false,
@@ -670,6 +672,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       isRTL,
       phrases,
       dayAriaLabelFormat,
+      onFocus,
       onBlur,
       showKeyboardShortcuts,
       weekDayFormat,
@@ -729,6 +732,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
         calendarInfoPosition={calendarInfoPosition}
         isFocused={isFocused}
         getFirstFocusableDay={this.getFirstFocusableDay}
+        onFocus={onFocus}
         onBlur={onBlur}
         onTab={onTab}
         onShiftTab={onShiftTab}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -510,6 +510,7 @@ class SingleDatePicker extends React.PureComponent {
           calendarInfoPosition={calendarInfoPosition}
           isFocused={isDayPickerFocused}
           showKeyboardShortcuts={showKeyboardShortcuts}
+          onFocus={this.onDayPickerFocus}
           onBlur={this.onDayPickerBlur}
           phrases={phrases}
           dayAriaLabelFormat={dayAriaLabelFormat}

--- a/stories/SingleDatePicker.js
+++ b/stories/SingleDatePicker.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import momentJalaali from 'moment-jalaali';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 import DirectionProvider, { DIRECTIONS } from 'react-with-direction/dist/DirectionProvider';
 import isInclusivelyBeforeDay from '../src/utils/isInclusivelyBeforeDay';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
@@ -12,9 +13,9 @@ import {
   ANCHOR_RIGHT,
 } from '../src/constants';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
-const TestInput = props => (
+const TestInput = (props) => (
   <div style={{ marginTop: 16 }} >
     <input
       {...props}
@@ -28,6 +29,14 @@ const TestInput = props => (
       }}
     />
   </div>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SingleDatePicker (SDP)', module)

--- a/stories/SingleDatePicker_calendar.js
+++ b/stories/SingleDatePicker_calendar.js
@@ -2,8 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
 import { VERTICAL_ORIENTATION, ANCHOR_RIGHT, OPEN_UP } from '../src/constants';
 
@@ -18,7 +19,7 @@ const TestPrevIcon = () => (
       position: 'absolute',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Prev
   </div>
@@ -35,7 +36,7 @@ const TestNextIcon = () => (
       right: '22px',
       top: '20px',
     }}
-    tabindex="0"
+    tabIndex="0"
   >
     Next
   </div>
@@ -50,6 +51,14 @@ const TestCustomInfoPanel = () => (
   >
     &#x2755; Some useful info here
   </div>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SDP - Calendar Props', module)

--- a/stories/SingleDatePicker_day.js
+++ b/stories/SingleDatePicker_day.js
@@ -2,11 +2,12 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 import isSameDay from '../src/utils/isSameDay';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from "../examples/SingleDatePickerWrapper";
 
 const datesList = [
   moment(),
@@ -18,6 +19,14 @@ const datesList = [
   moment().add(12, 'days'),
   moment().add(13, 'days'),
 ];
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
+);
 
 storiesOf('SDP - Day Props', module)
   .add('default', withInfo()(() => (

--- a/stories/SingleDatePicker_input.js
+++ b/stories/SingleDatePicker_input.js
@@ -2,8 +2,9 @@ import React from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
+import { action } from '@storybook/addon-actions';
 
-import SingleDatePickerWrapper from '../examples/SingleDatePickerWrapper';
+import SingleDatePickerWrapperExample from '../examples/SingleDatePickerWrapper';
 
 const TestCustomInputIcon = () => (
   <span
@@ -16,6 +17,14 @@ const TestCustomInputIcon = () => (
   >
     C
   </span>
+);
+
+const SingleDatePickerWrapper = (props) => (
+  <SingleDatePickerWrapperExample
+    {...props}
+    onDateChange={action('onDateChange')}
+    onFocusChange={action('onFocusChange')}
+  />
 );
 
 storiesOf('SDP - Input Props', module)

--- a/test/components/CalendarDay_spec.jsx
+++ b/test/components/CalendarDay_spec.jsx
@@ -239,6 +239,23 @@ describe('CalendarDay', () => {
     });
   });
 
+  describe('#componentDidMount', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
+      const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidMount({ isFocused: true, tabIndex: 0 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(focus.callCount).to.eq(1);
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
   describe('#componentDidUpdate', () => {
     it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
       const wrapper = shallow(<CalendarDay isFocused tabIndex={0} />).dive();

--- a/test/components/CustomizableCalendarDay_spec.jsx
+++ b/test/components/CustomizableCalendarDay_spec.jsx
@@ -190,6 +190,23 @@ describe('CustomizableCalendarDay', () => {
     });
   });
 
+  describe('#componentDidMount', () => {
+    it('focuses buttonRef after a delay when isFocused and tabIndex is 0', () => {
+      const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();
+      const focus = sinon.spy();
+      wrapper.instance().buttonRef = { focus };
+      wrapper.instance().componentDidMount({ isFocused: true, tabIndex: 0 });
+      expect(focus.callCount).to.eq(0);
+
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(focus.callCount).to.eq(1);
+          resolve();
+        }, 0);
+      });
+    });
+  });
+
   describe('#componentDidUpdate', () => {
     it('focuses buttonRef after a delay when isFocused, tabIndex is 0, and tabIndex was not 0', () => {
       const wrapper = shallow(<CustomizableCalendarDay isFocused tabIndex={0} />).dive();

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -751,13 +751,15 @@ describe('DateRangePickerInputController', () => {
     });
 
     describe('is outside range', () => {
-      const futureDate = moment().add(7, 'days').format('DD/MM/YYYY');
+      const displayFormat = 'DD/MM/YYYY';
+      const futureDate = moment().add(7, 'days').format(displayFormat);
       const isOutsideRange = (day) => day > moment().add(5, 'days');
 
       it('calls props.onDatesChange', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
+            displayFormat={displayFormat}
             onDatesChange={onDatesChangeStub}
             isOutsideRange={isOutsideRange}
           />
@@ -770,6 +772,7 @@ describe('DateRangePickerInputController', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
+            displayFormat={displayFormat}
             onDatesChange={onDatesChangeStub}
             startDate={today}
             isOutsideRange={isOutsideRange}
@@ -784,6 +787,7 @@ describe('DateRangePickerInputController', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
+            displayFormat={displayFormat}
             onDatesChange={onDatesChangeStub}
             endDate={today}
             isOutsideRange={isOutsideRange}
@@ -796,13 +800,15 @@ describe('DateRangePickerInputController', () => {
     });
 
     describe('is blocked', () => {
-      const futureDate = moment().add(7, 'days').format('DD/MM/YYYY');
+      const displayFormat = 'DD/MM/YYYY';
+      const futureDate = moment().add(7, 'days').format(displayFormat);
       const isDayBlocked = sinon.stub().returns(true);
 
       it('calls props.onDatesChange', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
+            displayFormat={displayFormat}
             onDatesChange={onDatesChangeStub}
             isDayBlocked={isDayBlocked}
           />
@@ -815,6 +821,7 @@ describe('DateRangePickerInputController', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
+            displayFormat={displayFormat}
             onDatesChange={onDatesChangeStub}
             startDate={today}
             isDayBlocked={isDayBlocked}

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -106,6 +106,47 @@ describe('DayPicker', () => {
           expect(CalendarMonthGridComponent.prop('isAnimating')).to.equal(false);
         });
       });
+
+      describe('prop.isFocused', () => {
+        it('is false if state.preventFocusDate is true', () => {
+          const wrapper = shallow(<DayPicker />).dive();
+          wrapper.setState({ preventFocusDate: true });
+          const CalendarMonthGridComponent = wrapper.find(CalendarMonthGrid);
+          expect(CalendarMonthGridComponent.prop('isFocused')).to.equal(false);
+        });
+
+        it('is false if state.monthTransition is truthy', () => {
+          const wrapper = shallow(<DayPicker />).dive();
+          wrapper.setState({
+            preventFocusDate: false,
+            monthTransition: 'foo',
+          });
+          const CalendarMonthGridComponent = wrapper.find(CalendarMonthGrid);
+          expect(CalendarMonthGridComponent.prop('isFocused')).to.equal(false);
+        });
+
+        it('is false if isFocused is false', () => {
+          const wrapper = shallow(<DayPicker />).dive();
+          wrapper.setState({
+            preventFocusDate: false,
+            monthTransition: null,
+            isFocused: false,
+          });
+          const CalendarMonthGridComponent = wrapper.find(CalendarMonthGrid);
+          expect(CalendarMonthGridComponent.prop('isFocused')).to.equal(false);
+        });
+
+        it('is true if state.preventFocusDate and state.monthTransition are falsy and isFocused is true', () => {
+          const wrapper = shallow(<DayPicker />).dive();
+          wrapper.setState({
+            preventFocusDate: false,
+            monthTransition: null,
+          });
+          wrapper.setProps({ isFocused: true });
+          const CalendarMonthGridComponent = wrapper.find(CalendarMonthGrid);
+          expect(CalendarMonthGridComponent.prop('isFocused')).to.equal(true);
+        });
+      });
     });
 
     describe('DayPickerNavigation', () => {


### PR DESCRIPTION
This aims to meet the request posed in Issue #1484.

This change adds a `preventFocusDate` property to the state of `DayPicker` so that after the Prev or Next Month buttons are pressed/clicked or when the Keyboard Shortcuts modal is opened the focus should _not_ move to the `nextFocusedDate`, otherwise it should.

One other thing to note is that I based this branch off of the branch here: https://github.com/airbnb/react-dates/pull/1948 as this change does depend on that change, so I apologize if that muddies the waters.