### PR TITLE
[New] `DateRangePicker`: pass noBorder as noBorder to `DayPickerRangeController`

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -451,6 +451,7 @@ class DateRangePicker extends React.PureComponent {
       weekDayFormat,
       styles,
       verticalHeight,
+      noBorder,
       transitionDuration,
       verticalSpacing,
       horizontalMonthPadding,
@@ -548,6 +549,7 @@ class DateRangePicker extends React.PureComponent {
           firstDayOfWeek={firstDayOfWeek}
           weekDayFormat={weekDayFormat}
           verticalHeight={verticalHeight}
+          noBorder={noBorder}
           transitionDuration={transitionDuration}
           disabled={disabled}
           horizontalMonthPadding={horizontalMonthPadding}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -253,4 +253,11 @@ storiesOf('DRP - Calendar Props', module)
       verticalSpacing={0}
       autoFocus
     />
+  )))
+  .add('without borders', withInfo()(() => (
+    <DateRangePickerWrapper
+      verticalSpacing={0}
+      noBorder
+      autoFocus
+    />
   )));

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -787,4 +787,12 @@ describe('DateRangePicker', () => {
       });
     });
   });
+
+  it('should pass noBorder as noBorder to <DayPickerRangeController>', () => {
+    const wrapper = shallow((
+      <DateRangePicker {...requiredProps} focusedInput={START_DATE} noBorder />
+    )).dive();
+
+    expect(wrapper.find(DayPickerRangeController).prop('noBorder')).to.equal(true);
+  });
 });


### PR DESCRIPTION
Hi

I'm following up on an issue raised https://github.com/airbnb/react-dates/issues/1592 about the `noBorder` props not passed to the `DayPickerRangeController`. As result the `noBorder` is only applied to the inputs and not to the day range panel.

With this PR also the date range will be rendered without border when `noBorder` is applied.

I‘ve also added a quick spec and story. 