### PR TITLE
Update storybook docs with default prop openDirection

### DIFF
--- a/examples/DateRangePickerWrapper.jsx
+++ b/examples/DateRangePickerWrapper.jsx
@@ -14,6 +14,7 @@ import {
   HORIZONTAL_ORIENTATION,
   ANCHOR_LEFT,
   NAV_POSITION_TOP,
+  OPEN_DOWN,
 } from '../src/constants';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
@@ -70,6 +71,7 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDates: false,
   isRTL: false,
+  openDirection: OPEN_DOWN,
 
   // navigation related props
   navPosition: NAV_POSITION_TOP,

--- a/examples/SingleDatePickerWrapper.jsx
+++ b/examples/SingleDatePickerWrapper.jsx
@@ -8,7 +8,7 @@ import SingleDatePicker from '../src/components/SingleDatePicker';
 
 import { SingleDatePickerPhrases } from '../src/defaultPhrases';
 import SingleDatePickerShape from '../src/shapes/SingleDatePickerShape';
-import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT } from '../src/constants';
+import { HORIZONTAL_ORIENTATION, ANCHOR_LEFT, OPEN_DOWN } from '../src/constants';
 import isInclusivelyAfterDay from '../src/utils/isInclusivelyAfterDay';
 
 const propTypes = {
@@ -56,6 +56,7 @@ const defaultProps = {
   keepOpenOnDateSelect: false,
   reopenPickerOnClearDate: false,
   isRTL: false,
+  openDirection: OPEN_DOWN,
 
   // navigation related props
   navPrev: null,


### PR DESCRIPTION
The openDirection property is not currently set as the default property in the storybook examples.

This PR sends the addition of that property.