### PR TITLE
Issue 1023 pass invalid date to onchange

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -22,7 +22,6 @@ import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 
-
 import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_SCROLLABLE,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -23,7 +23,6 @@ import ModifiersShape from '../shapes/ModifiersShape';
 import ScrollableOrientationShape from '../shapes/ScrollableOrientationShape';
 import DayOfWeekShape from '../shapes/DayOfWeekShape';
 
-
 import {
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -281,7 +281,6 @@ function DateRangePickerInput({
         regular={regular}
       />
 
-
       {showClearDates && (
         <button
           type="button"

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -187,6 +187,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
       onDatesChange({
         startDate,
         endDate: null,
+        endDateInvalid: endDateString
       });
     }
   }
@@ -237,6 +238,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
     } else {
       onDatesChange({
         startDate: null,
+        startDateInvalid: startDateString
         endDate,
       });
     }

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -187,7 +187,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
       onDatesChange({
         startDate,
         endDate: null,
-        endDateInvalid: endDateString
+        endDateInvalid: endDateString,
       });
     }
   }
@@ -238,7 +238,7 @@ export default class DateRangePickerInputController extends React.PureComponent 
     } else {
       onDatesChange({
         startDate: null,
-        startDateInvalid: startDateString
+        startDateInvalid: startDateString,
         endDate,
       });
     }

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -898,7 +898,6 @@ export default class DayPickerRangeController extends React.PureComponent {
       }
     }
 
-
     this.setState({
       hoverDate: null,
       visibleDays: {

--- a/src/components/SingleDatePickerInputController.jsx
+++ b/src/components/SingleDatePickerInputController.jsx
@@ -151,7 +151,6 @@ export default class SingleDatePickerInputController extends React.PureComponent
     }
   }
 
-
   onFocus() {
     const {
       onFocusChange,

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -377,7 +377,7 @@ describe('DateRangePickerInputController', () => {
         expect(args.startDate).to.equal(today);
       });
 
-      it('calls props.onDatesChange with endDate === null', () => {
+      it('calls props.onDatesChange with endDate === null and endDateInvalid === endDateString', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController onDatesChange={onDatesChangeStub} />
@@ -385,6 +385,7 @@ describe('DateRangePickerInputController', () => {
         wrapper.instance().onEndDateChange(invalidDateString);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.endDate).to.equal(null);
+        expect(args.endDateInvalid).to.equal(invalidDateString);
       });
     });
 
@@ -726,7 +727,7 @@ describe('DateRangePickerInputController', () => {
         expect(onDatesChangeStub.callCount).to.equal(1);
       });
 
-      it('calls props.onDatesChange with startDate === null', () => {
+      it('calls props.onDatesChange with startDate === null and startDateInvalid === startDateString', () => {
         const onDatesChangeStub = sinon.stub();
         const wrapper = shallow((
           <DateRangePickerInputController
@@ -737,6 +738,7 @@ describe('DateRangePickerInputController', () => {
         wrapper.instance().onStartDateChange(invalidDateString);
         const args = onDatesChangeStub.getCall(0).args[0];
         expect(args.startDate).to.equal(null);
+        expect(args.startDateInvalid).to.equal(invalidDateString);
       });
 
       it('calls props.onDatesChange with endDate === props.endDate', () => {

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -145,7 +145,6 @@ describe('DateRangePickerInput', () => {
       });
     });
 
-
     describe('props.disabled=false', () => {
       it('First DateInput gets disabled prop, second does not', () => {
         const wrapper = shallow(<DateRangePickerInput disabled={false} />).dive();

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -593,7 +593,6 @@ describe('DateRangePicker', () => {
       expect(onOutsideClick.callCount).to.equal(1);
     });
 
-
     it('tabbing within itself does not behave as an outside click', () => {
       const target = sinon.stub();
       const onOutsideClick = sinon.stub();

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -1651,7 +1651,6 @@ describe('DayPickerRangeController', () => {
           });
         });
 
-
         describe('start date has changed, and end date or previous end date are falsey', () => {
           it('calls deleteModifier with `selected-start-no-selected-end`', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');

--- a/test/components/DayPicker_spec.jsx
+++ b/test/components/DayPicker_spec.jsx
@@ -18,7 +18,6 @@ import {
   NAV_POSITION_BOTTOM,
 } from '../../src/constants';
 
-
 const today = moment().locale('en');
 const event = { preventDefault() {}, stopPropagation() {} };
 
@@ -513,7 +512,6 @@ describe('DayPicker', () => {
         });
       });
     });
-
 
     describe('focusedDate is falsy', () => {
       it('does not call maybeTransitionPrevMonth', () => {

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -376,7 +376,6 @@ describe('SingleDatePicker', () => {
       expect(onDayPickerFocusSpy.callCount).to.equal(1);
     });
 
-
     it('calls onDayPickerFocus if readOnly and keepFocusOnInput', () => {
       const wrapper = shallow((
         <SingleDatePicker


### PR DESCRIPTION
Resolve issue [1023](https://github.com/airbnb/react-dates/issues/1023)

When a date is invalid, it is hard to tell if it is invalid due to an empty string, where the user has not entered a date, or if the user entered an invalid date.

Currently the only way to determine if the date is invalid or just empty, is to query the DOM for the specific <input/> tags to read their values.

This change will pass a new argument to the onChangeHandler that will include the date string that was entered into the input.

* NOTE
There were some unrelated files that had linting errors related to having too many spaces. This PR also helps the team out in fixing those issues.