### PR TITLE
SingleDatePicker supports custom onOutsideClick

### DIFF
--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -102,6 +102,7 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onClose() {},
+  onOutsideClick() {},
 
   // month presentation and interaction related props
   renderMonthText: null,
@@ -412,6 +413,7 @@ class SingleDatePicker extends React.PureComponent {
       onPrevMonthClick,
       onNextMonthClick,
       onClose,
+      onOutsideClick,
       withPortal,
       withFullScreenPortal,
       keepOpenOnDateSelect,
@@ -444,7 +446,8 @@ class SingleDatePicker extends React.PureComponent {
     } = this.props;
     const { dayPickerContainerStyles, isDayPickerFocused, showKeyboardShortcuts } = this.state;
 
-    const onOutsideClick = (!withFullScreenPortal && withPortal) ? this.onOutsideClick : undefined;
+    const onOutsideClickImpl = onOutsideClick || this.onOutsideClick;
+    const onOutsideClickWithPortal = (!withFullScreenPortal && withPortal) ? onOutsideClickImpl : undefined;
     const closeIcon = customCloseIcon || (<CloseButton />);
 
     const inputHeight = getInputHeight(reactDates, small);
@@ -475,7 +478,7 @@ class SingleDatePicker extends React.PureComponent {
           isRTL && styles.SingleDatePicker_picker__rtl,
           dayPickerContainerStyles,
         )}
-        onClick={onOutsideClick}
+        onClick={onOutsideClickWithPortal}
       >
         <DayPickerSingleDateController
           date={date}
@@ -530,7 +533,7 @@ class SingleDatePicker extends React.PureComponent {
             {...css(styles.SingleDatePicker_closeButton)}
             aria-label={phrases.closeDatePicker}
             type="button"
-            onClick={this.onOutsideClick}
+            onClick={onOutsideClickImpl}
           >
             <div {...css(styles.SingleDatePicker_closeButton_svg)}>
               {closeIcon}
@@ -562,6 +565,7 @@ class SingleDatePicker extends React.PureComponent {
       onDateChange,
       displayFormat,
       phrases,
+      onOutsideClick,
       withPortal,
       withFullScreenPortal,
       screenReaderInputMessage,
@@ -583,6 +587,8 @@ class SingleDatePicker extends React.PureComponent {
     const enableOutsideClick = (!withPortal && !withFullScreenPortal);
 
     const hideFang = verticalSpacing < FANG_HEIGHT_PX;
+
+    const onOutsideClickImpl = onOutsideClick || this.onOutsideClick;
 
     const input = (
       <SingleDatePickerInputController
@@ -633,7 +639,7 @@ class SingleDatePicker extends React.PureComponent {
         )}
       >
         {enableOutsideClick && (
-          <OutsideClickHandler onOutsideClick={this.onOutsideClick}>
+          <OutsideClickHandler onOutsideClick={onOutsideClickImpl}>
             {input}
           </OutsideClickHandler>
         )}

--- a/src/shapes/SingleDatePickerShape.js
+++ b/src/shapes/SingleDatePickerShape.js
@@ -78,6 +78,7 @@ export default {
   onPrevMonthClick: PropTypes.func,
   onNextMonthClick: PropTypes.func,
   onClose: PropTypes.func,
+  onOutsideClick: PropTypes.func,
 
   // day presentation and interaction related props
   renderCalendarDay: PropTypes.func,


### PR DESCRIPTION
This PR aims to meet the request posed in Issue [#662](https://github.com/airbnb/react-dates/issues/662)

Adding custom onOutsideClick fn to SingleDatePicker.