### PR TITLE
Add support for shifting endDateOffset if offset range includes blocked days

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "mocha-wrap": "^2.1.2",
     "moment": "^2.29.1",
     "moment-jalaali": "^0.7.4",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.14.0",
     "nyc": "^14.1.1",
     "raw-loader": "^0.5.1",
     "react": "^0.14 || ^15.5.4 || ^16.1.1",

--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -20,6 +20,7 @@ import getVisibleDays from '../utils/getVisibleDays';
 import isDayVisible from '../utils/isDayVisible';
 
 import getSelectedDateOffset from '../utils/getSelectedDateOffset';
+import enumrateDatesBetween from '../utils/enumrateDatesBetween';
 
 import toISODateString from '../utils/toISODateString';
 import { addModifier, deleteModifier } from '../utils/modifiers';
@@ -65,6 +66,7 @@ const propTypes = forbidExtraProps({
   isDayHighlighted: PropTypes.func,
   getMinNightsForHoverDate: PropTypes.func,
   daysViolatingMinNightsCanBeClicked: PropTypes.bool,
+  moveOffsetForDisabledDates: PropTypes.bool,
 
   // DayPicker props
   renderMonthText: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),
@@ -118,6 +120,8 @@ const propTypes = forbidExtraProps({
   dayAriaLabelFormat: PropTypes.string,
 
   isRTL: PropTypes.bool,
+
+  
 });
 
 const defaultProps = {
@@ -141,6 +145,7 @@ const defaultProps = {
   isDayHighlighted() {},
   getMinNightsForHoverDate() {},
   daysViolatingMinNightsCanBeClicked: false,
+  moveOffsetForDisabledDates: false,
 
   // DayPicker props
   renderMonthText: null,
@@ -596,6 +601,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       endDateOffset,
       disabled,
       daysViolatingMinNightsCanBeClicked,
+      moveOffsetForDisabledDates
     } = this.props;
 
     if (e) e.preventDefault();
@@ -605,7 +611,11 @@ export default class DayPickerRangeController extends React.PureComponent {
 
     if (startDateOffset || endDateOffset) {
       startDate = getSelectedDateOffset(startDateOffset, day);
-      endDate = getSelectedDateOffset(endDateOffset, day);
+      if (moveOffsetForDisabledDates) {
+        endDate = this.getDisabledEndDateOffset(startDate, getSelectedDateOffset(endDateOffset, day));
+      } else {
+        endDate = getSelectedDateOffset(endDateOffset, day);
+      }
 
       if (this.isBlocked(startDate) || this.isBlocked(endDate)) {
         return;
@@ -683,6 +693,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       minimumNights,
       startDateOffset,
       endDateOffset,
+      moveOffsetForDisabledDates
     } = this.props;
 
     const {
@@ -699,7 +710,14 @@ export default class DayPickerRangeController extends React.PureComponent {
 
       if (hasOffset) {
         const start = getSelectedDateOffset(startDateOffset, day);
-        const end = getSelectedDateOffset(endDateOffset, day, (rangeDay) => rangeDay.add(1, 'day'));
+        let end = null;
+        if (moveOffsetForDisabledDates) {
+          end = this.getDisabledEndDateOffset(start, getSelectedDateOffset(
+            endDateOffset, day, (rangeDay) => rangeDay.add(1, 'day')));
+        } else {
+          end = getSelectedDateOffset(
+            endDateOffset, day, (rangeDay) => rangeDay.add(1, 'day'))
+        }
 
         nextDateOffset = {
           start,
@@ -1183,6 +1201,18 @@ export default class DayPickerRangeController extends React.PureComponent {
       return dayDiff < minNights && dayDiff >= 0;
     }
     return false;
+  }
+
+  getDisabledEndDateOffset(start, end) {
+    const dates = enumrateDatesBetween(start, end);
+    let daysToAdd = 0;
+    dates.map(d => {
+      if (this.isBlocked(moment(d))) {
+        daysToAdd++;
+      }
+    });
+    
+    return end.add(daysToAdd, 'day');
   }
 
   isDayAfterHoveredStartDate(day) {

--- a/src/utils/enumrateDatesBetween.js
+++ b/src/utils/enumrateDatesBetween.js
@@ -1,0 +1,10 @@
+export default function enumrateDatesBetween(startDate, endDate) {
+    let now = startDate.clone(), dates = [];
+
+    while (now.isSameOrBefore(endDate)) {
+        dates.push(now.format('M/D/YYYY'));
+        now.add(1, 'days');
+    }
+    
+    return dates;
+}

--- a/stories/DayPickerRangeController.js
+++ b/stories/DayPickerRangeController.js
@@ -368,6 +368,18 @@ storiesOf('DayPickerRangeController', module)
       endDateOffset={(day) => day.add(4, 'days')}
     />
   )))
+  .add('with 4 days after today range selection with disabled dates', withInfo()(() => (
+    <DayPickerRangeControllerWrapper
+      isDayBlocked={(day1) => {
+        return new Date(day1).getDay() % 6 == 0
+      }}
+      moveOffsetForDisabledDates={false}
+      onOutsideClick={action('DayPickerRangeController::onOutsideClick')}
+      onPrevMonthClick={action('DayPickerRangeController::onPrevMonthClick')}
+      onNextMonthClick={action('DayPickerRangeController::onNextMonthClick')}
+      endDateOffset={(day) => day.add(3, 'days')}
+    />
+  )))
   .add('with current week range selection', withInfo()(() => (
     <DayPickerRangeControllerWrapper
       onOutsideClick={action('DayPickerRangeController::onOutsideClick')}


### PR DESCRIPTION
Hi Team,

One of the use cases I've encountered recently was allowing endDateOffSet to go past the offset range if offset falls in blocked days.

I wasn't sure if it's something we could already do hence wrote simple patch for it. Looking forward to any feedback on it!

Thank you!