### PR TITLE
Add possibility to use label for startDate and endDate input in DateRangePicker 

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -27,6 +27,7 @@ const propTypes = forbidExtraProps({
   ...withStylesPropTypes,
   id: PropTypes.string.isRequired,
   placeholder: PropTypes.string,
+  labelText: PropTypes.string,
   displayValue: PropTypes.string,
   ariaLabel: PropTypes.string,
   autoComplete: PropTypes.string,
@@ -57,6 +58,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   placeholder: 'Select Date',
+  labelText: '',
   displayValue: '',
   ariaLabel: undefined,
   autoComplete: 'off',
@@ -178,6 +180,7 @@ class DateInput extends React.PureComponent {
     const {
       id,
       placeholder,
+      labelText,
       ariaLabel,
       autoComplete,
       titleText,
@@ -203,6 +206,7 @@ class DateInput extends React.PureComponent {
     const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     const withFang = showCaret && focused;
+    const withLabel = !!labelText;
 
     const inputHeight = getInputHeight(reactDates, small);
 
@@ -218,6 +222,18 @@ class DateInput extends React.PureComponent {
           withFang && openDirection === OPEN_UP && styles.DateInput__openUp,
         )}
       >
+        {labelText && (
+          <label
+            className={`DateInput_label ${id}_label`}
+            htmlFor={id}
+            {...css(
+              styles.DateInput_label,
+              small && styles.DateInput_label__small,
+            )}
+          >
+            {labelText}
+          </label>
+        )}
         <input
           {...css(
             styles.DateInput_input,
@@ -226,6 +242,7 @@ class DateInput extends React.PureComponent {
             readOnly && styles.DateInput_input__readOnly,
             focused && styles.DateInput_input__focused,
             disabled && styles.DateInput_input__disabled,
+            withLabel && styles.DateInput_input__withLabel
           )}
           aria-label={ariaLabel === undefined ? placeholder : ariaLabel}
           title={titleText}
@@ -263,7 +280,7 @@ class DateInput extends React.PureComponent {
               {...css(styles.DateInput_fangShape)}
               d={openDirection === OPEN_DOWN ? FANG_PATH_TOP : FANG_PATH_BOTTOM}
             />
-            <path
+           <path
               {...css(styles.DateInput_fangStroke)}
               d={openDirection === OPEN_DOWN ? FANG_STROKE_TOP : FANG_STROKE_BOTTOM}
             />
@@ -283,113 +300,138 @@ class DateInput extends React.PureComponent {
 DateInput.propTypes = propTypes;
 DateInput.defaultProps = defaultProps;
 
-export default withStyles(({
-  reactDates: {
-    border, color, sizing, spacing, font, zIndex,
+export default withStyles(({ 
+  reactDates: { 
+    border, color, sizing, spacing, font, zIndex, 
   },
-}) => ({
-  DateInput: {
-    margin: 0,
-    padding: spacing.inputPadding,
-    background: color.background,
-    position: 'relative',
-    display: 'inline-block',
-    width: sizing.inputWidth,
-    verticalAlign: 'middle',
-  },
+ }) => ({
+    DateInput: {
+      margin: 0,
+      padding: spacing.inputPadding,
+      background: color.background,
+      position: 'relative',
+      display: 'inline-block',
+      width: sizing.inputWidth,
+      verticalAlign: 'middle',
+    },
 
-  DateInput__small: {
-    width: sizing.inputWidth_small,
-  },
+    DateInput__small: {
+      width: sizing.inputWidth_small,
+    },
 
-  DateInput__block: {
-    width: '100%',
-  },
+    DateInput__block: {
+      width: '100%',
+    },
 
-  DateInput__disabled: {
-    background: color.disabled,
-    color: color.textDisabled,
-  },
+    DateInput__disabled: {
+      background: color.disabled,
+      color: color.textDisabled,
+    },
 
-  DateInput_input: {
-    fontWeight: font.input.weight,
-    fontSize: font.input.size,
-    lineHeight: font.input.lineHeight,
-    color: color.text,
-    backgroundColor: color.background,
-    width: '100%',
-    padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
-    paddingTop: spacing.displayTextPaddingTop,
-    paddingBottom: spacing.displayTextPaddingBottom,
-    paddingLeft: noflip(spacing.displayTextPaddingLeft),
-    paddingRight: noflip(spacing.displayTextPaddingRight),
-    border: border.input.border,
-    borderTop: border.input.borderTop,
-    borderRight: noflip(border.input.borderRight),
-    borderBottom: border.input.borderBottom,
-    borderLeft: noflip(border.input.borderLeft),
-    borderRadius: border.input.borderRadius,
-  },
+    DateInput_input: {
+      fontWeight: font.input.weight,
+      fontSize: font.input.size,
+      lineHeight: font.input.lineHeight,
+      color: color.text,
+      backgroundColor: color.background,
+      width: '100%',
+      padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
+      paddingTop: spacing.displayTextPaddingTop,
+      paddingBottom: spacing.displayTextPaddingBottom,
+      paddingLeft: noflip(spacing.displayTextPaddingLeft),
+      paddingRight: noflip(spacing.displayTextPaddingRight),
+      border: border.input.border,
+      borderTop: border.input.borderTop,
+      borderRight: noflip(border.input.borderRight),
+      borderBottom: border.input.borderBottom,
+      borderLeft: noflip(border.input.borderLeft),
+      borderRadius: border.input.borderRadius,
+    },
 
-  DateInput_input__small: {
-    fontSize: font.input.size_small,
-    lineHeight: font.input.lineHeight_small,
-    letterSpacing: font.input.letterSpacing_small,
-    padding: `${spacing.displayTextPaddingVertical_small}px ${spacing.displayTextPaddingHorizontal_small}px`,
-    paddingTop: spacing.displayTextPaddingTop_small,
-    paddingBottom: spacing.displayTextPaddingBottom_small,
-    paddingLeft: noflip(spacing.displayTextPaddingLeft_small),
-    paddingRight: noflip(spacing.displayTextPaddingRight_small),
-  },
+    DateInput_input__small: {
+      fontSize: font.input.size_small,
+      lineHeight: font.input.lineHeight_small,
+      letterSpacing: font.input.letterSpacing_small,
+      padding: `${spacing.displayTextPaddingVertical_small}px ${spacing.displayTextPaddingHorizontal_small}px`,
+      paddingTop: spacing.displayTextPaddingTop_small,
+      paddingBottom: spacing.displayTextPaddingBottom_small,
+      paddingLeft: noflip(spacing.displayTextPaddingLeft_small),
+      paddingRight: noflip(spacing.displayTextPaddingRight_small),
+    },
 
-  DateInput_input__regular: {
-    fontWeight: 'inherit',
-  },
+    DateInput_input__regular: {
+      fontWeight: 'inherit',
+    },
 
-  DateInput_input__readOnly: {
-    userSelect: 'none',
-  },
+    DateInput_input__readOnly: {
+      userSelect: 'none',
+    },
 
-  DateInput_input__focused: {
-    outline: border.input.outlineFocused,
-    background: color.backgroundFocused,
-    border: border.input.borderFocused,
-    borderTop: border.input.borderTopFocused,
-    borderRight: noflip(border.input.borderRightFocused),
-    borderBottom: border.input.borderBottomFocused,
-    borderLeft: noflip(border.input.borderLeftFocused),
-  },
+    DateInput_input__focused: {
+      outline: border.input.outlineFocused,
+      background: color.backgroundFocused,
+      border: border.input.borderFocused,
+      borderTop: border.input.borderTopFocused,
+      borderRight: noflip(border.input.borderRightFocused),
+      borderBottom: border.input.borderBottomFocused,
+      borderLeft: noflip(border.input.borderLeftFocused),
+    },
+    
+    DateInput_input__withLabel:{
+      paddingTop: spacing.inputPadding,
+    },
 
-  DateInput_input__disabled: {
-    background: color.disabled,
-    fontStyle: font.input.styleDisabled,
-  },
+    DateInput_input__disabled: {
+      background: color.disabled,
+      fontStyle: font.input.styleDisabled,
+    },
 
-  DateInput_screenReaderMessage: {
-    border: 0,
-    clip: 'rect(0, 0, 0, 0)',
-    height: 1,
-    margin: -1,
-    overflow: 'hidden',
-    padding: 0,
-    position: 'absolute',
-    width: 1,
-  },
+    DateInput_screenReaderMessage: {
+      border: 0,
+      clip: 'rect(0, 0, 0, 0)',
+      height: 1,
+      margin: -1,
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      width: 1,
+    },
 
-  DateInput_fang: {
-    position: 'absolute',
-    width: FANG_WIDTH_PX,
-    height: FANG_HEIGHT_PX,
-    left: 22, // TODO: should be noflip wrapped and handled by an isRTL prop
-    zIndex: zIndex + 2,
-  },
+    DateInput_fang: {
+      position: 'absolute',
+      width: FANG_WIDTH_PX,
+      height: FANG_HEIGHT_PX,
+      left: 22, // TODO: should be noflip wrapped and handled by an isRTL prop
+      zIndex: zIndex + 2,
+    },
 
-  DateInput_fangShape: {
-    fill: color.background,
-  },
+    DateInput_fangShape: {
+      fill: color.background,
+    },
 
-  DateInput_fangStroke: {
-    stroke: color.core.border,
-    fill: 'transparent',
-  },
-}), { pureComponent: typeof React.PureComponent !== 'undefined' })(DateInput);
+    DateInput_fangStroke: {
+      stroke: color.core.border,
+      fill: 'transparent',
+    },
+
+    DateInput_label: {
+      fontSize: font.size,
+      color: color.text,
+      padding: `${spacing.displayTextPaddingVertical}px ${spacing.displayTextPaddingHorizontal}px`,
+      paddingTop: spacing.displayTextPaddingTop,
+      paddingBottom: spacing.displayTextPaddingBottom,
+      paddingLeft: noflip(spacing.displayTextPaddingLeft),
+      paddingRight: noflip(spacing.displayTextPaddingRight),
+    },
+
+    DateInput_label__small: {
+      fontSize: font.size,
+      padding: `${spacing.displayTextPaddingVertical_small}px ${spacing.displayTextPaddingHorizontal_small}px`,
+      paddingTop: spacing.displayTextPaddingTop_small,
+      paddingBottom: spacing.displayTextPaddingBottom_small,
+      paddingLeft: noflip(spacing.displayTextPaddingLeft_small),
+      paddingRight: noflip(spacing.displayTextPaddingRight_small),
+    },
+  }),
+  { pureComponent: typeof React.PureComponent !== 'undefined' }
+)(DateInput);

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -53,6 +53,8 @@ const defaultProps = {
   // input related props
   startDatePlaceholderText: 'Start Date',
   endDatePlaceholderText: 'End Date',
+  startDateLabelText: '',
+  endDateLabelText: '',
   startDateAriaLabel: undefined,
   endDateAriaLabel: undefined,
   startDateTitleText: undefined,
@@ -459,6 +461,8 @@ class DateRangePicker extends React.PureComponent {
       horizontalMonthPadding,
       small,
       disabled,
+      startDateLabelText,
+      endDateLabelText,
       theme: { reactDates },
     } = this.props;
 
@@ -556,6 +560,8 @@ class DateRangePicker extends React.PureComponent {
           transitionDuration={transitionDuration}
           disabled={disabled}
           horizontalMonthPadding={horizontalMonthPadding}
+          startDateLabelText={startDateLabelText}
+          endDateLabelText={endDateLabelText}
         />
 
         {withFullScreenPortal && (
@@ -619,6 +625,8 @@ class DateRangePicker extends React.PureComponent {
       regular,
       css,
       styles,
+      startDateLabelText,
+      endDateLabelText
     } = this.props;
 
     const { isDateRangePickerInputFocused } = this.state;
@@ -635,6 +643,8 @@ class DateRangePicker extends React.PureComponent {
         isStartDateFocused={focusedInput === START_DATE}
         startDateAriaLabel={startDateAriaLabel}
         startDateTitleText={startDateTitleText}
+        startDateLabelText={startDateLabelText}
+        endDateLabelText={endDateLabelText}
         endDate={endDate}
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -32,12 +32,14 @@ const propTypes = forbidExtraProps({
 
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
+  startDateLabelText: PropTypes.string,
   startDateAriaLabel: PropTypes.string,
   startDateTitleText: PropTypes.string,
   screenReaderMessage: PropTypes.string,
 
   endDateId: PropTypes.string,
   endDatePlaceholderText: PropTypes.string,
+  endDateLabelText: PropTypes.string,
   endDateAriaLabel: PropTypes.string,
   endDateTitleText: PropTypes.string,
 
@@ -89,6 +91,8 @@ const defaultProps = {
   endDateId: END_DATE,
   startDatePlaceholderText: 'Start Date',
   endDatePlaceholderText: 'End Date',
+  startDateLabelText: '',
+  endDateLabelText: '',
   startDateAriaLabel: undefined,
   endDateAriaLabel: undefined,
   startDateTitleText: undefined,
@@ -141,6 +145,7 @@ function DateRangePickerInput({
   startDate,
   startDateId,
   startDatePlaceholderText,
+  startDateLabelText,
   screenReaderMessage,
   isStartDateFocused,
   onStartDateChange,
@@ -151,6 +156,7 @@ function DateRangePickerInput({
   endDate,
   endDateId,
   endDatePlaceholderText,
+  endDateLabelText,
   isEndDateFocused,
   onEndDateChange,
   onEndDateFocus,
@@ -202,7 +208,7 @@ function DateRangePickerInput({
 
   const screenReaderStartDateText = screenReaderMessage
     || phrases.keyboardForwardNavigationInstructions;
-  const screenReaderEndDateText = screenReaderMessage
+    const screenReaderEndDateText = screenReaderMessage
     || phrases.keyboardBackwardNavigationInstructions;
 
   const inputIcon = (showDefaultInputIcon || customInputIcon !== null) && (
@@ -236,6 +242,7 @@ function DateRangePickerInput({
       <DateInput
         id={startDateId}
         placeholder={startDatePlaceholderText}
+        labelText={startDateLabelText}
         ariaLabel={startDateAriaLabel}
         autoComplete={autoComplete}
         titleText={startDateTitleText}
@@ -271,6 +278,7 @@ function DateRangePickerInput({
       <DateInput
         id={endDateId}
         placeholder={endDatePlaceholderText}
+        labelText={endDateLabelText}
         ariaLabel={endDateAriaLabel}
         autoComplete={autoComplete}
         titleText={endDateTitleText}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -33,6 +33,7 @@ const propTypes = forbidExtraProps({
   startDate: momentPropTypes.momentObj,
   startDateId: PropTypes.string,
   startDatePlaceholderText: PropTypes.string,
+  startDateLabelText: PropTypes.string,
   isStartDateFocused: PropTypes.bool,
   startDateAriaLabel: PropTypes.string,
   startDateTitleText: PropTypes.string,
@@ -40,6 +41,7 @@ const propTypes = forbidExtraProps({
   endDate: momentPropTypes.momentObj,
   endDateId: PropTypes.string,
   endDatePlaceholderText: PropTypes.string,
+  endDateLabelText: PropTypes.string,
   isEndDateFocused: PropTypes.bool,
   endDateAriaLabel: PropTypes.string,
   endDateTitleText: PropTypes.string,
@@ -291,11 +293,13 @@ export default class DateRangePickerInputController extends React.PureComponent 
       isStartDateFocused,
       startDateAriaLabel,
       startDateTitleText,
+      startDateLabelText,
       endDate,
       endDateId,
       endDatePlaceholderText,
       endDateAriaLabel,
       endDateTitleText,
+      endDateLabelText,
       isEndDateFocused,
       screenReaderMessage,
       showClearDates,
@@ -330,12 +334,14 @@ export default class DateRangePickerInputController extends React.PureComponent 
         startDate={startDateString}
         startDateId={startDateId}
         startDatePlaceholderText={startDatePlaceholderText}
+        startDateLabelText={startDateLabelText}
         isStartDateFocused={isStartDateFocused}
         startDateAriaLabel={startDateAriaLabel}
         startDateTitleText={startDateTitleText}
         endDate={endDateString}
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}
+        endDateLabelText={endDateLabelText}
         isEndDateFocused={isEndDateFocused}
         endDateAriaLabel={endDateAriaLabel}
         endDateTitleText={endDateTitleText}

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -53,6 +53,8 @@ export default {
   regular: PropTypes.bool,
   keepFocusOnInput: PropTypes.bool,
   autoComplete: PropTypes.string,
+  startDateLabelText: PropTypes.string,
+  endDateLabelText: PropTypes.string,
 
   // calendar presentation and interaction related props
   renderMonthText: mutuallyExclusiveProps(PropTypes.func, 'renderMonthText', 'renderMonthElement'),

--- a/stories/DateRangePicker.js
+++ b/stories/DateRangePicker.js
@@ -127,4 +127,10 @@ storiesOf('DateRangePicker (DRP)', module)
   )))
   .add('with custom autoComplete', withInfo()(() => (
     <DateRangePickerWrapper autoComplete="datePicker" />
+  )))
+  .add('with label', withInfo()(() => (
+    <DateRangePickerWrapper 
+      startDateLabelText='Check in'
+      endDateLabelText='Check out'   
+    />
   )));


### PR DESCRIPTION
## Feature: Use custom label for start and end date in DateRangePicker

This commit introduces a new feature to the DateRangePicker component, enabling users to define custom labels for the start and end date inputs. Users can now pass an optional `startDateLabelText` and `endDateLabelText` prop to specify their preferred labels.

### Closes [#[2191]](https://github.com/react-dates/react-dates/issues/2191)

### Screenshots: 

#### Preview
![image](https://github.com/react-dates/react-dates/assets/62833134/dc795264-fec8-4a70-82ae-bebb92b9057b)

![image](https://github.com/react-dates/react-dates/assets/62833134/2ee6f53d-99a8-4581-b69c-924930c181a6)

