### PR TITLE
[Fix] `DateInput`: Fix invalid font-weight for regular option

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -342,7 +342,7 @@ export default withStyles(({
   },
 
   DateInput_input__regular: {
-    fontWeight: 'auto',
+    fontWeight: 'inherit',
   },
 
   DateInput_input__readOnly: {


### PR DESCRIPTION
Fixes #1868. Closes #1869.