### PR TITLE
Clear renderCalendarInfo timeout before assigning a new timeout (#1323)

### DIFF
--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -367,6 +367,8 @@ class DayPicker extends React.PureComponent {
     // breaks the CSS transition.
     // The setTimeout will wait until the transition ends.
     if (this.calendarInfo) {
+      clearTimeout(this.setCalendarInfoWidthTimeout);
+
       this.setCalendarInfoWidthTimeout = setTimeout(() => {
         const { calendarInfoWidth } = this.state;
         const calendarInfoPanelWidth = calculateDimension(this.calendarInfo, 'width', true, true);


### PR DESCRIPTION
This is a do-over of @mstanaland's work on https://github.com/airbnb/react-dates/pull/1736 to fix a memory leak issue where the timeout is not cleared before being set again. I am doing this so that we can be current with master, since the original PR went unmerged for six months due to lack of a unit test. This branch does contain a test displaying that `setState` is called by the timeout only once.

Original PR description by @mstanaland:

> Clears the setTimeout assigned to this.setCalendarInfoWidthTimeout before a new setTimeout is assigned/reassigned to prevent a possible memory leak.
  Fixes issue #1323