### PR TITLE
run npx react-codemod rename-unsafe-lifecycles on javascript files

### DIFF
--- a/src/components/CalendarMonth.jsx
+++ b/src/components/CalendarMonth.jsx
@@ -109,7 +109,7 @@ class CalendarMonth extends React.PureComponent {
     this.setMonthTitleHeightTimeout = setTimeout(this.setMonthTitleHeight, 0);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { month, enableOutsideDays, firstDayOfWeek } = nextProps;
     const {
       month: prevMonth,

--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -139,7 +139,7 @@ class CalendarMonthGrid extends React.PureComponent {
     );
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { initialMonth, numberOfMonths, orientation } = nextProps;
     const { months } = this.state;
 

--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -102,7 +102,7 @@ class DateInput extends React.PureComponent {
     this.setState({ isTouchDevice: isTouchDevice() });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { dateString } = this.state;
     if (dateString && nextProps.displayValue) {
       this.setState({

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -281,7 +281,7 @@ class DayPicker extends React.PureComponent {
     this.setCalendarMonthWeeks(currentMonth);
   }
 
-  componentWillReceiveProps(nextProps, nextState) {
+  UNSAFE_componentWillReceiveProps(nextProps, nextState) {
     const {
       hidden,
       isFocused,
@@ -360,7 +360,7 @@ class DayPicker extends React.PureComponent {
     }
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     const { transitionDuration } = this.props;
 
     // Calculating the dimensions trigger a DOM repaint which

--- a/src/components/DayPickerKeyboardShortcuts.jsx
+++ b/src/components/DayPickerKeyboardShortcuts.jsx
@@ -91,7 +91,7 @@ class DayPickerKeyboardShortcuts extends React.PureComponent {
     this.onKeyDown = this.onKeyDown.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { phrases } = this.props;
     if (nextProps.phrases !== phrases) {
       this.keyboardShortcuts = getKeyboardShortcuts(nextProps.phrases);

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -270,7 +270,7 @@ export default class DayPickerRangeController extends React.PureComponent {
     this.getFirstFocusableDay = this.getFirstFocusableDay.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       startDate,
       endDate,

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -216,7 +216,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     this.isTouchDevice = isTouchDevice();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       date,
       focused,
@@ -344,7 +344,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
     }
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     this.today = moment();
   }
 

--- a/test/components/CalendarMonthGrid_spec.jsx
+++ b/test/components/CalendarMonthGrid_spec.jsx
@@ -31,7 +31,7 @@ describe('CalendarMonthGrid', () => {
       <CalendarMonthGrid numberOfMonths={12} initialMonth={initialMonth} />
     )).dive();
 
-    wrapper.instance().componentWillReceiveProps({
+    wrapper.instance().UNSAFE_componentWillReceiveProps({
       initialMonth,
       numberOfMonths: 24,
     });
@@ -51,7 +51,7 @@ describe('CalendarMonthGrid', () => {
       <CalendarMonthGrid numberOfMonths={12} initialMonth={initialMonth} />
     )).dive();
 
-    wrapper.instance().componentWillReceiveProps({
+    wrapper.instance().UNSAFE_componentWillReceiveProps({
       initialMonth,
       numberOfMonths: 12,
       firstVisibleMonthIndex: 0,

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -127,7 +127,7 @@ describe('DateInput', () => {
         const dateString = 'foo123';
         const wrapper = shallow(<DateInput id="date" />).dive();
         wrapper.setState({ dateString });
-        wrapper.instance().componentWillReceiveProps({ displayValue: '1991-07-13' });
+        wrapper.instance().UNSAFE_componentWillReceiveProps({ displayValue: '1991-07-13' });
         expect(wrapper.state()).to.have.property('dateString', '');
       });
     });
@@ -137,7 +137,7 @@ describe('DateInput', () => {
         const dateString = 'foo123';
         const wrapper = shallow(<DateInput id="date" />).dive();
         wrapper.setState({ dateString });
-        wrapper.instance().componentWillReceiveProps({ displayValue: null });
+        wrapper.instance().UNSAFE_componentWillReceiveProps({ displayValue: null });
         expect(wrapper.state()).to.have.property('dateString', dateString);
       });
     });

--- a/test/components/DayPickerKeyboardShortcuts_spec.jsx
+++ b/test/components/DayPickerKeyboardShortcuts_spec.jsx
@@ -20,7 +20,7 @@ describe('DayPickerKeyboardShortcuts', () => {
       it('updates the keyboardShortcuts', () => {
         const wrapper = shallow(<DayPickerKeyboardShortcuts {...prevProps} />).dive();
         const prevKeyboardShortcuts = wrapper.instance().keyboardShortcuts;
-        wrapper.instance().componentWillReceiveProps(newProps);
+        wrapper.instance().UNSAFE_componentWillReceiveProps(newProps);
         const updatedKeyboardShortcuts = wrapper.instance().keyboardShortcuts;
         expect(prevKeyboardShortcuts).to.not.equal(updatedKeyboardShortcuts);
       });
@@ -33,7 +33,7 @@ describe('DayPickerKeyboardShortcuts', () => {
       it('does NOT update the keyboardShortcuts', () => {
         const wrapper = shallow(<DayPickerKeyboardShortcuts {...prevProps} />).dive();
         const prevKeyboardShortcuts = wrapper.instance().keyboardShortcuts;
-        wrapper.instance().componentWillReceiveProps(newProps);
+        wrapper.instance().UNSAFE_componentWillReceiveProps(newProps);
         const updatedKeyboardShortcuts = wrapper.instance().keyboardShortcuts;
         expect(prevKeyboardShortcuts).to.deep.equal(updatedKeyboardShortcuts);
       });

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -113,7 +113,7 @@ describe('DayPickerRangeController', () => {
             );
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
             getStateForNewMonthSpy.resetHistory();
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               initialVisibleMonth: () => moment(),
@@ -130,7 +130,7 @@ describe('DayPickerRangeController', () => {
             getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
 
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               initialVisibleMonth: () => moment(),
@@ -148,7 +148,7 @@ describe('DayPickerRangeController', () => {
             getStateForNewMonthStub.returns({ currentMonth, visibleDays });
 
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               initialVisibleMonth: () => moment(),
@@ -165,7 +165,7 @@ describe('DayPickerRangeController', () => {
             );
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
             getStateForNewMonthSpy.resetHistory();
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: null,
               initialVisibleMonth: () => moment(),
@@ -183,7 +183,7 @@ describe('DayPickerRangeController', () => {
 
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
             wrapper.setState({ currentMonth });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: null,
               initialVisibleMonth: () => moment(),
@@ -201,7 +201,7 @@ describe('DayPickerRangeController', () => {
 
             const wrapper = shallow(<DayPickerRangeController {...props} focusedInput={null} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: null,
               initialVisibleMonth: () => moment(),
@@ -219,7 +219,7 @@ describe('DayPickerRangeController', () => {
           );
           const wrapper = shallow(<DayPickerRangeController {...props} />);
           getStateForNewMonthSpy.resetHistory();
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             numberOfMonths: 5,
           });
@@ -235,7 +235,7 @@ describe('DayPickerRangeController', () => {
           getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
 
           const wrapper = shallow(<DayPickerRangeController {...props} />);
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             numberOfMonths: 5,
           });
@@ -252,7 +252,7 @@ describe('DayPickerRangeController', () => {
           getStateForNewMonthStub.returns({ currentMonth, visibleDays });
 
           const wrapper = shallow(<DayPickerRangeController {...props} />);
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             numberOfMonths: 5,
           });
@@ -265,7 +265,7 @@ describe('DayPickerRangeController', () => {
           const getStateForNewMonthSpy = sinon.spy(DayPickerRangeController.prototype, 'getStateForNewMonth');
           const wrapper = shallow(<DayPickerRangeController {...props} />);
           getStateForNewMonthSpy.resetHistory();
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             enableOutsideDays: true,
           });
@@ -278,7 +278,7 @@ describe('DayPickerRangeController', () => {
           getStateForNewMonthStub.returns({ currentMonth, visibleDays: {} });
 
           const wrapper = shallow(<DayPickerRangeController {...props} />);
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             enableOutsideDays: true,
           });
@@ -292,7 +292,7 @@ describe('DayPickerRangeController', () => {
           getStateForNewMonthStub.returns({ currentMonth, visibleDays });
 
           const wrapper = shallow(<DayPickerRangeController {...props} />);
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             enableOutsideDays: true,
           });
@@ -318,7 +318,7 @@ describe('DayPickerRangeController', () => {
             />
           ));
           deleteModifierFromRangeSpy.resetHistory();
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             startDate: nextStartDate,
           });
@@ -347,7 +347,7 @@ describe('DayPickerRangeController', () => {
           ));
           deleteModifierSpy.resetHistory();
           addModifierSpy.resetHistory();
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             endDate: nextEndDate,
           });
@@ -374,7 +374,7 @@ describe('DayPickerRangeController', () => {
 
           getStateForNewMonthSpy.resetHistory();
 
-          wrapper.instance().componentWillReceiveProps({
+          wrapper.instance().UNSAFE_componentWillReceiveProps({
             ...props,
             endDate: nextEndDate,
           });
@@ -389,7 +389,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const startDate = today;
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate });
             expect(getCallsByModifier(addModifierSpy, 'selected-start').length).to.equal(0);
           });
 
@@ -397,7 +397,7 @@ describe('DayPickerRangeController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
             const startDate = today;
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate });
             expect(getCallsByModifier(deleteModifierSpy, 'selected-start').length).to.equal(0);
           });
         });
@@ -408,7 +408,7 @@ describe('DayPickerRangeController', () => {
             const startDate = today;
             const newStartDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: newStartDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: newStartDate });
             const selectedStartCalls = getCallsByModifier(deleteModifierSpy, 'selected-start');
             expect(selectedStartCalls.length).to.equal(1);
             expect(selectedStartCalls[0].args[1]).to.equal(startDate);
@@ -419,7 +419,7 @@ describe('DayPickerRangeController', () => {
             const startDate = today;
             const newStartDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: newStartDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: newStartDate });
             const selectedStartCalls = getCallsByModifier(addModifierSpy, 'selected-start');
             expect(selectedStartCalls.length).to.equal(1);
             expect(selectedStartCalls[0].args[1]).to.equal(newStartDate);
@@ -433,7 +433,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const endDate = today;
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate });
             expect(getCallsByModifier(addModifierSpy, 'selected-end').length).to.equal(0);
           });
 
@@ -441,7 +441,7 @@ describe('DayPickerRangeController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
             const endDate = today;
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate });
             expect(getCallsByModifier(deleteModifierSpy, 'selected-end').length).to.equal(0);
           });
         });
@@ -452,7 +452,7 @@ describe('DayPickerRangeController', () => {
             const endDate = today;
             const newEndDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate: newEndDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate: newEndDate });
             const selectedEndCalls = getCallsByModifier(deleteModifierSpy, 'selected-end');
             expect(selectedEndCalls.length).to.equal(1);
             expect(selectedEndCalls[0].args[1]).to.equal(endDate);
@@ -463,7 +463,7 @@ describe('DayPickerRangeController', () => {
             const endDate = today;
             const newEndDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate: newEndDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate: newEndDate });
             const selectedEndCalls = getCallsByModifier(addModifierSpy, 'selected-end');
             expect(selectedEndCalls.length).to.equal(1);
             expect(selectedEndCalls[0].args[1]).to.equal(newEndDate);
@@ -478,7 +478,7 @@ describe('DayPickerRangeController', () => {
               const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
               const endDate = moment().add(10, 'days');
               const wrapper = shallow(<DayPickerRangeController {...props} startDate={today} />);
-              wrapper.instance().componentWillReceiveProps({ ...props, startDate: null, endDate });
+              wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: null, endDate });
               const hoverSpanCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'hovered-span');
               expect(hoverSpanCalls.length).to.equal(0);
             });
@@ -489,7 +489,7 @@ describe('DayPickerRangeController', () => {
               const deleteModifierFromRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifierFromRange');
               const startDate = today;
               const wrapper = shallow(<DayPickerRangeController {...props} />);
-              wrapper.instance().componentWillReceiveProps({ ...props, startDate, endDate: null });
+              wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate, endDate: null });
               const hoverSpanCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'hovered-span');
               expect(hoverSpanCalls.length).to.equal(0);
             });
@@ -502,7 +502,7 @@ describe('DayPickerRangeController', () => {
               const endDate = today.clone().add(10, 'days');
               const dayAfterEndDate = endDate.clone().add(1, 'day');
               const wrapper = shallow(<DayPickerRangeController {...props} />);
-              wrapper.instance().componentWillReceiveProps({ ...props, startDate, endDate });
+              wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate, endDate });
               const hoverSpanCalls = getCallsByModifier(deleteModifierFromRangeSpy, 'hovered-span');
               expect(hoverSpanCalls.length).to.equal(1);
               expect(hoverSpanCalls[0].args[1]).to.equal(startDate);
@@ -524,7 +524,7 @@ describe('DayPickerRangeController', () => {
               const wrapper = shallow((
                 <DayPickerRangeController {...props} startDate={startDate} endDate={endDate} />
               ));
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate: newStartDate,
                 endDate,
@@ -546,7 +546,7 @@ describe('DayPickerRangeController', () => {
               const wrapper = shallow((
                 <DayPickerRangeController {...props} startDate={startDate} endDate={endDate} />
               ));
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate: newStartDate,
                 endDate,
@@ -569,7 +569,7 @@ describe('DayPickerRangeController', () => {
               const wrapper = shallow((
                 <DayPickerRangeController {...props} startDate={startDate} endDate={endDate} />
               ));
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 endDate: moment().add(11, 'day'),
@@ -593,7 +593,7 @@ describe('DayPickerRangeController', () => {
                 startDate={startDate}
                 endDate={endDate}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 endDate: newEndDate,
@@ -612,7 +612,7 @@ describe('DayPickerRangeController', () => {
           it('calls addModifierToRange with `after-hovered-start`', () => {
             const addModifierToRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifierToRange');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: moment() });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: moment() });
             const afterHoverStartCalls = getCallsByModifier(addModifierToRangeSpy, 'after-hovered-start');
             expect(afterHoverStartCalls.length).to.equal(1);
           });
@@ -622,7 +622,7 @@ describe('DayPickerRangeController', () => {
             const startDate = moment();
             const startSpan = toISODateString(startDate.clone().add(1, 'day'));
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate });
             const afterHoverStartCalls = getCallsByModifier(addModifierToRangeSpy, 'after-hovered-start');
             expect(toISODateString(afterHoverStartCalls[0].args[1])).to.equal(startSpan);
           });
@@ -635,7 +635,7 @@ describe('DayPickerRangeController', () => {
             const wrapper = shallow((
               <DayPickerRangeController {...props} minimumNights={minimumNights} />
             ));
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate, minimumNights });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate, minimumNights });
             const afterHoverStartCalls = getCallsByModifier(addModifierToRangeSpy, 'after-hovered-start');
             expect(toISODateString(afterHoverStartCalls[0].args[2])).to.equal(endSpan);
           });
@@ -646,7 +646,7 @@ describe('DayPickerRangeController', () => {
             const startDate = moment();
             const addModifierToRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifierToRange');
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate });
             const afterHoverStartCalls = getCallsByModifier(addModifierToRangeSpy, 'after-hovered-start');
             expect(afterHoverStartCalls.length).to.equal(0);
           });
@@ -657,7 +657,7 @@ describe('DayPickerRangeController', () => {
             const startDate = moment();
             const addModifierToRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifierToRange');
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: null });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: null });
             const afterHoverStartCalls = getCallsByModifier(addModifierToRangeSpy, 'after-hovered-start');
             expect(afterHoverStartCalls.length).to.equal(0);
           });
@@ -667,7 +667,7 @@ describe('DayPickerRangeController', () => {
           it('does not call addModifierToRange with `after-hovered-start`', () => {
             const addModifierToRangeSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifierToRange');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               startDate: moment(),
               endDate: moment(),
@@ -691,7 +691,7 @@ describe('DayPickerRangeController', () => {
                 endDate={null}
                 focusedInput={focusedInput}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput,
@@ -713,7 +713,7 @@ describe('DayPickerRangeController', () => {
                 focusedInput={focusedInput}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate: moment().add(5, 'days'),
                 focusedInput,
@@ -738,7 +738,7 @@ describe('DayPickerRangeController', () => {
                 focusedInput={START_DATE}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput,
@@ -763,7 +763,7 @@ describe('DayPickerRangeController', () => {
                 focusedInput={focusedInput}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput,
                 startDate,
@@ -789,7 +789,7 @@ describe('DayPickerRangeController', () => {
                 startDate={startDate}
                 minimumNights={5}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate: today,
                 focusedInput: START_DATE,
@@ -818,7 +818,7 @@ describe('DayPickerRangeController', () => {
                 day.add(1, 'day');
               }
 
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput: START_DATE,
@@ -848,7 +848,7 @@ describe('DayPickerRangeController', () => {
                 startDate={startDate}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput: END_DATE,
@@ -868,7 +868,7 @@ describe('DayPickerRangeController', () => {
                 startDate={startDate}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput: END_DATE,
@@ -892,7 +892,7 @@ describe('DayPickerRangeController', () => {
                 startDate={startDate}
                 minimumNights={minimumNights}
               />);
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 startDate,
                 focusedInput: END_DATE,
@@ -920,7 +920,7 @@ describe('DayPickerRangeController', () => {
               isOutsideRange={isOutsideRangeStub}
             />);
             const prevCallCount = isOutsideRangeStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
@@ -930,7 +930,7 @@ describe('DayPickerRangeController', () => {
           it('calls isOutsideRange if changed', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
@@ -956,7 +956,7 @@ describe('DayPickerRangeController', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isOutsideRange: isOutsideRangeStub,
@@ -969,7 +969,7 @@ describe('DayPickerRangeController', () => {
             const isOutsideRangeStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               isOutsideRange: isOutsideRangeStub,
@@ -983,7 +983,7 @@ describe('DayPickerRangeController', () => {
             const isOutsideRangeStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isOutsideRange: isOutsideRangeStub,
@@ -1003,7 +1003,7 @@ describe('DayPickerRangeController', () => {
               isDayBlocked={isDayBlockedStub}
             />);
             const prevCallCount = isDayBlockedStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
@@ -1013,7 +1013,7 @@ describe('DayPickerRangeController', () => {
           it('calls isDayBlocked if changed', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
@@ -1039,7 +1039,7 @@ describe('DayPickerRangeController', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isDayBlocked: isDayBlockedStub,
@@ -1052,7 +1052,7 @@ describe('DayPickerRangeController', () => {
             const isDayBlockedStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               isDayBlocked: isDayBlockedStub,
@@ -1066,7 +1066,7 @@ describe('DayPickerRangeController', () => {
             const isDayBlockedStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isDayBlocked: isDayBlockedStub,
@@ -1086,7 +1086,7 @@ describe('DayPickerRangeController', () => {
               isDayHighlighted={isDayHighlightedStub}
             />);
             const prevCallCount = isDayHighlightedStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
@@ -1096,7 +1096,7 @@ describe('DayPickerRangeController', () => {
           it('calls isDayHighlighted if changed', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
@@ -1122,7 +1122,7 @@ describe('DayPickerRangeController', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isDayHighlighted: isDayHighlightedStub,
@@ -1135,7 +1135,7 @@ describe('DayPickerRangeController', () => {
             const isDayHighlightedStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isDayHighlighted: isDayHighlightedStub,
@@ -1149,7 +1149,7 @@ describe('DayPickerRangeController', () => {
             const isDayHighlightedStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               isDayHighlighted: isDayHighlightedStub,
@@ -1166,7 +1166,7 @@ describe('DayPickerRangeController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().today = today;
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(deleteModifierSpy, 'today');
             expect(todayCalls.length).to.equal(0);
           });
@@ -1175,7 +1175,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().today = today;
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(addModifierSpy, 'today');
             expect(todayCalls.length).to.equal(0);
           });
@@ -1186,7 +1186,7 @@ describe('DayPickerRangeController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'deleteModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().today = moment().subtract(1, 'day');
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(deleteModifierSpy, 'today');
             expect(todayCalls.length).to.equal(1);
           });
@@ -1195,7 +1195,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.instance().today = moment().subtract(1, 'day');
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(addModifierSpy, 'today');
             expect(todayCalls.length).to.equal(1);
           });
@@ -1210,7 +1210,7 @@ describe('DayPickerRangeController', () => {
               {...props}
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
             });
@@ -1225,7 +1225,7 @@ describe('DayPickerRangeController', () => {
               {...props}
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1240,7 +1240,7 @@ describe('DayPickerRangeController', () => {
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
             wrapper.setState({ hoverDate: today });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1257,7 +1257,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1279,7 +1279,7 @@ describe('DayPickerRangeController', () => {
                 />,
               );
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1296,7 +1296,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1311,7 +1311,7 @@ describe('DayPickerRangeController', () => {
                 {...props}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
               });
@@ -1329,7 +1329,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1351,7 +1351,7 @@ describe('DayPickerRangeController', () => {
                 />,
               );
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1368,7 +1368,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1383,7 +1383,7 @@ describe('DayPickerRangeController', () => {
                 {...props}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
               });
@@ -1402,7 +1402,7 @@ describe('DayPickerRangeController', () => {
               {...props}
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
             });
@@ -1417,7 +1417,7 @@ describe('DayPickerRangeController', () => {
               {...props}
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1432,7 +1432,7 @@ describe('DayPickerRangeController', () => {
               getMinNightsForHoverDate={getMinNightsForHoverDateStub}
             />);
             wrapper.setState({ hoverDate: today });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1449,7 +1449,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1470,7 +1470,7 @@ describe('DayPickerRangeController', () => {
                 />,
               );
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1487,7 +1487,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1502,7 +1502,7 @@ describe('DayPickerRangeController', () => {
                 {...props}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
               });
@@ -1520,7 +1520,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1541,7 +1541,7 @@ describe('DayPickerRangeController', () => {
                 />,
               );
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: START_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1558,7 +1558,7 @@ describe('DayPickerRangeController', () => {
                 getMinNightsForHoverDate={getMinNightsForHoverDateStub}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
                 getMinNightsForHoverDate: getMinNightsForHoverDateStub,
@@ -1573,7 +1573,7 @@ describe('DayPickerRangeController', () => {
                 {...props}
               />);
               wrapper.setState({ hoverDate: today });
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 focusedInput: END_DATE,
               });
@@ -1597,7 +1597,7 @@ describe('DayPickerRangeController', () => {
               />,
             );
             const newEndDate = endDate.clone().add(1, 'days');
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               endDate: newEndDate,
             });
@@ -1627,7 +1627,7 @@ describe('DayPickerRangeController', () => {
               (total, visibleDayArray) => total + Object.keys(visibleDayArray).length,
               0,
             );
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               endDate,
               startDate: newStartDate,
@@ -1644,7 +1644,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             const startDate = moment();
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate });
             const selectedStartNoSelectedEndCalls = getCallsByModifier(addModifierSpy, 'selected-start-no-selected-end');
             expect(selectedStartNoSelectedEndCalls.length).to.equal(1);
             expect(selectedStartNoSelectedEndCalls[0].args[1]).to.equal(startDate);
@@ -1657,7 +1657,7 @@ describe('DayPickerRangeController', () => {
             const startDate = moment();
             const wrapper = shallow(<DayPickerRangeController {...props} startDate={startDate} />);
             const newStartDate = startDate.clone().add(1, 'days');
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: newStartDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: newStartDate });
             const selectedStartNoSelectedEndCalls = getCallsByModifier(deleteModifierSpy, 'selected-start-no-selected-end');
             expect(selectedStartNoSelectedEndCalls.length).to.equal(1);
             expect(selectedStartNoSelectedEndCalls[0].args[1]).to.equal(startDate);
@@ -1671,7 +1671,7 @@ describe('DayPickerRangeController', () => {
             const addModifierSpy = sinon.spy(DayPickerRangeController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             const endDate = moment();
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate });
             const selectedStartNoSelectedEndCalls = getCallsByModifier(addModifierSpy, 'selected-end-no-selected-start');
             expect(selectedStartNoSelectedEndCalls.length).to.equal(1);
             expect(selectedStartNoSelectedEndCalls[0].args[1]).to.equal(endDate);
@@ -1684,7 +1684,7 @@ describe('DayPickerRangeController', () => {
             const endDate = moment();
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
             const newEndDate = endDate.clone().add(1, 'days');
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate: newEndDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate: newEndDate });
             const selectedStartNoSelectedEndCalls = getCallsByModifier(deleteModifierSpy, 'selected-end-no-selected-start');
             expect(selectedStartNoSelectedEndCalls.length).to.equal(1);
             expect(selectedStartNoSelectedEndCalls[0].args[1]).to.equal(endDate);
@@ -1697,7 +1697,7 @@ describe('DayPickerRangeController', () => {
             const endDate = moment();
             const wrapper = shallow(<DayPickerRangeController {...props} endDate={endDate} />);
             const newStartDate = endDate.clone().subtract(1, 'days');
-            wrapper.instance().componentWillReceiveProps({ ...props, startDate: newStartDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, startDate: newStartDate });
             const selectedStartNoSelectedEndCalls = getCallsByModifier(deleteModifierSpy, 'selected-end-no-selected-start');
             expect(selectedStartNoSelectedEndCalls.length).to.equal(1);
             expect(selectedStartNoSelectedEndCalls[0].args[1]).to.equal(endDate);
@@ -1720,7 +1720,7 @@ describe('DayPickerRangeController', () => {
             );
             const newEndDate = endDate.clone().add(1, 'days');
             addModifierToRangeSpy.resetHistory();
-            wrapper.instance().componentWillReceiveProps({ ...props, endDate: newEndDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, endDate: newEndDate });
             const beforeHoveredEndCalls = getCallsByModifier(addModifierToRangeSpy, 'before-hovered-end');
             expect(beforeHoveredEndCalls.length).to.equal(1);
             expect(toISODateString(beforeHoveredEndCalls[0].args[1])).to.equal(
@@ -1747,7 +1747,7 @@ describe('DayPickerRangeController', () => {
               );
               const newStartDate = endDate.clone().subtract(3, 'days');
               deleteModifierSpy.resetHistory();
-              wrapper.instance().componentWillReceiveProps({
+              wrapper.instance().UNSAFE_componentWillReceiveProps({
                 ...props,
                 endDate,
                 startDate: newStartDate,
@@ -1776,7 +1776,7 @@ describe('DayPickerRangeController', () => {
             phrases={phrases}
           />);
           wrapper.setState({ phrases: phrasesObject });
-          wrapper.instance().componentWillReceiveProps({ ...props, phrases });
+          wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, phrases });
           expect(wrapper.state().phrases).to.equal(phrasesObject);
         });
       });
@@ -1789,7 +1789,7 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               phrases,
@@ -1806,7 +1806,7 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               phrases,
@@ -1824,7 +1824,7 @@ describe('DayPickerRangeController', () => {
               phrases={phrases}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               phrases,
             });
@@ -1843,7 +1843,7 @@ describe('DayPickerRangeController', () => {
               phrases={{}}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: START_DATE,
               phrases,
@@ -1861,7 +1861,7 @@ describe('DayPickerRangeController', () => {
               phrases={{}}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
               phrases,
@@ -1878,7 +1878,7 @@ describe('DayPickerRangeController', () => {
               phrases={{}}
             />);
             wrapper.setState({ phrases: {} });
-            wrapper.instance().componentWillReceiveProps({ ...props, phrases });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, phrases });
             const newAvailableDatePhrase = wrapper.state().phrases.chooseAvailableDate;
             expect(newAvailableDatePhrase).to.equal(phrases.chooseAvailableDate);
           });

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -54,7 +54,7 @@ describe('DayPickerSingleDateController', () => {
             const addModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'addModifier');
             const date = today;
             const wrapper = shallow(<DayPickerSingleDateController {...props} date={date} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, date });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, date });
             expect(getCallsByModifier(addModifierSpy, 'selected').length).to.equal(0);
           });
 
@@ -62,7 +62,7 @@ describe('DayPickerSingleDateController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'deleteModifier');
             const date = today;
             const wrapper = shallow(<DayPickerSingleDateController {...props} date={date} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, date });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, date });
             expect(getCallsByModifier(deleteModifierSpy, 'selected').length).to.equal(0);
           });
         });
@@ -73,7 +73,7 @@ describe('DayPickerSingleDateController', () => {
             const date = today;
             const newDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerSingleDateController {...props} date={date} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, date: newDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, date: newDate });
             const selectedCalls = getCallsByModifier(deleteModifierSpy, 'selected');
             expect(selectedCalls.length).to.equal(1);
             expect(selectedCalls[0].args[1]).to.equal(date);
@@ -84,7 +84,7 @@ describe('DayPickerSingleDateController', () => {
             const date = today;
             const newDate = moment().add(1, 'day');
             const wrapper = shallow(<DayPickerSingleDateController {...props} date={date} />);
-            wrapper.instance().componentWillReceiveProps({ ...props, date: newDate });
+            wrapper.instance().UNSAFE_componentWillReceiveProps({ ...props, date: newDate });
             const selectedStartCalls = getCallsByModifier(addModifierSpy, 'selected');
             expect(selectedStartCalls.length).to.equal(1);
             expect(selectedStartCalls[0].args[1]).to.equal(newDate);
@@ -98,7 +98,7 @@ describe('DayPickerSingleDateController', () => {
             const isBlockedStub = sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             isBlockedStub.resetHistory();
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
             });
             expect(isBlockedStub.callCount).to.equal(0);
@@ -124,7 +124,7 @@ describe('DayPickerSingleDateController', () => {
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
             isBlockedStub.resetHistory();
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
             });
@@ -136,7 +136,7 @@ describe('DayPickerSingleDateController', () => {
             sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked').returns(true);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
             });
@@ -149,7 +149,7 @@ describe('DayPickerSingleDateController', () => {
             sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked').returns(false);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
             });
@@ -170,7 +170,7 @@ describe('DayPickerSingleDateController', () => {
               />
             ));
             const prevCallCount = isOutsideRangeStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
@@ -180,7 +180,7 @@ describe('DayPickerSingleDateController', () => {
           it('calls isOutsideRange if changed', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isOutsideRange: isOutsideRangeStub,
             });
@@ -206,7 +206,7 @@ describe('DayPickerSingleDateController', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isOutsideRange: isOutsideRangeStub,
@@ -222,7 +222,7 @@ describe('DayPickerSingleDateController', () => {
             const isOutsideRangeStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isOutsideRange: isOutsideRangeStub,
@@ -242,7 +242,7 @@ describe('DayPickerSingleDateController', () => {
             const isOutsideRangeStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isOutsideRange: isOutsideRangeStub,
@@ -265,7 +265,7 @@ describe('DayPickerSingleDateController', () => {
               isDayBlocked={isDayBlockedStub}
             />);
             const prevCallCount = isDayBlockedStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
@@ -275,7 +275,7 @@ describe('DayPickerSingleDateController', () => {
           it('calls isDayBlocked if changed', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayBlocked: isDayBlockedStub,
             });
@@ -301,7 +301,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayBlocked: isDayBlockedStub,
@@ -314,7 +314,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayBlockedStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayBlocked: isDayBlockedStub,
@@ -328,7 +328,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayBlockedStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayBlocked: isDayBlockedStub,
@@ -348,7 +348,7 @@ describe('DayPickerSingleDateController', () => {
               isDayHighlighted={isDayHighlightedStub}
             />);
             const prevCallCount = isDayHighlightedStub.callCount;
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
@@ -358,7 +358,7 @@ describe('DayPickerSingleDateController', () => {
           it('calls isDayHighlighted if changed', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               isDayHighlighted: isDayHighlightedStub,
             });
@@ -384,7 +384,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayHighlighted: isDayHighlightedStub,
@@ -397,7 +397,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayHighlightedStub = sinon.stub().returns(true);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayHighlighted: isDayHighlightedStub,
@@ -411,7 +411,7 @@ describe('DayPickerSingleDateController', () => {
             const isDayHighlightedStub = sinon.stub().returns(false);
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
-            wrapper.instance().componentWillReceiveProps({
+            wrapper.instance().UNSAFE_componentWillReceiveProps({
               ...props,
               focused: true,
               isDayHighlighted: isDayHighlightedStub,
@@ -428,7 +428,7 @@ describe('DayPickerSingleDateController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'deleteModifier');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().today = today;
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(deleteModifierSpy, 'today');
             expect(todayCalls.length).to.equal(0);
           });
@@ -437,7 +437,7 @@ describe('DayPickerSingleDateController', () => {
             const addModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().today = today;
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(addModifierSpy, 'today');
             expect(todayCalls.length).to.equal(0);
           });
@@ -448,7 +448,7 @@ describe('DayPickerSingleDateController', () => {
             const deleteModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'deleteModifier');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().today = moment().subtract(1, 'day');
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(deleteModifierSpy, 'today');
             expect(todayCalls.length).to.equal(1);
           });
@@ -457,7 +457,7 @@ describe('DayPickerSingleDateController', () => {
             const addModifierSpy = sinon.spy(DayPickerSingleDateController.prototype, 'addModifier');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.instance().today = moment().subtract(1, 'day');
-            wrapper.instance().componentWillReceiveProps(props);
+            wrapper.instance().UNSAFE_componentWillReceiveProps(props);
             const todayCalls = getCallsByModifier(addModifierSpy, 'today');
             expect(todayCalls.length).to.equal(1);
           });


### PR DESCRIPTION
This PR is to address the following console warnings in version 21.8.0

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: CalendarMonth, CalendarMonthGrid, DayPicker, DayPickerKeyboardShortcuts, DayPickerRangeController react-dom.development.js:91
```

```
Warning: componentWillUpdate has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: DayPicker react-dom.development.js:91

```

`npx react-codemod rename-unsafe-lifecycles` was run with the `javascript` option.