### PR TITLE
Fixes issue where user has ability to type in to input when portal is…

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -231,7 +231,7 @@ class DateRangePicker extends React.PureComponent {
 
     if (focusedInput) {
       const withAnyPortal = withPortal || withFullScreenPortal;
-      const moveFocusToDayPicker = withAnyPortal
+      const moveFocusToDayPicker = (withAnyPortal && !keepFocusOnInput)
         || (readOnly && !keepFocusOnInput)
         || (this.isTouchDevice && !keepFocusOnInput);
 
@@ -613,6 +613,7 @@ class DateRangePicker extends React.PureComponent {
       small,
       regular,
       styles,
+      keepFocusOnInput
     } = this.props;
 
     const { isDateRangePickerInputFocused } = this.state;
@@ -620,7 +621,7 @@ class DateRangePicker extends React.PureComponent {
     const enableOutsideClick = (!withPortal && !withFullScreenPortal);
 
     const hideFang = verticalSpacing < FANG_HEIGHT_PX;
-
+    const disabledByPortal = focusedInput && (withPortal || withFullScreenPortal) && !keepFocusOnInput;
     const input = (
       <DateRangePickerInputController
         startDate={startDate}
@@ -643,7 +644,7 @@ class DateRangePicker extends React.PureComponent {
         customInputIcon={customInputIcon}
         customArrowIcon={customArrowIcon}
         customCloseIcon={customCloseIcon}
-        disabled={disabled}
+        disabled={disabled || disabledByPortal}
         required={required}
         readOnly={readOnly}
         openDirection={openDirection}

--- a/stories/DateRangePicker_calendar.js
+++ b/stories/DateRangePicker_calendar.js
@@ -97,6 +97,13 @@ storiesOf('DRP - Calendar Props', module)
       autoFocus
     />
   )))
+  .add('horizontal with portal and Input Focus', withInfo()(() => (
+    <DateRangePickerWrapper
+      withPortal
+      autoFocus
+      keepFocusOnInput
+    />
+  )))
   .add('horizontal with fullscreen portal', withInfo()(() => (
     <DateRangePickerWrapper withFullScreenPortal autoFocus />
   )))


### PR DESCRIPTION
If using the portal you can still type an initial valid start date, however once said start date is finished, you lose focus off the input itself and can only enter the next date via the calendar. It was suggested in response to https://github.com/airbnb/react-dates/issues/2078 that we should simply disable the input while the calendar portal is open. This does that, but also allows the keepFocusOnInput prop to actually work with the portal, such that if you have both a portal prop and the keepFocusOnInput prop you can type in the entire start/end date. These two small changes make both possible.