### PR TITLE
[Fix] `CalendarMonthGrid`: Fix iOS 14 navigation 

### DIFF
--- a/src/components/CalendarMonthGrid.jsx
+++ b/src/components/CalendarMonthGrid.jsx
@@ -292,7 +292,7 @@ class CalendarMonthGrid extends React.PureComponent {
           isVerticalScrollable && styles.CalendarMonthGrid__vertical_scrollable,
           isAnimating && styles.CalendarMonthGrid__animating,
           isAnimating && transitionDuration && {
-            transition: `transform ${transitionDuration}ms ease-in-out`,
+            transition: `transform ${transitionDuration}ms ease-in-out 0.1s`,
           },
           {
             ...getTransformStyles(transformValue),


### PR DESCRIPTION
Fixes #2034. Fixes #2050.

Just find out that there is some problems with `transition` - adding some delay helped