### PR TITLE
[Fix] `DayPicker`: check for renderMonthText when recomputing height

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -339,7 +339,8 @@ class DayPicker extends React.PureComponent {
       }
     }
 
-    if (renderMonthText !== prevRenderMonthText) {
+    if (renderMonthText !== null && prevRenderMonthText !== null
+        && renderMonthText(currentMonth) !== prevRenderMonthText(currentMonth)) {
       this.setState({
         monthTitleHeight: null,
       });

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -606,6 +606,21 @@ describe('DayPicker', () => {
     });
   });
 
+  describe('monthTitleHeight', () => {
+    it('change monthTitleHeight correctly with setMonthTitleHeight', () => {
+      const wrapper = shallow(<DayPicker />).dive();
+      wrapper.instance().setMonthTitleHeight(80);
+      expect(wrapper.state().monthTitleHeight).to.equal(80);
+    });
+
+    it('do not change monthTitleHeight with renderMonthText === prevRenderMonthText', () => {
+      const wrapper = shallow(<DayPicker renderMonthText={() => 'foo'} />).dive();
+      wrapper.instance().setMonthTitleHeight(80);
+      wrapper.setProps({ renderMonthText: () => 'foo' });
+      expect(wrapper.state().monthTitleHeight).to.equal(80);
+    });
+  });
+
   describe('#onNextMonthClick', () => {
     it('calls onNextMonthTransition', () => {
       const onNextMonthTransitionSpy = sinon.spy(PureDayPicker.prototype, 'onNextMonthTransition');


### PR DESCRIPTION
Close #1993 
Cause **renderMonthText** is need to be function, comparing two function will be always false, so it will make unnecessary **setState** for **monthTitleHeight**: https://github.com/airbnb/react-dates/blob/480b9902d69e64e62a2ef5c2d3b5fc3adef94444/src/components/DayPicker.jsx#L342-L346 