### PR TITLE
fix: DateInput box-sizing

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -321,6 +321,7 @@ export default withStyles(({
     borderBottom: border.input.borderBottom,
     borderLeft: noflip(border.input.borderLeft),
     borderRadius: border.input.borderRadius,
+    boxSizing: 'border-box',
   },
 
   DateInput_input__small: {


### PR DESCRIPTION
# Summary

Fixes #1964. In a basic setup `DateInput` border is hidden due to missing `box-sizing` property and `overflow: hidden` (I'm guessing).

This wasn't reproducible in Storybook because of the styles below:
https://github.com/airbnb/react-dates/blob/480b9902d69e64e62a2ef5c2d3b5fc3adef94444/css/storybook.scss#L13-L15