### PR TITLE
[Fix] `DateRangePicker`, `DateRangePickerInput`: Fix keyboard navigation for second input

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -481,6 +481,7 @@ class DateRangePicker extends React.PureComponent {
     /* eslint-disable jsx-a11y/click-events-have-key-events */
     return (
       <div
+        key="day-picker"
         ref={this.setDayPickerContainerRef}
         {...css(
           styles.DateRangePicker_picker,

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -253,7 +253,7 @@ function DateRangePickerInput({
         regular={regular}
       />
 
-      {children}
+      {!isEndDateFocused && children}
 
       {
         <div
@@ -288,6 +288,8 @@ function DateRangePickerInput({
         small={small}
         regular={regular}
       />
+
+      {isEndDateFocused && children}
 
       {showClearDates && (
         <button

--- a/test/components/DateRangePicker_spec.jsx
+++ b/test/components/DateRangePicker_spec.jsx
@@ -9,6 +9,7 @@ import DateRangePicker, { PureDateRangePicker } from '../../src/components/DateR
 
 import DateRangePickerInputController from '../../src/components/DateRangePickerInputController';
 import DayPickerRangeController from '../../src/components/DayPickerRangeController';
+import DayPicker from '../../src/components/DayPicker';
 
 import {
   HORIZONTAL_ORIENTATION,
@@ -16,6 +17,49 @@ import {
 } from '../../src/constants';
 
 const describeIfWindow = typeof document === 'undefined' ? describe.skip : describe;
+
+class DateRangePickerWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      focusedInput: null,
+      startDate: null,
+      endDate: null,
+    };
+
+    this.onDatesChange = this.onDatesChange.bind(this);
+    this.onFocusChange = this.onFocusChange.bind(this);
+  }
+
+  onDatesChange({ startDate, endDate }) {
+    this.setState({ startDate, endDate });
+  }
+
+  onFocusChange(focusedInput) {
+    this.setState({ focusedInput });
+  }
+
+  render() {
+    const { focusedInput, startDate, endDate } = this.state;
+
+    return (
+      <div>
+        <DateRangePicker
+          {...this.props}
+          onDatesChange={this.onDatesChange}
+          onFocusChange={this.onFocusChange}
+          focusedInput={focusedInput}
+          startDate={startDate}
+          endDate={endDate}
+        />
+        <button type="button">
+          Dummy button
+        </button>
+      </div>
+    );
+  }
+}
 
 const requiredProps = {
   onDatesChange: () => {},
@@ -536,6 +580,23 @@ describe('DateRangePicker', () => {
         wrapper.instance().onDayPickerFocus();
         expect(onFocusChangeStub.getCall(0).args[0]).to.equal(START_DATE);
       });
+    });
+  });
+
+  describeIfWindow('day picker position', () => {
+    it('day picker is opened after the end date input when end date input is focused', () => {
+      const wrapper = mount((
+        <DateRangePickerWrapper
+          startDateId="startDate"
+          endDateId="endDate"
+        />
+      ));
+      expect(wrapper.find(DayPicker)).to.have.length(0);
+      wrapper.find('input').at(0).simulate('focus'); // when focusing on start date the day picker is rendered after the start date input
+      expect(wrapper.find('DateRangePickerInput').children().childAt(1).find(DayPicker)).to.have.length(1);
+      wrapper.find('input').at(1).simulate('focus'); // when focusing on end date the day picker is rendered after the end date input
+      expect(wrapper.find('DateRangePickerInput').children().childAt(1).find(DayPicker)).to.have.length(0);
+      expect(wrapper.find('DateRangePickerInput').children().childAt(3).find(DayPicker)).to.have.length(1);
     });
   });
 


### PR DESCRIPTION
Keyboard navigation is broken for the date range picker. The following bugs exist:
* When passing through the component with tab-navigation, after exiting the end-date input the dropdown does not close [1]
* When attempting to enter values into the end-date dropdown, users would have to tab backwards back to the dropdown to enter values [2]

The simplest and clearest solution that came to be is simply to put the day picker after the currently active input. In this way, the dropdown always appears next in the tab-order to the input the user has selected. The existing blur handler in the dropdown means that tabbing through the component will leave the dropdown closed at the end.

The react keys ensure that the element is just moved over in the DOM and so there is no flickering.

Fixes https://github.com/airbnb/react-dates/issues/1809

@majapw 

[1] Before, passing through the component using tab
![jan27-before-pass-through](https://user-images.githubusercontent.com/2872321/106044360-7dfb9c80-6094-11eb-86a5-9e2f2b4f71b0.gif)

[2] Before, enter values with keyboard
![jan27-before-enter](https://user-images.githubusercontent.com/2872321/106044357-7d630600-6094-11eb-90a6-f5c554303691.gif)

[3] After, passing through the component using tab
![jan27-after-pass-through](https://user-images.githubusercontent.com/2872321/106044352-7c31d900-6094-11eb-9164-0e00a33db517.gif)

[4] After, enter values with keyboard
![jan27-after-enter](https://user-images.githubusercontent.com/2872321/106044335-789e5200-6094-11eb-99a1-f7030cbb3dd6.gif)


